### PR TITLE
Issue-318:Update develop docker-compose image tags to be latest

### DIFF
--- a/configuration/amd64/docker-compose.yml
+++ b/configuration/amd64/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ./mysql/port_drayage.sql:/docker-entrypoint-initdb.d/port_drayage.sql
 
   php:
-    image: usdotfhwaops/php:7.0
+    image: usdotfhwaops/php:latest
     container_name: php
     network_mode: host
     depends_on: 
@@ -29,7 +29,7 @@ services:
     tty: true
 
   v2xhub:
-    image: usdotfhwaops/v2xhubamd:7.0
+    image: usdotfhwaops/v2xhubamd:latest
     container_name: v2xhub
     network_mode: host
     restart: always
@@ -43,7 +43,7 @@ services:
       - ./logs:/var/log/tmx
       - ./MAP:/var/www/plugins/MAP
   port_drayage_webservice:
-    image: usdotfhwaops/port-drayage-webservice:7.0
+    image: usdotfhwaops/port-drayage-webservice:latest
     container_name: port_drayage_webservice
     network_mode: host
 secrets:

--- a/configuration/arm64/docker-compose.yml
+++ b/configuration/arm64/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ./mysql/port_drayage.sql:/docker-entrypoint-initdb.d/port_drayage.sql
 
   php:
-    image: usdotfhwaops/php:7.0
+    image: usdotfhwaops/php:latest
     container_name: php
     network_mode: host
     depends_on: 
@@ -29,7 +29,7 @@ services:
     tty: true
 
   v2xhub:
-    image: usdotfhwaops/v2xhubarm:7.0
+    image: usdotfhwaops/v2xhubarm:latest
     container_name: v2xhub
     network_mode: host
     restart: always
@@ -43,7 +43,7 @@ services:
       - ./logs:/var/log/tmx
       - ./MAP:/var/www/plugins/MAP
   port_drayage_webservice:
-    image: usdotfhwaops/port-drayage-webservice:7.0
+    image: usdotfhwaops/port-drayage-webservice:latest
     container_name: port_drayage_webservice
     network_mode: host
 secrets:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
<!--- Describe your changes in detail -->
Update docker-compose image tags to point at `latest` since develop images are built and pushed as latest.

## Related Issue
#318 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix docker-compose file to pull develop images by default.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested using `docker-compose pull`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
