### PR TITLE
Mobility messages and BSM message encoding update

### DIFF
--- a/src/tmx/Asn_J2735/include/asn_j2735_r63/MobilityRequest.h
+++ b/src/tmx/Asn_J2735/include/asn_j2735_r63/MobilityRequest.h
@@ -16,6 +16,7 @@
 #include "MobilityPlanType.h"
 #include "MobilityUrgency.h"
 #include "MobilityLocation.h"
+#include "MobilityLocationOffsets.h"
 #include "MobilityParameters.h"
 #include "MobilityTimestamp.h"
 #include "constr_SEQUENCE.h"
@@ -35,9 +36,9 @@ typedef struct MobilityRequest {
 	MobilityUrgency_t	 urgency;
 	MobilityLocation_t	 location;
 	MobilityParameters_t	 strategyParams;
-	struct MobilityLocation	*trajectoryStart	/* OPTIONAL */;
-	struct MobilityLocationOffsets	*trajectory	/* OPTIONAL */;
-	MobilityTimestamp_t	*expiration	/* OPTIONAL */;
+	MobilityLocation_t	trajectoryStart	/* OPTIONAL */;
+	MobilityLocationOffsets_t	trajectory	/* OPTIONAL */;
+	MobilityTimestamp_t	expiration	/* OPTIONAL */;
 	
 	/* Context for parsing across buffer boundaries */
 	asn_struct_ctx_t _asn_ctx;

--- a/src/tmx/Asn_J2735/include/asn_j2735_r63/TestMessage00.h
+++ b/src/tmx/Asn_J2735/include/asn_j2735_r63/TestMessage00.h
@@ -21,13 +21,13 @@ extern "C" {
 #endif
 
 /* Forward declarations */
-struct Header;
-struct Reg_BasicSafetyMessage;
+// struct Header;
+// struct Reg_BasicSafetyMessage;
 
 /* TestMessage00 */
 typedef struct TestMessage00 {
-	struct Header	*header;	/* OPTIONAL */
-	struct Reg_BasicSafetyMessage	*regional;	/* OPTIONAL */
+	MobilityHeader_t	header;	/* OPTIONAL */
+	MobilityRequest_t	body;	/* OPTIONAL */
 	/*
 	 * This type is extensible,
 	 * possible extensions are below.
@@ -47,8 +47,8 @@ extern asn_TYPE_member_t asn_MBR_TestMessage00_1[2];
 #endif
 
 /* Referred external types */
-#include "Header.h"
-#include "RegionalExtension.h"
+// #include "Header.h"
+// #include "RegionalExtension.h"
 
 #endif	/* _TestMessage00_H_ */
 #include "asn_internal.h"

--- a/src/tmx/Asn_J2735/include/asn_j2735_r63/TestMessage01.h
+++ b/src/tmx/Asn_J2735/include/asn_j2735_r63/TestMessage01.h
@@ -21,13 +21,13 @@ extern "C" {
 #endif
 
 /* Forward declarations */
-struct Header;
-struct Reg_BasicSafetyMessage;
+// struct Header;
+// struct Reg_BasicSafetyMessage;
 
 /* TestMessage01 */
 typedef struct TestMessage01 {
-	struct Header	*header;	/* OPTIONAL */
-	struct Reg_BasicSafetyMessage	*regional;	/* OPTIONAL */
+	MobilityHeader_t	header;	/* OPTIONAL */
+	MobilityResponse_t	body;	/* OPTIONAL */
 	/*
 	 * This type is extensible,
 	 * possible extensions are below.
@@ -47,8 +47,8 @@ extern asn_TYPE_member_t asn_MBR_TestMessage01_1[2];
 #endif
 
 /* Referred external types */
-#include "Header.h"
-#include "RegionalExtension.h"
+// #include "Header.h"
+// #include "RegionalExtension.h"
 
 #endif	/* _TestMessage01_H_ */
 #include "asn_internal.h"

--- a/src/tmx/Asn_J2735/src/r63/MobilityLocationOffsets.c
+++ b/src/tmx/Asn_J2735/src/r63/MobilityLocationOffsets.c
@@ -16,7 +16,7 @@ asn_per_constraints_t asn_PER_type_MobilityLocationOffsets_constr_1 CC_NOTUSED =
 	0, 0	/* No PER value map */
 };
 asn_TYPE_member_t asn_MBR_MobilityLocationOffsets_1[] = {
-	{ ATF_POINTER, 0, 0,
+	{ ATF_NOFLAGS, 0, 0,
 		(ASN_TAG_CLASS_UNIVERSAL | (16 << 2)),
 		0,
 		&asn_DEF_MobilityECEFOffset,

--- a/src/tmx/Asn_J2735/src/r63/MobilityRequest.c
+++ b/src/tmx/Asn_J2735/src/r63/MobilityRequest.c
@@ -53,7 +53,7 @@ asn_TYPE_member_t asn_MBR_MobilityRequest_1[] = {
 		0, 0, /* No default value */
 		"strategyParams"
 		},
-	{ ATF_POINTER, 3, offsetof(struct MobilityRequest, trajectoryStart),
+	{ ATF_NOFLAGS, 0, offsetof(struct MobilityRequest, trajectoryStart),
 		(ASN_TAG_CLASS_CONTEXT | (5 << 2)),
 		-1,	/* IMPLICIT tag at current level */
 		&asn_DEF_MobilityLocation,
@@ -62,7 +62,7 @@ asn_TYPE_member_t asn_MBR_MobilityRequest_1[] = {
 		0, 0, /* No default value */
 		"trajectoryStart"
 		},
-	{ ATF_POINTER, 2, offsetof(struct MobilityRequest, trajectory),
+	{ ATF_NOFLAGS, 0, offsetof(struct MobilityRequest, trajectory),
 		(ASN_TAG_CLASS_CONTEXT | (6 << 2)),
 		-1,	/* IMPLICIT tag at current level */
 		&asn_DEF_MobilityLocationOffsets,
@@ -71,7 +71,7 @@ asn_TYPE_member_t asn_MBR_MobilityRequest_1[] = {
 		0, 0, /* No default value */
 		"trajectory"
 		},
-	{ ATF_POINTER, 1, offsetof(struct MobilityRequest, expiration),
+	{ ATF_NOFLAGS, 0, offsetof(struct MobilityRequest, expiration),
 		(ASN_TAG_CLASS_CONTEXT | (7 << 2)),
 		-1,	/* IMPLICIT tag at current level */
 		&asn_DEF_MobilityTimestamp,

--- a/src/tmx/Asn_J2735/src/r63/TestMessage00.c
+++ b/src/tmx/Asn_J2735/src/r63/TestMessage00.c
@@ -8,23 +8,23 @@
 #include "TestMessage00.h"
 
 asn_TYPE_member_t asn_MBR_TestMessage00_1[] = {
-	{ ATF_POINTER, 2, offsetof(struct TestMessage00, header),
+	{ ATF_NOFLAGS, 0, offsetof(struct TestMessage00, header),
 		(ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		-1,	/* IMPLICIT tag at current level */
-		&asn_DEF_Header,
+		&asn_DEF_MobilityHeader,
 		0,
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
 		"header"
 		},
-	{ ATF_POINTER, 1, offsetof(struct TestMessage00, regional),
+	{ ATF_NOFLAGS, 0, offsetof(struct TestMessage00, body),
 		(ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		-1,	/* IMPLICIT tag at current level */
-		&asn_DEF_Reg_BasicSafetyMessage,
+		&asn_DEF_MobilityRequest,
 		0,
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
-		"regional"
+		"body"
 		},
 };
 static const int asn_MAP_TestMessage00_oms_1[] = { 0, 1 };

--- a/src/tmx/Asn_J2735/src/r63/TestMessage01.c
+++ b/src/tmx/Asn_J2735/src/r63/TestMessage01.c
@@ -8,23 +8,23 @@
 #include "TestMessage01.h"
 
 asn_TYPE_member_t asn_MBR_TestMessage01_1[] = {
-	{ ATF_POINTER, 2, offsetof(struct TestMessage01, header),
+	{ ATF_NOFLAGS, 0, offsetof(struct TestMessage01, header),
 		(ASN_TAG_CLASS_CONTEXT | (0 << 2)),
 		-1,	/* IMPLICIT tag at current level */
-		&asn_DEF_Header,
+		&asn_DEF_MobilityHeader,
 		0,
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
 		"header"
 		},
-	{ ATF_POINTER, 1, offsetof(struct TestMessage01, regional),
+	{ ATF_NOFLAGS, 0, offsetof(struct TestMessage01, body),
 		(ASN_TAG_CLASS_CONTEXT | (1 << 2)),
 		-1,	/* IMPLICIT tag at current level */
-		&asn_DEF_Reg_BasicSafetyMessage,
+		&asn_DEF_MobilityResponse,
 		0,
 		{ 0, 0, 0 },
 		0, 0, /* No default value */
-		"regional"
+		"body"
 		},
 };
 static const int asn_MAP_TestMessage01_oms_1[] = { 0, 1 };

--- a/src/tmx/TmxUtils/test/J2735MessageTest.cpp
+++ b/src/tmx/TmxUtils/test/J2735MessageTest.cpp
@@ -333,7 +333,6 @@ TEST_F(J2735MessageTest, EncodeMobilityOperation)
 	delete my_bytes_1;
 	delete my_str_1;
 	free(frame_msg.get_j2735_data().get());	
-	std::cout << tsm3EncodeMessage<< std::endl;
 	ASSERT_EQ(243,  tsm3EncodeMessage.get_msgId());
 }
 
@@ -423,7 +422,6 @@ TEST_F(J2735MessageTest, EncodeMobilityRequest)
 	delete my_str_1;
 	free(offset);
 	free(frame_msg.get_j2735_data().get());
-	std::cout << tsm0EncodeMessage<< std::endl;
 	ASSERT_EQ(240,  tsm0EncodeMessage.get_msgId());
 }
 
@@ -480,7 +478,6 @@ TEST_F(J2735MessageTest, EncodeMobilityResponse)
 	delete my_bytes_1;
 	delete my_str_1;
 	free(frame_msg.get_j2735_data().get());
-	std::cout << tsm1EncodeMessage<< std::endl;
 	ASSERT_EQ(241,  tsm1EncodeMessage.get_msgId());
 }
 
@@ -541,7 +538,6 @@ TEST_F(J2735MessageTest, EncodeBasicSafetyMessage)
 		
 	free(message);
 	free(frame_msg.get_j2735_data().get());
-	std::cout << bsmEncodeMessage<< std::endl;
 	ASSERT_EQ(20,  bsmEncodeMessage.get_msgId());
 }
 

--- a/src/tmx/TmxUtils/test/J2735MessageTest.cpp
+++ b/src/tmx/TmxUtils/test/J2735MessageTest.cpp
@@ -6,8 +6,13 @@
 #include <boost/any.hpp>
 #include <gtest/gtest.h>
 #include <tmx/j2735_messages/J2735MessageFactory.hpp>
+#include <tmx/j2735_messages/testMessage03.hpp>
 #include <tmx/messages/message_document.hpp>
 #include <vector>
+#include <iostream>
+#include <chrono>
+#include <sstream>
+#include <cassert>
 
 using namespace std;
 using namespace battelle::attributes;
@@ -268,5 +273,277 @@ TEST_F(J2735MessageTest, FactoryTest) {
 		msgFromId = NULL;
 	}
 }
+
+TEST_F(J2735MessageTest, EncodeMobilityOperation)
+{	
+	TestMessage03_t* message = (TestMessage03_t*) malloc( sizeof(TestMessage03_t) );
+
+	/**
+	 * Populate MobilityHeader 
+	 */
+	
+	char* my_str = (char *) "sender_id";
+	uint8_t * my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.hostStaticId.buf = my_bytes;
+	message->header.hostStaticId.size = strlen(my_str);
+	message->header.targetStaticId.buf = my_bytes;
+	message->header.targetStaticId.size = strlen(my_str);
+
+	my_str = (char *) "bsm_idXX";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.hostBSMId.buf = my_bytes;
+	message->header.hostBSMId.size = strlen(my_str);
+
+	my_str = (char *) "00000000-0000-0000-0000-000000000000";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.planId.buf = my_bytes;
+	message->header.planId.size = strlen(my_str);
+
+	unsigned long timestamp_ll = std::chrono::duration_cast<std::chrono::nanoseconds>( std::chrono::system_clock::now().time_since_epoch()).count();		
+	std::string timestamp_str = std::to_string(timestamp_ll).c_str();
+	char * my_str_1 = new char[strlen(timestamp_str.c_str())];
+	uint8_t * my_bytes_1 = new uint8_t[strlen(timestamp_str.c_str())];
+	strcpy(my_str_1, timestamp_str.c_str());
+	for(int i = 0; i< strlen(my_str_1); i++)
+	{
+		my_bytes_1[i] =  (uint8_t)my_str_1[i];
+	}
+	message->header.timestamp.buf = my_bytes_1;
+	message->header.timestamp.size = strlen(my_str_1);
+
+	/**
+	 * Populate MobilityOperation Body 
+	 */
+	my_str = (char *) "traffic_control_id: traffic_control_id, acknowledgement: true, reason: optional reason text";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->body.operationParams.buf = my_bytes;
+	message->body.operationParams.size = strlen(my_str);
+
+	my_str = (char *) "carma3/Geofence_Acknowledgement";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->body.strategy.buf = my_bytes;
+	message->body.strategy.size = strlen(my_str);
+
+	tmx::messages::tsm3EncodedMessage tsm3EncodeMessage;
+	tmx::messages::tsm3Message*  _tsm3Message = new tmx::messages::tsm3Message(message);
+	tmx::messages::MessageFrameMessage frame_msg(_tsm3Message->get_j2735_data());
+	tsm3EncodeMessage.set_data(TmxJ2735EncodedMessage<TestMessage03>::encode_j2735_message<codec::uper<MessageFrameMessage>>(frame_msg));
+		
+	free(message);
+	delete my_bytes_1;
+	delete my_str_1;
+	free(frame_msg.get_j2735_data().get());	
+	std::cout << tsm3EncodeMessage<< std::endl;
+	ASSERT_EQ(243,  tsm3EncodeMessage.get_msgId());
+}
+
+
+TEST_F(J2735MessageTest, EncodeMobilityRequest)
+{	
+	TestMessage00_t* message = (TestMessage00_t*) malloc( sizeof(TestMessage00_t) );
+
+	/**
+	 * Populate MobilityHeader 
+	 */
+	
+	char* my_str = (char *) "sender_id";
+	uint8_t* my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.hostStaticId.buf = my_bytes;
+	message->header.hostStaticId.size = strlen(my_str);
+	message->header.targetStaticId.buf = my_bytes;
+	message->header.targetStaticId.size = strlen(my_str);
+
+	my_str = (char *) "bsm_idXX";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.hostBSMId.buf = my_bytes;
+	message->header.hostBSMId.size = strlen(my_str);
+
+	my_str = (char *) "00000000-0000-0000-0000-000000000000";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.planId.buf = my_bytes;
+	message->header.planId.size = strlen(my_str);
+
+	unsigned long timestamp_ll = std::chrono::duration_cast<std::chrono::nanoseconds>( std::chrono::system_clock::now().time_since_epoch()).count();		
+	std::string timestamp_str = std::to_string(timestamp_ll).c_str();
+	char * my_str_1 = new char[strlen(timestamp_str.c_str())];
+	uint8_t * my_bytes_1 = new uint8_t[strlen(timestamp_str.c_str())];
+	strcpy(my_str_1, timestamp_str.c_str());
+	for(int i = 0; i< strlen(my_str_1); i++)
+	{
+		my_bytes_1[i] =  (uint8_t)my_str_1[i];
+	}
+	message->header.timestamp.buf = my_bytes_1;
+	message->header.timestamp.size = strlen(my_str_1);
+
+	/**
+	 * Populate MobilityRequest Body 
+	 */
+	my_str = (char *) "traffic_control_id: traffic_control_id, acknowledgement: true, reason: optional reason text";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->body.strategyParams.buf = my_bytes;
+	message->body.strategyParams.size = strlen(my_str);
+
+	my_str = (char *) "carma3/Geofence_Acknowledgement";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->body.strategy.buf = my_bytes;
+	message->body.strategy.size = strlen(my_str);
+
+	message->body.urgency = 1;
+	message->body.planType = 0;
+	message->body.location.ecefX = 1;
+	message->body.location.ecefY = 1;
+	message->body.location.ecefZ = 1;
+	message->body.location.timestamp.buf = my_bytes_1;
+	message->body.location.timestamp.size = strlen(my_str_1);
+	
+	message->body.expiration.buf = my_bytes_1;
+	message->body.expiration.size = strlen(my_str_1);
+	
+		
+	MobilityECEFOffset_t* offset = (MobilityECEFOffset_t*) malloc( sizeof(MobilityECEFOffset_t) );
+	offset->offsetX = 1;
+	offset->offsetY = 1;
+	offset->offsetZ = 1;
+	ASN_SEQUENCE_ADD(&message->body.trajectory.list.array, offset);
+	ASN_SEQUENCE_ADD(&message->body.trajectory.list.array, offset);
+
+	message->body.trajectoryStart.ecefX = 1;
+	message->body.trajectoryStart.ecefY = 1;
+	message->body.trajectoryStart.ecefZ = 1;
+	message->body.trajectoryStart.timestamp.buf = my_bytes_1;
+	message->body.trajectoryStart.timestamp.size = strlen(my_str_1);
+		
+	tmx::messages::tsm0EncodedMessage tsm0EncodeMessage;
+	tmx::messages::tsm0Message*  _tsm0Message = new tmx::messages::tsm0Message(message);
+	tmx::messages::MessageFrameMessage frame_msg(_tsm0Message->get_j2735_data());
+	tsm0EncodeMessage.set_data(TmxJ2735EncodedMessage<TestMessage00>::encode_j2735_message<codec::uper<MessageFrameMessage>>(frame_msg));
+		
+	free(message);
+	delete my_bytes_1;
+	delete my_str_1;
+	free(offset);
+	free(frame_msg.get_j2735_data().get());
+	std::cout << tsm0EncodeMessage<< std::endl;
+	ASSERT_EQ(240,  tsm0EncodeMessage.get_msgId());
+}
+
+
+TEST_F(J2735MessageTest, EncodeMobilityResponse)
+{	
+	TestMessage01_t* message = (TestMessage01_t*) malloc( sizeof(TestMessage01_t) );
+
+	/**
+	 * Populate MobilityHeader 
+	 */
+	
+	char* my_str = (char *) "sender_id";
+	uint8_t* my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.hostStaticId.buf = my_bytes;
+	message->header.hostStaticId.size = strlen(my_str);
+	message->header.targetStaticId.buf = my_bytes;
+	message->header.targetStaticId.size = strlen(my_str);
+
+	my_str = (char *) "bsm_idXX";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.hostBSMId.buf = my_bytes;
+	message->header.hostBSMId.size = strlen(my_str);
+
+	my_str = (char *) "00000000-0000-0000-0000-000000000000";
+	my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->header.planId.buf = my_bytes;
+	message->header.planId.size = strlen(my_str);
+
+	unsigned long timestamp_ll = std::chrono::duration_cast<std::chrono::nanoseconds>( std::chrono::system_clock::now().time_since_epoch()).count();		
+	std::string timestamp_str = std::to_string(timestamp_ll).c_str();
+	char * my_str_1 = new char[strlen(timestamp_str.c_str())];
+	uint8_t * my_bytes_1 = new uint8_t[strlen(timestamp_str.c_str())];
+	strcpy(my_str_1, timestamp_str.c_str());
+	for(int i = 0; i< strlen(my_str_1); i++)
+	{
+		my_bytes_1[i] =  (uint8_t)my_str_1[i];
+	}
+	message->header.timestamp.buf = my_bytes_1;
+	message->header.timestamp.size = strlen(my_str_1);
+
+	/**
+	 * Populate MobilityResponse Body 
+	 */
+	message->body.isAccepted = 1;
+	message->body.urgency = 1;
+
+	tmx::messages::tsm1EncodedMessage tsm1EncodeMessage;
+	tmx::messages::tsm1Message*  _tsm1Message = new tmx::messages::tsm1Message(message);
+	tmx::messages::MessageFrameMessage frame_msg(_tsm1Message->get_j2735_data());
+	tsm1EncodeMessage.set_data(TmxJ2735EncodedMessage<TestMessage01>::encode_j2735_message<codec::uper<MessageFrameMessage>>(frame_msg));
+		
+	free(message);
+	delete my_bytes_1;
+	delete my_str_1;
+	free(frame_msg.get_j2735_data().get());
+	std::cout << tsm1EncodeMessage<< std::endl;
+	ASSERT_EQ(241,  tsm1EncodeMessage.get_msgId());
+}
+
+
+TEST_F(J2735MessageTest, EncodeBasicSafetyMessage)
+{	
+	BasicSafetyMessage_t* message = (BasicSafetyMessage_t*) malloc( sizeof(BasicSafetyMessage_t) );
+
+	/**
+	 * Populate BSMcoreData 
+	 */
+	
+	char* my_str = (char *) "sender_id";
+	uint8_t* my_bytes = reinterpret_cast<uint8_t *>(my_str);
+	message->coreData.msgCnt = 1;
+	uint8_t  my_bytes_id[4] = {(uint8_t)1, (uint8_t)12, (uint8_t)12, (uint8_t)10};
+	message->coreData.id.buf = my_bytes_id;
+	message->coreData.id.size = sizeof(my_bytes_id);
+	message->coreData.secMark = 1023;
+	message->coreData.lat = 38954961;
+	message->coreData.Long = -77149303;
+	message->coreData.elev = 72;
+	message->coreData.speed = 100;
+	message->coreData.heading = 12;
+	message->coreData.angle = 10;
+	message->coreData.transmission = 0;  // allow 0...7
+
+	//position accuracy
+	message->coreData.accuracy.orientation= 100;
+	message->coreData.accuracy.semiMajor = 200;
+	message->coreData.accuracy.semiMinor = 200;
+
+	//Acceleration set
+	message->coreData.accelSet.lat = 100;
+	message->coreData.accelSet.Long = 300;
+	message->coreData.accelSet.vert = 100;
+	message->coreData.accelSet.yaw = 0;
+
+	//populate brakes
+	message->coreData.brakes.abs = 1; // allow 0,1,2,3
+	message->coreData.brakes.scs = 1; // allow 0,1,2,3
+	message->coreData.brakes.traction = 1; // allow 0,1,2,3
+	message->coreData.brakes.brakeBoost = 1; // allow 0,1,2
+	message->coreData.brakes.auxBrakes = 1; // allow 0,1,2,3
+	uint8_t  my_bytes_brakes[1] = {8};
+	message->coreData.brakes.wheelBrakes.buf = my_bytes_brakes; // allow 0,1,2,3,4
+	message->coreData.brakes.wheelBrakes.size = sizeof(my_bytes_brakes); // allow 0,1,2,3,4	
+	message->coreData.brakes.wheelBrakes.bits_unused = 3; // allow 0,1,2,3,4	
+
+	//vehicle size
+	message->coreData.size.length = 500;
+	message->coreData.size.width = 300;
+
+	tmx::messages::BsmEncodedMessage bsmEncodeMessage;
+	tmx::messages::BsmMessage*  _bsmMessage = new tmx::messages::BsmMessage(message);
+	tmx::messages::MessageFrameMessage frame_msg(_bsmMessage->get_j2735_data());
+	bsmEncodeMessage.set_data(TmxJ2735EncodedMessage<BasicSafetyMessage>::encode_j2735_message<codec::uper<MessageFrameMessage>>(frame_msg));
+		
+	free(message);
+	free(frame_msg.get_j2735_data().get());
+	std::cout << bsmEncodeMessage<< std::endl;
+	ASSERT_EQ(20,  bsmEncodeMessage.get_msgId());
+}
+
 
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Messages will come into TENA plugin via platoon SDO and need to be encoded and sent to DSRC immediate forwarder plugin via V2XHub.
This PR includes MobilityOperation, MobilityRequest, and MobilityResponse and BSM messages encoding to help the encoding and message creation issues.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
voices
<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?
Local integration testing

![update_j2735_mobility_request_response_operation_bsm_1](https://user-images.githubusercontent.com/62157949/155810808-ef516161-20a3-42dd-bb1b-aa27980b139c.PNG)


MobilityRequest Type: TMSG00-P 
MobilityResponse Type: TMSG01-P 
MobilityOperation Type: TMSG03-P 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
