### PR TITLE
fix for multiple pedestrian handling

### DIFF
--- a/src/v2i-hub/PedestrianPlugin/src/FLIRWebSockAsyncClnSession.cpp
+++ b/src/v2i-hub/PedestrianPlugin/src/FLIRWebSockAsyncClnSession.cpp
@@ -276,6 +276,7 @@ namespace PedestrianPlugin
 
 		                std::lock_guard<mutex> lock(_psmLock);
                         psmxml = psm_xml_str;
+                        psmQueue.push(psmxml);
 
                         PLOG(logDEBUG) << "Sending PSM xml to BroadcastPsm: " << psmxml.c_str() <<endl;
 
@@ -317,10 +318,10 @@ namespace PedestrianPlugin
         std::cout << beast::make_printable(buffer_.data()) << std::endl;
     }
 
-    //returns the variable containing the psm xml 
-    string FLIRWebSockAsyncClnSession::getPSMXML() const
+    std::queue<std::string>& FLIRWebSockAsyncClnSession::getPSMQueue()
     {
-        return psmxml;
+        std::lock_guard<mutex> lock(_psmLock);
+        return psmQueue;
     }
 
     vector<int> FLIRWebSockAsyncClnSession::timeStringParser(string dateTimeStr) const

--- a/src/v2i-hub/PedestrianPlugin/src/PedestrianPlugin.cpp
+++ b/src/v2i-hub/PedestrianPlugin/src/PedestrianPlugin.cpp
@@ -132,16 +132,15 @@ int PedestrianPlugin::checkXML()
 			PLOG(logDEBUG) << "flir session not yet initialized: " << std::endl;
 		}
 		else
-		{
-			std::string currentXML = flirSession->getPSMXML();
+		{	
+			//retrieve the PSM queue and send each one to be broadcast, then pop		
+			std::queue<string> &currentPSMQueue = flirSession->getPSMQueue();
 
-			if (currentXML.compare(lastGeneratedXML) != 0)
-			{				
-				PLOG(logINFO) << "CheckXML: Broadcasting new CP PSM!" << std::endl;
-
-				BroadcastPsm(const_cast<char*>(currentXML.c_str()));
-				lastGeneratedXML = currentXML;
-			}
+			for (int i = 0; i < currentPSMQueue.size(); i++)
+			{
+				BroadcastPsm(const_cast<char*>(currentPSMQueue.front().c_str()));
+				currentPSMQueue.pop();
+			} 
 		}
 		
 	}	

--- a/src/v2i-hub/PedestrianPlugin/src/include/FLIRWebSockAsyncClnSession.hpp
+++ b/src/v2i-hub/PedestrianPlugin/src/include/FLIRWebSockAsyncClnSession.hpp
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 #include <algorithm>
+#include <queue>
 
 namespace beast = boost::beast;         // from <boost/beast.hpp>
 namespace http = beast::http;           // from <boost/beast/http.hpp>
@@ -36,6 +37,7 @@ namespace PedestrianPlugin
         std::string pedPresenceTrackingReq = std::string("{\"messageType\":\"Subscription\", \"subscription\":{ \"type\":\"Data\", \"action\":\"Subscribe\", \"inclusions\":[{\"type\":\"PedestrianPresenceTracking\"}]}}");
         float cameraRotation_;
         std::string psmxml = "";
+        std::queue<std::string> psmQueue;
         std::mutex _psmLock;
         int msgCount = 0;
     public:
@@ -130,11 +132,11 @@ namespace PedestrianPlugin
     on_close(beast::error_code ec);
 
     /**
-     * @brief Get method for xml containing psm data
+     * @brief Get method for queue containing psm for all tracked pedestrians
      * 
-     * @return std::string the psm xml
+     * @return std::queue the psm queue
      */
-    std::string getPSMXML() const;
+    std::queue<std::string> &getPSMQueue();
 
     /**
      * @brief Parses the datetime string that the camera returns into a vector containing each component

--- a/src/v2i-hub/PedestrianPlugin/src/include/PedestrianPlugin.hpp
+++ b/src/v2i-hub/PedestrianPlugin/src/include/PedestrianPlugin.hpp
@@ -43,6 +43,7 @@
 #include <qhttpengine/server.h>
 #include <qserverPedestrian/OAIApiRouter.h>
 #include <qserverPedestrian/OAIPSM.h>
+#include <queue>
 
 
 using namespace std;


### PR DESCRIPTION
# PR Details
## Description

Now using queue to store all created PSMs for each pedestrian reported by FLIR camera. Pedestrian plugin reads from the queue, sends each PSM to the RSU, and then pops from the queue.

## Related Issue
#374 

## Motivation and Context
Need all pedestrian data.

## How Has This Been Tested?
Two pedestrians walked through the detection zone and I confirmed that multiple unique PSMs were being created and sent to the RSU for broadcast.

## Types of changes
- [x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
