### PR TITLE
Hotfix remove tcms for  duplicated tcr ids

### DIFF
--- a/src/v2i-hub/CARMACloudPlugin/manifest.json
+++ b/src/v2i-hub/CARMACloudPlugin/manifest.json
@@ -49,6 +49,11 @@
 			"description": "After it receives TCM from carma cloud, it repeatedly broadcasts TCM until TCMRepeatTimeOut milliseconds."
 		},
 		{
+			"key": "TCMRepeatedlyBroadCastTotalTimes",
+			"default": "1",
+			"description": "The number of times TCMs with the same request id should be broadcast within the time out period."
+		},
+		{
 			"key": "TCMNOAcknowledgementDescription",
 			"default": "No response received from CMV after repeatedly broadcast TCMs.",
 			"description": "If the plugin does not receives any aknowledgement from CMV within the configured seconds that match the original TCM, the plugin will create an NO ACK message and display it on UI."

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -32,6 +32,7 @@ CARMACloudPlugin::CARMACloudPlugin(string name) :PluginClient(name) {
 	base_ack = "/carmacloud/tcmack";
 	method = "POST";
 	_not_ACK_TCMs = std::make_shared<multimap<string, tsm5EncodedMessage>>();
+	_tcm_broadcast_times = std::make_shared<std::map<string, int>>();
 	std::thread Broadcast_t(&CARMACloudPlugin::Broadcast_TCMs, this);
 	Broadcast_t.detach();
 

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -304,7 +304,7 @@ void CARMACloudPlugin::Broadcast_TCMs()
 				{
 					_tcm_broadcast_times->insert({tcmv01_req_id_hex, 0});
 				}
-				else if (_tcm_broadcast_times->at(tcmv01_req_id_hex) > _TCMRepeatedlyBroadCastTotalTimes){
+				else if (_tcm_broadcast_times->at(tcmv01_req_id_hex) >= _TCMRepeatedlyBroadCastTotalTimes){
 					//Skip the broadcasting logic below if the TCMs with this request id has already been broadcast more than _TCMRepeatedlyBroadCastTotalTimes
 					continue;
 				}

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -94,6 +94,14 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 	PLOG(logINFO) << "Sent TCR to cloud: "<< xml_str<<endl;
 	CloudSend(xml_str,url, base_req, method);
 
+	//If TCR reqids match with the any existing TCMs, erase the TCMs from the list after sending new TCR request to carma-cloud.	
+	std::lock_guard<mutex> lock(_not_ACK_TCMs_mutex);
+	if(_not_ACK_TCMs->erase(reqid) <= 0)
+	{
+		PLOG(logDEBUG) << "TCR request id =" << reqid << " Not Found in TCM map." << std::endl;
+	}else{
+		PLOG(logDEBUG) << "TCR request id =" << reqid << " Found in TCM map. Remove the existing TCMs with the same TCR request id." << std::endl;
+	}
 }
 
 void CARMACloudPlugin::HandleMobilityOperationMessage(tsm3Message &msg, routeable_message &routeableMsg){

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -172,6 +172,11 @@ private:
 	//TCM repeatedly broadcast time out in unit of second
 	uint16_t _TCMRepeatedlyBroadcastTimeOut = 0;
 	std::string _TCMNOAcknowledgementDescription = "";
+
+	//Total number of times repeatedly broadcast TCMs with the same request id
+	int _TCMRepeatedlyBroadCastTotalTimes = 0; 
+	//Keep tracking of the number of times repeatedly broadcast TCMS. Key: tcm request id, value: the number of times
+	std::shared_ptr<std::map<string, int>> _tcm_broadcast_times;
 	const string _TCMAcknowledgementStrategy = "carma3/geofence_acknowledgement";
 
 };


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Not broadcasting messages after you see another TCR with the same request id.
Add configuration parameter to restrict the number of TCMs broadcast within a time out period.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
freight
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
NA
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
