### PR TITLE
fix second field in generated PSM

### DIFF
--- a/src/v2i-hub/PedestrianPlugin/src/FLIRWebSockAsyncClnSession.cpp
+++ b/src/v2i-hub/PedestrianPlugin/src/FLIRWebSockAsyncClnSession.cpp
@@ -367,14 +367,15 @@ namespace PedestrianPlugin
 
         std::string milliseconds = dateTimeStr.substr(0, dateTimeStr.find(delimiter2));
         milliseconds.erase(0, std::min(milliseconds.find_first_not_of('0'), milliseconds.size()-1));
-
+  
+        int millisecondsTotal = (std::stoi(sec) * 1000) + std::stoi(milliseconds);
         parsedArr.push_back(std::stoi(year));
         parsedArr.push_back(std::stoi(month));
         parsedArr.push_back(std::stoi(day));
         parsedArr.push_back(std::stoi(hour));
         parsedArr.push_back(std::stoi(mins));
         parsedArr.push_back(std::stoi(sec));
-        parsedArr.push_back(std::stoi(milliseconds));      
+        parsedArr.push_back(millisecondsTotal);      
 
         return parsedArr;
     }       

--- a/src/v2i-hub/PedestrianPlugin/src/PedestrianPlugin.cpp
+++ b/src/v2i-hub/PedestrianPlugin/src/PedestrianPlugin.cpp
@@ -136,13 +136,12 @@ int PedestrianPlugin::checkXML()
 			//retrieve the PSM queue and send each one to be broadcast, then pop		
 			std::queue<string> currentPSMQueue = flirSession->getPSMQueue();
 
-			if (currentPSMQueue.size() > 0)
-			{				
-				for (int i = 0; i < currentPSMQueue.size(); i++)
-				{
-					BroadcastPsm(const_cast<char*>(currentPSMQueue.front().c_str()));
-					currentPSMQueue.pop();
-				}
+			while(!currentPSMQueue.empty())
+			{		
+				char* char_arr = &currentPSMQueue.front()[0];
+
+				BroadcastPsm(char_arr);
+				currentPSMQueue.pop();
 			}			 
 		}
 		


### PR DESCRIPTION
# PR Details
## Description
Create a new variable to calculate the total milliseconds in the current minute.

## Related Issue
#383 

## Motivation and Context
Secmark field in PSM needs to be corrected.

## How Has This Been Tested?
Collected data at the West Intersection and verified the seconds field in the PSM is properly being updated via the docker log.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
