### PR TITLE
Added button to clear all actions in web-service

### DIFF
--- a/tools/port-drayage-webservice/src/main/java/com/leidos/controller/ResetController.java
+++ b/tools/port-drayage-webservice/src/main/java/com/leidos/controller/ResetController.java
@@ -1,0 +1,50 @@
+package com.leidos.controller;
+
+import com.baeldung.openapi.api.ResetApi;
+import com.leidos.inspection.InspectionActions;
+import com.leidos.loading.LoadingActions;
+import com.leidos.unloading.UnloadingActions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+public class ResetController implements ResetApi {
+
+    private static Logger logger = LoggerFactory.getLogger(ResetController.class);
+
+    /**
+     * Injected {@link LoadingActions} Spring Bean
+     */
+    @Autowired
+    private LoadingActions loadingActions;
+
+    /**
+     * Injected {@link UnloadingActions} Spring Bean
+     */
+    @Autowired
+    private UnloadingActions unloadingActions;
+
+    /**
+     * Injected {@link InspectionActions} Spring Bean
+     */
+    @Autowired
+    private InspectionActions inspectionActions;
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseEntity<Void> resetPost() {
+        inspectionActions.clear();
+        unloadingActions.clear();
+        loadingActions.clear();
+        logger.warn("Web Service Actions were cleared!");
+        return new ResponseEntity<Void>(HttpStatus.OK);
+    }
+}

--- a/tools/port-drayage-webservice/src/main/java/com/leidos/inspection/InspectionActions.java
+++ b/tools/port-drayage-webservice/src/main/java/com/leidos/inspection/InspectionActions.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
  * @author Paul Bourelly
  */
 @Component
-public class InspectionActions implements InspectionApi {
+public class InspectionActions  {
 
     private static Logger logger = LoggerFactory.getLogger(InspectionActions.class);
 
@@ -189,6 +189,17 @@ public class InspectionActions implements InspectionApi {
             currentInspection.setStatus(StatusEnum.HOLDING);
         } else
             logger.warn("No current inspection in progress!");
+    }
+
+    /**
+     * Clear all inspection actions
+     */
+    public void clear() {
+        if ( pendingInspections.getInspections() != null )
+            pendingInspections.getInspections().clear();
+        if ( completedInspections.getInspections() != null )
+            completedInspections.getInspections().clear();
+        currentInspection = null;
     }
 
 }

--- a/tools/port-drayage-webservice/src/main/java/com/leidos/loading/LoadingActions.java
+++ b/tools/port-drayage-webservice/src/main/java/com/leidos/loading/LoadingActions.java
@@ -171,4 +171,15 @@ public class LoadingActions {
 
     }
 
+    /**
+     * Clear all loading actions
+     */
+    public void clear() {
+        if ( pendingActions.getActions() != null )
+            pendingActions.getActions().clear();
+        if ( completedActions.getActions() != null )
+            completedActions.getActions().clear();
+        currentAction = null;
+    }
+
 }

--- a/tools/port-drayage-webservice/src/main/java/com/leidos/unloading/UnloadingActions.java
+++ b/tools/port-drayage-webservice/src/main/java/com/leidos/unloading/UnloadingActions.java
@@ -167,4 +167,14 @@ public class UnloadingActions {
 
     }
 
+     /**
+     * Clear all unloading actions
+     */
+    public void clear() {
+        if ( pendingActions.getActions() != null )
+            pendingActions.getActions().clear();
+        if ( completedActions.getActions() != null )
+            completedActions.getActions().clear();
+        currentAction = null;
+    }
 }

--- a/tools/port-drayage-webservice/src/main/resources/port-drayage-webservice.yml
+++ b/tools/port-drayage-webservice/src/main/resources/port-drayage-webservice.yml
@@ -9,6 +9,14 @@ servers:
   - url: https://127.0.0.1:8443
     description: Secured hosting for deployment
 paths:
+  /reset:
+    post:
+      summary: Clear Web Service Actions
+      description:
+        Request will clear all actions in InspectionActions, LoadingActions, and UnloadingActions.
+      responses:
+        "201":
+          description: Created
   /loading:
     post:
       summary: Request a container is loaded on to freight vehicle.

--- a/tools/port-drayage-webservice/src/main/resources/templates/index.html
+++ b/tools/port-drayage-webservice/src/main/resources/templates/index.html
@@ -29,6 +29,31 @@
                     <div class="tab-pane" id="unloading"></div>
                     <div class="tab-pane" id="inspection"></div>
                 </div>
+                <!-- Button trigger modal -->
+                <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#clearModal">
+                    Clear Web Service Actions
+                </button>
+                
+                <!-- Modal -->
+                <div class="modal fade" id="clearModal" tabindex="-1" role="dialog" aria-labelledby="clearModalLabel" aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="clearModalLabel">Caution</h5>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                            Clearing the Web Service Actions will remove all pending, in-progress and completed actions!
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                <button id="clear-actions"type="button" class="btn btn-warning" data-dismiss="modal">Clear Actions</button>
+                            </div>
+                        </div>
+                    </div>
+                 </div>
             </div>
         </div>
     
@@ -65,6 +90,22 @@
         $('#loading').load($('.nav-link.active').attr("data-url"), function (result) {
         });
 
+    </script>
+    <script >
+        // Clear Web Service Actions
+        $('#clear-actions').on('click', function (e) {
+            console.log(e)    
+            e.preventDefault();
+            $.ajax({
+                type: 'post',
+                url: 'reset/',
+                success: function () {
+                    $('#loading').load("loading/")
+                    $('#unloading').load("unloading/")
+                    $('#inspection').load("inspection/")
+                }
+            });
+        });
     </script>
 </main>
 <!-- /.container -->


### PR DESCRIPTION
+ This allows repeated demonstrations of one set of actions
with given actions IDs with requiring web-service restart.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Added Clear button for web service to clear existing actions to allow for repeated executions of the same sequence of actions without requiring restart of web service.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Added Clear button for web service to clear existing actions to allow for repeated executions of the same sequence of actions without requiring restart of web service.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested using the swagger-ui (localhost:8090/swagger-ui/) to send request  and clearing actions using web ui (localhost:8090).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ x ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
