### PR TITLE
Update spat_log_files header 

### DIFF
--- a/src/v2i-hub/SPaTLoggerPlugin/src/SPaTLoggerPlugin.cpp
+++ b/src/v2i-hub/SPaTLoggerPlugin/src/SPaTLoggerPlugin.cpp
@@ -158,14 +158,14 @@ void SPaTLoggerPlugin::HandleSpatMessage(SpatMessage &msg, routeable_message &ro
         intersectionId_hex<<intersectionId_int_hex.str()[0]<<intersectionId_int_hex.str()[1]<<' '<<intersectionId_int_hex.str()[2]<<intersectionId_int_hex.str()[3];
 	
 	std::string interstatus = std::bitset<8>(spat->intersections.list.array[0]->status.buf).to_string();
-	        int interstatint_sw = stoi(interstatus);
+	        uint8_t interstatint_sw = (uint8_t) stoi(interstatus);
         std::stringstream interstatint_size;
         interstatint_size << interstatint_sw;
         std::stringstream interstatint_int_hex;
         if (interstatint_size.str().length() == 1)
         {
                 interstatint_int_hex<<"0"<<std::hex<<interstatint_sw;
-                unsigned int interstatint_size2 = interstatint_int_hex.str().size();
+                uint8_t interstatint_size2 = interstatint_int_hex.str().size();
                 std::stringstream interstatint_hex;
                 interstatint_hex<<interstatint_int_hex.str()[1];
         }
@@ -204,6 +204,9 @@ void SPaTLoggerPlugin::HandleSpatMessage(SpatMessage &msg, routeable_message &ro
         else{
                 spatmillis16_hex<<spatmillis16_int_hex.str()[2]<<spatmillis16_int_hex.str()[3]<<' '<<spatmillis16_int_hex.str()[0]<<spatmillis16_int_hex.str()[1];
         }
+        //Add is_cert_present
+        std::stringstream IsCertPresent_hex;
+        IsCertPresent_hex<<"00";
 
 	int spat_size;
         if (routeableMsg.get_payload_str().length()%4 == 0){
@@ -231,7 +234,7 @@ void SPaTLoggerPlugin::HandleSpatMessage(SpatMessage &msg, routeable_message &ro
 	std::stringstream metadata;
         std::string spat_output_payload = routeableMsg.get_payload_str();
 
-        metadata<<direction_hex.str()<<' '<<intersectionId_hex.str()<<' '<<interstatint_hex.str()<<' '<<spatreceivetime_hex.str()<<' '<<spatmillis16_hex.str()<<' '<<signStatus_hex.str()<<' '<<spat_size_hex.str();
+        metadata<<direction_hex.str()<<' '<<intersectionId_hex.str()<<' '<<interstatint_hex.str()<<' '<<spatreceivetime_hex.str()<<' '<<spatmillis16_hex.str()<<' '<<signStatus_hex.str()<<' '<<IsCertPresent_hex.str()<<' '<<spat_size_hex.str();
 
         unsigned int payload_size = spat_output_payload.size();
         std::stringstream spat_output_data;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->


```
typedef struct _intersection {
    int16_t intersectionId;
    int8_t intersectionStatus;
} __attribute__((__packed__)) intersection;

typedef struct _SPaTMsgRecord {
    uint8_t   rxFrom; /* refer rxSource for values */
    intersection  curIntersection;
    uint32_t  utcTimeInSec;
    uint16_t  msec;
    int8_t    verificationStatus;
    int8_t    is_cert_present; /*ieee 1609 (acceptable values 0 = no,1 =yes)*/
    uint16_t  length;
    /* payload of length size*/
} __attribute__((__packed__)) SPaTMsgRecord;
```
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/169
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Add SPAT support
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
