### PR TITLE
Issue-287: Update docker-compose image tags to 6.2 release

### DIFF
--- a/configuration/amd64/docker-compose.yml
+++ b/configuration/amd64/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ./mysql/port_drayage.sql:/docker-entrypoint-initdb.d/port_drayage.sql
 
   php:
-    image: usdotfhwaops/php:latest
+    image: usdotfhwaops/php:6.2
     container_name: php
     network_mode: host
     depends_on: 
@@ -28,7 +28,7 @@ services:
     tty: true
 
   v2xhub:
-    image: usdotfhwaops/v2xhubamd:v2xrelease_6.2
+    image: usdotfhwaops/v2xhubamd:6.2
     container_name: v2xhub
     network_mode: host
     restart: always
@@ -42,7 +42,7 @@ services:
       - ./logs:/var/log/tmx
       - ./MAP:/var/www/plugins/MAP
   port_drayage_webservice:
-    image: usdotfhwaops/port-drayage-webservice:v2xrelease_6.2
+    image: usdotfhwaops/port-drayage-webservice:6.2
     container_name: port_drayage_webservice
     network_mode: host
 secrets:

--- a/configuration/arm64/docker-compose.yml
+++ b/configuration/arm64/docker-compose.yml
@@ -19,10 +19,8 @@ services:
       - ./mysql/:/docker-entrypoint-initdb.d/
 
   php:
-    image: php:7.2.2-apache
+    image: usdotfhwaops/php:6.2
     container_name: php
-    volumes:
-      - ../../web/:/var/www/html/
     network_mode: host
     depends_on: 
       - db
@@ -30,7 +28,7 @@ services:
     tty: true
 
   v2xhub:
-    image: usdotfhwaops/v2xhubarm:v2xrelease_6.2
+    image: usdotfhwaops/v2xhubarm:6.2
     container_name: v2xhub
     network_mode: host
     restart: always
@@ -44,7 +42,7 @@ services:
       - ./logs:/var/log/tmx
       - ./MAP:/var/www/plugins/MAP
   port_drayage_webservice:
-    image: usdotfhwaops/port-drayage-webservice:v2xrelease_6.2
+    image: usdotfhwaops/port-drayage-webservice:6.2
     container_name: port_drayage_webservice
     network_mode: host
 secrets:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Updated image tags for arm64 and amd64 docker-compose deployments to use 6.2 release images.
<!--- Describe your changes in detail -->

## Related Issue
#287 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Currently docker-compose files will use release candidate images. Update will use release images for 6.2
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Changes tested locally and on Suntrax onsite deployment 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
