### PR TITLE
Hotfix Repeatedly broadcast TCM and timeout bugs

### DIFF
--- a/src/v2i-hub/CARMACloudPlugin/manifest.json
+++ b/src/v2i-hub/CARMACloudPlugin/manifest.json
@@ -51,12 +51,12 @@
 		{
 			"key": "TCMRepeatedlyBroadcastSleep",
 			"default": "100",
-			"description": "The broadcast thread should sleep for number of milliseconds."
+			"description": "The repeatedly broadcast thread should sleep for number of milliseconds."
 		},
 		{
 			"key": "TCMRepeatedlyBroadCastTotalTimes",
 			"default": "1",
-			"description": "The number of times TCMs with the same request id should be broadcast within the time out period."
+			"description": "The number of times TCMs with the same request id should be repeatedly broadcast within the time out period."
 		},
 		{
 			"key": "TCMNOAcknowledgementDescription",

--- a/src/v2i-hub/CARMACloudPlugin/manifest.json
+++ b/src/v2i-hub/CARMACloudPlugin/manifest.json
@@ -49,6 +49,11 @@
 			"description": "After it receives TCM from carma cloud, it repeatedly broadcasts TCM until TCMRepeatTimeOut milliseconds."
 		},
 		{
+			"key": "TCMRepeatedlyBroadcastSleep",
+			"default": "100",
+			"description": "The broadcast thread should sleep for number of milliseconds."
+		},
+		{
 			"key": "TCMRepeatedlyBroadCastTotalTimes",
 			"default": "1",
 			"description": "The number of times TCMs with the same request id should be broadcast within the time out period."

--- a/src/v2i-hub/CARMACloudPlugin/manifest.json
+++ b/src/v2i-hub/CARMACloudPlugin/manifest.json
@@ -49,6 +49,11 @@
 			"description": "After it receives TCM from carma cloud, it repeatedly broadcasts TCM until TCMRepeatTimeOut milliseconds."
 		},
 		{
+			"key": "TCMRepeatedlyBroadCastTotalTimes",
+			"default": "1",
+			"description": "The number of times TCMs with the same request id should be broadcast within the time out period."
+		},
+		{
 			"key": "TCMNOAcknowledgementDescription",
 			"default": "No response received from CMV after repeatedly broadcast TCMs.",
 			"description": "If the plugin does not receives any aknowledgement from CMV within the configured seconds that match the original TCM, the plugin will create an NO ACK message and display it on UI."

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -363,6 +363,12 @@ void CARMACloudPlugin::BroadcastTCM(tsm5EncodedMessage& tsm5ENC) {
 
 bool CARMACloudPlugin::IsSkipBroadcastCurTCM(const string & tcmv01_req_id_hex, const string & tcm_hex_payload ) const
 {
+	//Skip repeatedly broadcasting  
+	if(_TCMRepeatedlyBroadCastTotalTimes == 0)
+	{
+			return true;
+	}
+
 	bool is_skip_cur_tcm = false;
 	bool is_tcm_hex_found = false;
 	auto tcms_metadatas = _tcm_broadcast_times->equal_range(tcmv01_req_id_hex);

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -32,6 +32,7 @@ CARMACloudPlugin::CARMACloudPlugin(string name) :PluginClient(name) {
 	base_ack = "/carmacloud/tcmack";
 	method = "POST";
 	_not_ACK_TCMs = std::make_shared<multimap<string, tsm5EncodedMessage>>();
+	_tcm_broadcast_times = std::make_shared<std::map<string, int>>();
 	std::thread Broadcast_t(&CARMACloudPlugin::Broadcast_TCMs, this);
 	Broadcast_t.detach();
 

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -260,9 +260,16 @@ void CARMACloudPlugin::Broadcast_TCMs()
 		if(_not_ACK_TCMs->size() > 0)
 		{
 			std::lock_guard<mutex> lock(_not_ACK_TCMs_mutex);
-			for( auto itr = _not_ACK_TCMs->begin(); itr!=_not_ACK_TCMs->end(); ++itr )
+			auto itr = _not_ACK_TCMs->begin();
+			while(  itr!=_not_ACK_TCMs->end() )
 			{
+				if(itr == _not_ACK_TCMs->end())
+				{
+					PLOG(logDEBUG) << "itr end " << std::endl;
+					break;
+				}
 				string tcmv01_req_id_hex = itr->first;	
+				PLOG(logDEBUG) << "tcmv01_req_id_hex  " << tcmv01_req_id_hex << std::endl;
 				auto cur_time = (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())).count();				
 				if (_tcm_broadcast_starting_time->count(tcmv01_req_id_hex) == 0)
 				{
@@ -291,8 +298,9 @@ void CARMACloudPlugin::Broadcast_TCMs()
 						  << "</description></TrafficControlAcknowledgement>"; 
 					PLOG(logINFO) << "Sent No ACK as Time Out: "<< sss.str() <<endl;
 					CloudSend(sss.str(),url, base_ack, method);					
-					break;
+					continue;
 				}
+				++itr;
 
 				std::unique_ptr<tsm5EncodedMessage> msg;
 				msg.reset();

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -304,7 +304,7 @@ void CARMACloudPlugin::Broadcast_TCMs()
 				{
 					_tcm_broadcast_times->insert({tcmv01_req_id_hex, 0});
 				}
-				else if (_tcm_broadcast_times->at(tcmv01_req_id_hex) > _TCMRepeatedlyBroadCastTotalTimes){
+				else if (_tcm_broadcast_times->at(tcmv01_req_id_hex) >= _TCMRepeatedlyBroadCastTotalTimes){
 					//Skip the broadcasting logic below if the TCMs with this request id has already been broadcast more than _TCMRepeatedlyBroadCastTotalTimes
 					continue;
 				}

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -94,6 +94,14 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 	PLOG(logINFO) << "Sent TCR to cloud: "<< xml_str<<endl;
 	CloudSend(xml_str,url, base_req, method);
 
+	//If TCR reqids match with the any existing TCMs, erase the TCMs from the list after sending new TCR request to carma-cloud.	
+	std::lock_guard<mutex> lock(_not_ACK_TCMs_mutex);
+	if(_not_ACK_TCMs->erase(reqid) <= 0)
+	{
+		PLOG(logDEBUG) << "TCR request id =" << reqid << " Not Found in TCM map." << std::endl;
+	}else{
+		PLOG(logDEBUG) << "TCR request id =" << reqid << " Found in TCM map. Remove the existing TCMs with the same TCR request id." << std::endl;
+	}
 }
 
 void CARMACloudPlugin::HandleMobilityOperationMessage(tsm3Message &msg, routeable_message &routeableMsg){

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -172,6 +172,11 @@ private:
 	//TCM repeatedly broadcast time out in unit of second
 	uint16_t _TCMRepeatedlyBroadcastTimeOut = 0;
 	std::string _TCMNOAcknowledgementDescription = "";
+
+	//Total number of times repeatedly broadcast TCMs with the same request id
+	int _TCMRepeatedlyBroadCastTotalTimes = 0; 
+	//Keep tracking of the number of times repeatedly broadcast TCMS. Key: tcm request id, value: the number of times
+	std::shared_ptr<std::map<string, int>> _tcm_broadcast_times;
 	const string _TCMAcknowledgementStrategy = "carma3/geofence_acknowledgement";
 
 };

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -194,6 +194,7 @@ private:
 	std::shared_ptr< std::multimap<string, TCMBroadcastMetadata>> _tcm_broadcast_times;
 
 	const string _TCMAcknowledgementStrategy = "carma3/geofence_acknowledgement";
+	int _TCMRepeatedlyBroadcastSleep = 100;
 	
 };
 std::mutex _cfgLock;

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -149,6 +149,12 @@ protected:
 	 * If it timed out, it would remove the TCMs from the list, and stop broadcasting them.
 	 * ***/
 	void Broadcast_TCMs();
+	/***
+	 * @brief: Determin if stop broadcasting the current TCM
+	 * @param: std::string of decoded TCM request id
+	 * @param: key string TCM hex payload
+	 * **/
+	bool IsSkipBroadcastCurTCM(const string & tcmv01_req_id_hex, const string & tcm_hex_payload ) const;
 
 private:
 
@@ -165,20 +171,30 @@ private:
 	//Comma separated string for list of strategies from MobilityOperation messages
 	std::string _strategies;
 
+	struct TCMBroadcastMetadata
+	{
+		string tcm_hex;
+		int num_of_times;
+	};
 	//Used to lock the shared TCMs resource
 	std::mutex _not_ACK_TCMs_mutex;
 	//An associated array to keep track of TCMs that are not acknowledged
 	std::shared_ptr<std::multimap<string, tsm5EncodedMessage>> _not_ACK_TCMs;
+	
 	//TCM repeatedly broadcast time out in unit of second
 	uint16_t _TCMRepeatedlyBroadcastTimeOut = 0;
+	//Keep track of the starting time (unit of milliseconds) TCMs with same TCR request ids being broadcast Key: tcm request id, value: the start broadcasting timestamp
+	std::shared_ptr<std::map<string, std::time_t>> _tcm_broadcast_starting_time;
+	
 	std::string _TCMNOAcknowledgementDescription = "";
 
 	//Total number of times repeatedly broadcast TCMs with the same request id
 	int _TCMRepeatedlyBroadCastTotalTimes = 0; 
-	//Keep tracking of the number of times repeatedly broadcast TCMS. Key: tcm request id, value: the number of times
-	std::shared_ptr<std::map<string, int>> _tcm_broadcast_times;
-	const string _TCMAcknowledgementStrategy = "carma3/geofence_acknowledgement";
+	//Keep track of the number of times repeatedly broadcast TCMS. Key: tcm hex string, value: the number of times
+	std::shared_ptr< std::multimap<string, TCMBroadcastMetadata>> _tcm_broadcast_times;
 
+	const string _TCMAcknowledgementStrategy = "carma3/geofence_acknowledgement";
+	
 };
 std::mutex _cfgLock;
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The TCMs should be broadcast upon receiving a response from carma-cloud. It should be handled inside the HandleResponse method.
Remove TCMs with the same request ids as TCR if receiving a duplicated TCR request.
Fix time out logic that cause segmentation fault.
Add config parameter for the thread sleep for.
Add configuration parameter and logic to control the number of TCMs being broadcast.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/pull/362
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/364
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Freight testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
