### PR TITLE
SPaT red & green phase state fix

### DIFF
--- a/src/v2i-hub/SpatPlugin/src/NTCIP1202.cpp
+++ b/src/v2i-hub/SpatPlugin/src/NTCIP1202.cpp
@@ -336,7 +336,11 @@ void Ntcip1202::populateVehicleSignalGroup(MovementState *movement, int phase)
 
 	if(getPhaseRedStatus(phase))
 	{
-		if(forceFlashing || isFlashing)
+		PLOG(logDEBUG3) << "Phase " << phase <<
+				" Red " << getPhaseRedStatus(phase) <<
+				", isFlashing  " << isFlashing <<
+				", forceFlashing " << forceFlashing ;
+		if(isFlashing)
 			stateTimeSpeed->eventState = MovementPhaseState_stop_Then_Proceed;
 		else
 			stateTimeSpeed->eventState = MovementPhaseState_stop_And_Remain;
@@ -353,8 +357,8 @@ void Ntcip1202::populateVehicleSignalGroup(MovementState *movement, int phase)
 	}
 	else if(getPhaseGreensStatus(phase))
 	{
-		//TODO Add protected and permissive
-		stateTimeSpeed->eventState = MovementPhaseState_permissive_Movement_Allowed;
+		//TODO Add logic for permissive which I am not sure we can figure out based on what's in the Spat status being provide by the controller.
+		stateTimeSpeed->eventState = MovementPhaseState_protected_Movement_Allowed;
 	}
 	else
 	{

--- a/src/v2i-hub/SpatPlugin/src/NTCIP1202.cpp
+++ b/src/v2i-hub/SpatPlugin/src/NTCIP1202.cpp
@@ -332,7 +332,7 @@ void Ntcip1202::populateVehicleSignalGroup(MovementState *movement, int phase)
 	MovementEvent *stateTimeSpeed = (MovementEvent *) calloc(1, sizeof(MovementEvent));
 
 	bool isFlashing = getPhaseFlashingStatus(phase);
-	bool forceFlashing = isFlashingStatus() && !isPhaseFlashing();
+	bool forceFlashing = isFlashingStatus();
 
 	if(getPhaseRedStatus(phase))
 	{


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This fix addresses  issue #233 and issue #124 to interpret red and green states correctly. 


## Related Issue

https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/233
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/124

## Motivation and Context


## How Has This Been Tested?
Yes

## Types of changes


- [x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:



- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
