### PR TITLE
Fixed PreemptionPlugin vehicleId 

### DIFF
--- a/src/v2i-hub/PreemptionPlugin/src/include/PreemptionPluginWorker.cpp
+++ b/src/v2i-hub/PreemptionPlugin/src/include/PreemptionPluginWorker.cpp
@@ -133,7 +133,7 @@ namespace PreemptionPlugin {
         else if(po->approach == "0"){
 
             if (preemption_map.find(po->vehicle_id) == preemption_map.end() ) {
-                std::cout << " vehicle id does not exitst" << po->vehicle_id << std::endl;
+                std::cout << " vehicle id does not exist" << po->vehicle_id << std::endl;
             }
             else {
                 TurnOffPreemption(po);
@@ -156,7 +156,7 @@ namespace PreemptionPlugin {
 
         int response = SendOid(PreemptionOid.c_str(), preemption_plan_flag.c_str());
         if(response != 0){
-            std::cout << "Sending oid intrupted with an error.";
+            std::cout << "Sending oid interupted with an error.";
         }
         else{
             std::cout << "Finished sending preemption plan.";
@@ -171,7 +171,7 @@ namespace PreemptionPlugin {
         int response = SendOid(PreemptionOid.c_str(), preemption_plan_flag.c_str());
 
         if(response != 0){
-            std::cout << "Sending oid intrupted with an error.";
+            std::cout << "Sending oid interupted with an error.";
         }
         else{
             std::cout << "Finished sending preemption plan.";

--- a/src/v2i-hub/PreemptionPlugin/src/include/PreemptionPluginWorker.cpp
+++ b/src/v2i-hub/PreemptionPlugin/src/include/PreemptionPluginWorker.cpp
@@ -73,9 +73,10 @@ namespace PreemptionPlugin {
         VehicleCoordinate* vehicle_coordinate = new VehicleCoordinate;
 
         auto bsm = msg->get_j2735_data();
-
+        int32_t bsmTmpID;
+        GetInt32((unsigned char *)bsm->coreData.id.buf, &bsmTmpID);
         int buff_size = bsm->coreData.id.size;
-        po->vehicle_id = (int)*(bsm->coreData.id.buf);
+        po->vehicle_id = bsmTmpID ;
         vehicle_coordinate->lat = bsm->coreData.lat / micro;
         vehicle_coordinate->lon = bsm->coreData.Long / micro;
         vehicle_coordinate->elevation = bsm->coreData.elev;
@@ -256,4 +257,10 @@ namespace PreemptionPlugin {
 
         return exitval;
     };
+
+    void PreemptionPluginWorker::GetInt32(unsigned char *buf, int32_t *value)
+{
+	*value = (int32_t)((buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3]);
+}
+
 };

--- a/src/v2i-hub/PreemptionPlugin/src/include/PreemptionPluginWorker.hpp
+++ b/src/v2i-hub/PreemptionPlugin/src/include/PreemptionPluginWorker.hpp
@@ -85,6 +85,7 @@ namespace PreemptionPlugin {
 			std::string base_preemption_oid;
 
 			int SendOid(const char *PreemptionOid, const char *value);
+			void GetInt32(unsigned char *buf, int32_t *value);
 
 			boost::property_tree::ptree geofence_data;
 			std::list<GeofenceObject*> GeofenceSet;


### PR DESCRIPTION

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Previously PreemptionPlugin was only processing one element of the bsm->coreData.id.buf char array. Added logic similar to MessageLogger to read all elements of the char array into an int.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Incorrect vehicle id's were being stored and compared to the allowed list of vehicle for the PreemptionPlugin.
## How Has This Been Tested?
Tested this by sending an extended BSM while the PreemptionPlugin is on and logging the vehicleID.
This id should be the decimal version of the value translated https://www.marben-products.com/decoder-asn1-automotive/ which is a hexadecimal number.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
Added GetInt32() method from MessageLoggerPlugin to translate 4 element long char array into an int and used this value as the vehicle ID
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
