### PR TITLE
TimPlugin and Pedestrian plugin REST endpoint fix

### DIFF
--- a/src/v2i-hub/PedestrianPlugin/src/include/PedestrianPlugin.hpp
+++ b/src/v2i-hub/PedestrianPlugin/src/include/PedestrianPlugin.hpp
@@ -81,6 +81,8 @@ protected:
 
 	int  StartWebService();
 	void PedestrianRequestHandler(QHttpEngine::Socket *socket);
+	void writeResponse(int responseCode , QHttpEngine::Socket *socket);
+
 
 
 private:

--- a/src/v2i-hub/TimPlugin/src/TimPlugin.h
+++ b/src/v2i-hub/TimPlugin/src/TimPlugin.h
@@ -104,6 +104,7 @@ protected:
 	bool LoadTim(TravelerInformation *tim, const char *mapFile);
 	int  StartWebService();
 	void TimRequestHandler(QHttpEngine::Socket *socket);
+	void writeResponse(int responseCode , QHttpEngine::Socket *socket);
 	//void BroadCastTIM();
 
 


### PR DESCRIPTION
TimPlugin and Pedestrian plugin did not respond to
correct or incorrect POST requests. Added code to
both plugins to catch, previously uncaught xml
parsing exceptions and return 201 responses for
successful requests and 400 responses for incorrect
requests.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
In Pedestrian and Tim plugins added logic to send http response 201 for valid xml requests and 400 responses for invalid xml. Also caught, previously uncaught xml parsing exceptions and log them
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
After investigation it looks like originally the REST api was set up using a web-service.yaml (https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/bbc641b733a384a579f1e75b2502641b8f6449e5/src/v2i-hub/PedestrianPlugin/websercive.yaml ) and the OpenAPI code generation tool from https://openapi-generator.tech . The effort seems to have been abandoned and the message formats seemed to have changed from json to xml. Instead the generated code seems to be partially unused and partially edited. In each plugin (TIM and Pedestrian) get the request payload but since they don’t use the code generated methods it seems implementing responses and error handling was forgotten. This causes any service that send the request like PostMan to hang waiting on a response. Also the uncaught exceptions had unknown impact on running plugin functionality.

Fixed this by implementing responses and catching xml parse exceptions. 
## How Has This Been Tested?

1. Build and run V2XHub
2. Send PersonalSafetyMessage and timdata xml using Postman chrome extension to any url with the correct configured port
3. Valid Messages result in 201 responses and invalid message in 400

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
