### PR TITLE
Fix BSM ID hex conversion into decimal 

### DIFF
--- a/docker/Dockerfile-depl
+++ b/docker/Dockerfile-depl
@@ -2,7 +2,7 @@ FROM ubuntu:bionic-20190807 AS install_dependencies
 
 RUN apt-get update  && apt-get install -y cmake git build-essential libgtest-dev libssl-dev qtbase5-dev \
     zip libmysqlcppconn-dev libboost1.65-all-dev libmysqlclient-dev uuid-dev libxerces-c-dev qtbase5-dev \
-    libcurl4-openssl-dev libgps-dev libsnmp-dev librdkafka-dev libev-dev libuv-dev libcpprest-dev
+    libcurl4-openssl-dev libgps-dev libsnmp-dev librdkafka-dev libev-dev libuv-dev libcpprest-dev libjsoncpp-dev
 # Build and install GTest 
 WORKDIR cd /usr/src/googletest/googletest
 RUN mkdir ~/build

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -153,15 +153,9 @@ void CARMAStreetsPlugin::HandleMobilityOperationMessage(tsm3Message &msg, routea
 			targetStaticId << mobilityOperation->header.targetStaticId.buf;
 			metadata["targetStaticId"] = targetStaticId.str();
 
-			std::stringstream hostBSMId_ss_hex;
-			hostBSMId_ss_hex << mobilityOperation->header.hostBSMId.buf;
-			std::string hostBSMId_hex = hostBSMId_ss_hex.str();
-			unsigned long hostBSMId_decimal = 0;
-			hostBSMId_ss_hex >> std::hex >> hostBSMId_decimal;
-			PLOG(logERROR) << "MO Hex value = " << hostBSMId_hex << ". Its decimal value is " << hostBSMId_decimal <<std::endl;
-			std::stringstream hostBSMId_ss;
-			hostBSMId_ss << hostBSMId_decimal;
-			metadata["hostBSMId"] = hostBSMId_ss.str();
+			std::stringstream hostBSMId;
+			hostBSMId << mobilityOperation->header.hostBSMId.buf;
+			metadata["hostBSMId"] =hostBSMId.str();
 
 			std::stringstream planId;
 			planId << mobilityOperation->header.planId.buf;
@@ -232,15 +226,9 @@ void CARMAStreetsPlugin::HandleMobilityPathMessage(tsm2Message &msg, routeable_m
 		targetStaticId << mobilityPathMsg->header.targetStaticId.buf;
 		metadata["targetStaticId"] = targetStaticId.str();
 
-		std::stringstream hostBSMId_ss_hex;
-		hostBSMId_ss_hex << mobilityPathMsg->header.hostBSMId.buf;
-		std::string hostBSMId_hex = hostBSMId_ss_hex.str();
-		unsigned long hostBSMId_decimal = 0;
-		hostBSMId_ss_hex >> std::hex >> hostBSMId_decimal;
-		PLOG(logERROR) << "MP Hex value = " << hostBSMId_hex << ". Its decimal value is " << hostBSMId_decimal <<std::endl;
-		std::stringstream hostBSMId_ss;
-		hostBSMId_ss << hostBSMId_decimal;
-		metadata["hostBSMId"] = hostBSMId_ss.str();
+		std::stringstream hostBSMId;
+		hostBSMId << mobilityPathMsg->header.hostBSMId.buf;
+		metadata["hostBSMId"] =hostBSMId.str();
 
 		std::stringstream planId;
 		planId << mobilityPathMsg->header.planId.buf;
@@ -366,7 +354,7 @@ void CARMAStreetsPlugin::HandleBasicSafetyMessage(BsmMessage &msg, routeable_mes
 		std::stringstream id_ss;
 		for(auto i = 0; i < id_len; i++)
 		{			
-			id_ss<<static_cast<int>(bsm->coreData.id.buf[i]);
+			id_ss<<std::hex<<static_cast<int>(bsm->coreData.id.buf[i]);
 		}
 		coreData["id"]  = id_ss.str();
 		

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -153,9 +153,15 @@ void CARMAStreetsPlugin::HandleMobilityOperationMessage(tsm3Message &msg, routea
 			targetStaticId << mobilityOperation->header.targetStaticId.buf;
 			metadata["targetStaticId"] = targetStaticId.str();
 
-			std::stringstream hostBSMId;
-			hostBSMId << mobilityOperation->header.hostBSMId.buf;
-			metadata["hostBSMId"] =hostBSMId.str();
+			std::stringstream hostBSMId_ss_hex;
+			hostBSMId_ss_hex << mobilityOperation->header.hostBSMId.buf;
+			std::string hostBSMId_hex = hostBSMId_ss_hex.str();
+			unsigned long hostBSMId_decimal = 0;
+			hostBSMId_ss_hex >> std::hex >> hostBSMId_decimal;
+			std::cout << "Hex value = " << hostBSMId_hex << ". Its decimal value is " << hostBSMId_decimal <<std::endl;
+			std::stringstream hostBSMId_ss;
+			hostBSMId_ss << hostBSMId_decimal;
+			metadata["hostBSMId"] = hostBSMId_ss.str();
 
 			std::stringstream planId;
 			planId << mobilityOperation->header.planId.buf;

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -158,7 +158,7 @@ void CARMAStreetsPlugin::HandleMobilityOperationMessage(tsm3Message &msg, routea
 			std::string hostBSMId_hex = hostBSMId_ss_hex.str();
 			unsigned long hostBSMId_decimal = 0;
 			hostBSMId_ss_hex >> std::hex >> hostBSMId_decimal;
-			std::cout << "Hex value = " << hostBSMId_hex << ". Its decimal value is " << hostBSMId_decimal <<std::endl;
+			PLOG(logERROR) << "MO Hex value = " << hostBSMId_hex << ". Its decimal value is " << hostBSMId_decimal <<std::endl;
 			std::stringstream hostBSMId_ss;
 			hostBSMId_ss << hostBSMId_decimal;
 			metadata["hostBSMId"] = hostBSMId_ss.str();
@@ -232,9 +232,15 @@ void CARMAStreetsPlugin::HandleMobilityPathMessage(tsm2Message &msg, routeable_m
 		targetStaticId << mobilityPathMsg->header.targetStaticId.buf;
 		metadata["targetStaticId"] = targetStaticId.str();
 
-		std::stringstream hostBSMId;
-		hostBSMId << mobilityPathMsg->header.hostBSMId.buf;
-		metadata["hostBSMId"] =hostBSMId.str();
+		std::stringstream hostBSMId_ss_hex;
+		hostBSMId_ss_hex << mobilityPathMsg->header.hostBSMId.buf;
+		std::string hostBSMId_hex = hostBSMId_ss_hex.str();
+		unsigned long hostBSMId_decimal = 0;
+		hostBSMId_ss_hex >> std::hex >> hostBSMId_decimal;
+		PLOG(logERROR) << "MP Hex value = " << hostBSMId_hex << ". Its decimal value is " << hostBSMId_decimal <<std::endl;
+		std::stringstream hostBSMId_ss;
+		hostBSMId_ss << hostBSMId_decimal;
+		metadata["hostBSMId"] = hostBSMId_ss.str();
 
 		std::stringstream planId;
 		planId << mobilityPathMsg->header.planId.buf;

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -356,7 +356,9 @@ void CARMAStreetsPlugin::HandleBasicSafetyMessage(BsmMessage &msg, routeable_mes
 		{			
 			id_ss<<std::hex<<static_cast<int>(bsm->coreData.id.buf[i]);
 		}
-		coreData["id"]  = id_ss.str();
+		std::stringstream id_fill_ss;
+		id_fill_ss <<  std::setfill('0') << std::setw(8) << id_ss.str();
+		coreData["id"]  = id_fill_ss.str();
 		
 		Json::Value accuracy;
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The BSM id from MobilityPath and MobilityOperation messages is a hex string. It needs to be converted into decimal, then string to match the BSM id type in the BSM message.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-streets/issues/47
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration testing with a vehicle
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
