### PR TITLE
Issue-218: Fix stale data

### DIFF
--- a/src/v2i-hub/TimPlugin/src/TimPlugin.h
+++ b/src/v2i-hub/TimPlugin/src/TimPlugin.h
@@ -63,6 +63,8 @@
 #include <qhttpengine/server.h>
 #include <qserverPedestrian/OAIApiRouter.h>
 #include <qserverPedestrian/OAIPSM.h>
+#include <boost/filesystem.hpp>
+
 
 
 
@@ -74,6 +76,7 @@ using namespace std;
 using namespace tmx;
 using namespace tmx::utils;
 using namespace tmx::messages;
+using namespace boost::filesystem;
 
 
 #define INPUTSREADY "Have Map/Spat/Veh"


### PR DESCRIPTION
+ close temp xml file
+ Fix webservice to allow for changing port configuration

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Stopped tmpTim XML file from appending to file. Previously, tmpTim XML file would be appended with each successful TIM update and the XMLParser would only read the first one. Corrected config and webservice logic to allow for creating webservice at configurable port.
<!--- Describe your changes in detail -->

## Related Issue
#224 #218 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fix was implement to avoid broadcasting stale TIM data and allow for configurable ports for the web service. The configurable web service port allows for installation of multiple TIM plugins.
## How Has This Been Tested?
Tested by changing tag name for v2xhub in docker-compose to 218-fix-stale-data, running docker-compose pull and testing the TIM plugin with wget and Postman tools
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
