### PR TITLE
TimPlugin destructing after sending the second XML POST request

### DIFF
--- a/src/v2i-hub/TimPlugin/src/TimPlugin.cpp
+++ b/src/v2i-hub/TimPlugin/src/TimPlugin.cpp
@@ -295,8 +295,6 @@ int TimPlugin::Main() {
 						//mapFileCopy = _mapFile;
 						_isMapFileNew = false;
 					}
-					if (_isTimLoaded)
-						ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_TravelerInformation, &_tim);
 					_isTimLoaded = LoadTim(&_tim, _mapFile.c_str());
 				}
 
@@ -318,9 +316,10 @@ int TimPlugin::Main() {
 
 					lastSendTime = time;
 					TimMessage timMsg(_tim);
-
+					//PLOG(logERROR) <<"timMsg XML to send....."<< timMsg<<std::endl;
 					TimEncodedMessage timEncMsg;
 					timEncMsg.initialize(timMsg);
+					//PLOG(logERROR) <<"encoded timEncMsg..."<< timEncMsg<<std::endl;
 
 					timEncMsg.set_flags(IvpMsgFlags_RouteDSRC);
 					timEncMsg.addDsrcMetadata(172, 0x8003);

--- a/src/v2i-hub/TimPlugin/src/XmlCurveParser.cpp
+++ b/src/v2i-hub/TimPlugin/src/XmlCurveParser.cpp
@@ -393,7 +393,10 @@ GeographicalPath* XmlCurveParser::ReadRegion(DOMElement* regionElement)
 		}
 		else if (MatchTagName(currentElement, "Nodes"))
 		{
-			ReadNodes(currentElement, &(geoPath->description->choice.path.offset.choice.xy.choice.nodes));
+			NodeSetXY_t* nodeset_p = (NodeSetXY_t*) calloc(1, sizeof(NodeSetXY));  
+			ReadNodes(currentElement, nodeset_p);
+			geoPath->description->choice.path.offset.choice.xy.choice.nodes = *nodeset_p;
+			free(nodeset_p);
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix the segmentation fault issue causing the timplugin to deconstruct.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/218
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Release testing
## How Has This Been Tested?
Release testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
