### PR TITLE
Hotfix ack partial reason

### DIFF
--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -447,7 +447,7 @@ void CARMACloudPlugin::ConvertString2Pair(std::pair<string,string> &str_pair, co
 			key = substring;
 			count += 1;
 		}else{
-			value = substring;
+			value += substring;
 		}		
 	}	
 	str_pair = std::make_pair(key, value);

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -447,7 +447,7 @@ void CARMACloudPlugin::ConvertString2Pair(std::pair<string,string> &str_pair, co
 			key = substring;
 			count += 1;
 		}else{
-			value += substring;
+			value +=  substring + " ";
 		}		
 	}	
 	str_pair = std::make_pair(key, value);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
When the v2xhub receives a positive acknowledgement, it extract data from the strategy_parameters by splitting the whole string into individual meaningful fields: acknowledgement, reason, msgnum etc...
The reason field data is not interpreted correctly and displayed partial reason values on the v2xhub UI.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/352
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
freight verification testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
