### PR TITLE
Delay fixes

### DIFF
--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -464,26 +464,26 @@ void CARMACloudPlugin::OnStateChange(IvpPluginState state) {
 	}
 }
 
-void CARMACloudPlugin::CloudSendAsync(const string& msg,const string& url, const string& base, const string& method)
+void CARMACloudPlugin::CloudSendAsync(const string& local_msg,const string& local_url, const string& local_base, const string& local_method)
 {
-	std::thread t([this, &msg, &url, &base, &method](){	
-		CloudSend(msg, url, base, method);	
+	std::thread t([this, &local_msg, &local_url, &local_base, &local_method](){	
+		CloudSend(local_msg, local_url, local_base, local_method);	
 	});
 	t.detach();
 }
 
-int CARMACloudPlugin::CloudSend(const string &msg, const string& url, const string& base, const string& method)
+int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url, const string& local_base, const string& local_method)
 { 	
 	CURL *req;
 	CURLcode res;
-	string urlfull = url+base;	
+	string urlfull = local_url+local_base;	
 	req = curl_easy_init();
 	if(req) {
 		curl_easy_setopt(req, CURLOPT_URL, urlfull.c_str());
 
-		if(strcmp(method.c_str(),"POST")==0)
+		if(strcmp(local_method.c_str(),"POST")==0)
 		{
-			curl_easy_setopt(req, CURLOPT_POSTFIELDS, msg.c_str());
+			curl_easy_setopt(req, CURLOPT_POSTFIELDS, local_msg.c_str());
 			curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 1000L); // Request operation complete within max millisecond timeout 
 			res = curl_easy_perform(req);
 			if(res != CURLE_OK)

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -464,7 +464,7 @@ void CARMACloudPlugin::OnStateChange(IvpPluginState state) {
 	}
 }
 
-void CARMACloudPlugin::CloudSendAsync(string msg,string url, string base, string method)
+void CARMACloudPlugin::CloudSendAsync(const string& msg,const string& url, const string& base, const string& method)
 {
 	std::thread t([this, &msg, &url, &base, &method](){	
 		CloudSend(msg, url, base, method);	
@@ -472,7 +472,7 @@ void CARMACloudPlugin::CloudSendAsync(string msg,string url, string base, string
 	t.detach();
 }
 
-int CARMACloudPlugin::CloudSend(string msg,string url, string base, string method)
+int CARMACloudPlugin::CloudSend(const string &msg, const string& url, const string& base, const string& method)
 { 	
 	CURL *req;
 	CURLcode res;

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -483,7 +483,6 @@ int CARMACloudPlugin::CloudSend(string msg,string url, string base, string metho
 				if(res != CURLE_OK)
 				{
 						fprintf(stderr, "curl send failed: %s\n",curl_easy_strerror(res));
-						return 1;
 				}	  
 			}
 			curl_easy_cleanup(req);

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -95,15 +95,6 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 
 	PLOG(logINFO) << "Sent TCR to cloud: "<< xml_str<<endl;
 	CloudSend(xml_str,url, base_req, method);
-
-	//If TCR reqids match with the any existing TCMs, erase the TCMs from the list after sending new TCR request to carma-cloud.	
-	std::lock_guard<mutex> lock(_not_ACK_TCMs_mutex);
-	if(_not_ACK_TCMs->erase(reqid) <= 0)
-	{
-		PLOG(logDEBUG) << "TCR request id =" << reqid << " Not Found in TCM map." << std::endl;
-	}else{
-		PLOG(logDEBUG) << "TCR request id =" << reqid << " Found in TCM map. Remove the existing TCMs with the same TCR request id." << std::endl;
-	}
 }
 
 void CARMACloudPlugin::HandleMobilityOperationMessage(tsm3Message &msg, routeable_message &routeableMsg){
@@ -487,7 +478,7 @@ int CARMACloudPlugin::CloudSend(string msg,string url, string base, string metho
 		if(strcmp(method.c_str(),"POST")==0)
 		{
     		curl_easy_setopt(req, CURLOPT_POSTFIELDS, msg.c_str());
-			curl_easy_setopt(req, CURLOPT_TIMEOUT, 2L); // Sets a 2 second timeout 
+			curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 500L); // Request operation complete within max millisecond timeout 
 			res = curl_easy_perform(req);
    			if(res != CURLE_OK)
 			   {

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -1,7 +1,7 @@
 #include "CARMACloudPlugin.h"
 #include <WGS84Point.h>
 #include <math.h>
-#include <future>
+#include <thread>
 using namespace std;
 using namespace tmx::messages;
 using namespace tmx::utils;
@@ -467,7 +467,7 @@ void CARMACloudPlugin::OnStateChange(IvpPluginState state) {
 
 int CARMACloudPlugin::CloudSend(string msg,string url, string base, string method)
 { 
-	std::async(std::launch::async, [msg, url, base, method](){
+	std::thread t([msg, url, base, method](){
 		CURL *req;
 		CURLcode res;
 		string urlfull = url+base;	
@@ -478,7 +478,7 @@ int CARMACloudPlugin::CloudSend(string msg,string url, string base, string metho
 			if(strcmp(method.c_str(),"POST")==0)
 			{
 				curl_easy_setopt(req, CURLOPT_POSTFIELDS, msg.c_str());
-				curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 500L); // Request operation complete within max millisecond timeout 
+				curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 1000L); // Request operation complete within max millisecond timeout 
 				res = curl_easy_perform(req);
 				if(res != CURLE_OK)
 				{
@@ -489,6 +489,7 @@ int CARMACloudPlugin::CloudSend(string msg,string url, string base, string metho
 			curl_easy_cleanup(req);
 		}			
 	});
+	t.detach();
   	
   return 0;
 }

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -1,6 +1,7 @@
 #include "CARMACloudPlugin.h"
 #include <WGS84Point.h>
 #include <math.h>
+#include <future>
 using namespace std;
 using namespace tmx::messages;
 using namespace tmx::utils;
@@ -466,20 +467,18 @@ void CARMACloudPlugin::OnStateChange(IvpPluginState state) {
 
 int CARMACloudPlugin::CloudSend(string msg,string url, string base, string method)
 { 
-	std::thread t([msg, url, base, method](){
-		
+	std::async(std::launch::async, [msg, url, base, method](){
 		CURL *req;
 		CURLcode res;
-		string urlfull = url+base;	 
+		string urlfull = url+base;	
 		req = curl_easy_init();
 		if(req) {
 			curl_easy_setopt(req, CURLOPT_URL, urlfull.c_str());
-			std::cout<< "URL " <<  urlfull.c_str()<<endl;
 
 			if(strcmp(method.c_str(),"POST")==0)
 			{
 				curl_easy_setopt(req, CURLOPT_POSTFIELDS, msg.c_str());
-				curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 1000L); // Request operation complete within max millisecond timeout 
+				curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 500L); // Request operation complete within max millisecond timeout 
 				res = curl_easy_perform(req);
 				if(res != CURLE_OK)
 				{
@@ -488,10 +487,8 @@ int CARMACloudPlugin::CloudSend(string msg,string url, string base, string metho
 				}	  
 			}
 			curl_easy_cleanup(req);
-		}
+		}			
 	});
-	t.detach();
-
   	
   return 0;
 }

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -465,29 +465,34 @@ void CARMACloudPlugin::OnStateChange(IvpPluginState state) {
 
 
 int CARMACloudPlugin::CloudSend(string msg,string url, string base, string method)
-{
-	CURL *req;
-  	CURLcode res;
-	string urlfull = url+base;	  
+{ 
+	std::thread t([msg, url, base, method](){
+		
+		CURL *req;
+		CURLcode res;
+		string urlfull = url+base;	 
+		req = curl_easy_init();
+		if(req) {
+			curl_easy_setopt(req, CURLOPT_URL, urlfull.c_str());
+			std::cout<< "URL " <<  urlfull.c_str()<<endl;
 
-
-  	req = curl_easy_init();
- 	 if(req) {
-  	  	curl_easy_setopt(req, CURLOPT_URL, urlfull.c_str());
-
-		if(strcmp(method.c_str(),"POST")==0)
-		{
-    		curl_easy_setopt(req, CURLOPT_POSTFIELDS, msg.c_str());
-			curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 500L); // Request operation complete within max millisecond timeout 
-			res = curl_easy_perform(req);
-   			if(res != CURLE_OK)
-			   {
-      				fprintf(stderr, "curl send failed: %s\n",curl_easy_strerror(res));
-					  return 1;
-			   }	  
+			if(strcmp(method.c_str(),"POST")==0)
+			{
+				curl_easy_setopt(req, CURLOPT_POSTFIELDS, msg.c_str());
+				curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 1000L); // Request operation complete within max millisecond timeout 
+				res = curl_easy_perform(req);
+				if(res != CURLE_OK)
+				{
+						fprintf(stderr, "curl send failed: %s\n",curl_easy_strerror(res));
+						return 1;
+				}	  
+			}
+			curl_easy_cleanup(req);
 		}
-    	curl_easy_cleanup(req);
-  }
+	});
+	t.detach();
+
+  	
   return 0;
 }
 

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -95,7 +95,7 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 	sprintf(xml_str,"<?xml version=\"1.0\" encoding=\"UTF-8\"?><TrafficControlRequest><reqid>%s</reqid><reqseq>%ld</reqseq><scale>%ld</scale>%s</TrafficControlRequest>",reqid, reqseq,scale,bounds_str);
 
 	PLOG(logINFO) << "Sent TCR to cloud: "<< xml_str<<endl;
-	CloudSendAsync(xml_str,url, base_req, method);
+	CloudSend(xml_str,url, base_req, method);
 }
 
 void CARMACloudPlugin::HandleMobilityOperationMessage(tsm3Message &msg, routeable_message &routeableMsg){
@@ -466,7 +466,7 @@ void CARMACloudPlugin::OnStateChange(IvpPluginState state) {
 
 void CARMACloudPlugin::CloudSendAsync(string msg,string url, string base, string method)
 {
-	std::thread t([this, msg, url, base, method](){	
+	std::thread t([this, &msg, &url, &base, &method](){	
 		CloudSend(msg, url, base, method);	
 	});
 	t.detach();

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -110,6 +110,8 @@ protected:
 	int  StartWebService();
 	void CARMAResponseHandler(QHttpEngine::Socket *socket);
 	int CloudSend(string msg,string url, string base, string method);
+	//Send HTTP request async
+	void CloudSendAsync(string msg,string url, string base, string method);
 	string updateTags(string s,string t, string t1);
 
 	void HandleCARMARequest(tsm4Message &msg, routeable_message &routeableMsg);

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -109,9 +109,9 @@ protected:
 
 	int  StartWebService();
 	void CARMAResponseHandler(QHttpEngine::Socket *socket);
-	int CloudSend(string msg,string url, string base, string method);
+	int CloudSend(const string& msg,const string& url, const string& base, const string& method);
 	//Send HTTP request async
-	void CloudSendAsync(string msg,string url, string base, string method);
+	void CloudSendAsync(const string& msg,const string& url, const string& base, const string& method);
 	string updateTags(string s,string t, string t1);
 
 	void HandleCARMARequest(tsm4Message &msg, routeable_message &routeableMsg);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
curl_easy_perform() function itself takes about 100ms, and it will will wait for the response within the operation timeout period and block the current code execution. This will incrementally adding delay as incoming TCRs are arriving much faster than the HTTP request (100ms + timeout period). Adding threads sending HTTP request to make sure it unblocks the incoming TCRs processing.
Removing unnecessary lock for TCR since every TCR has different request id.

## Description
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/392
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/392
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
IHP use case
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing with carma-cloud
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
