### PR TITLE
Update CARMA-Streets Plugin to be able to consume UC 3 scheduling messages

### DIFF
--- a/src/v2i-hub/CARMAStreetsPlugin/manifest.json
+++ b/src/v2i-hub/CARMAStreetsPlugin/manifest.json
@@ -57,11 +57,6 @@
             "description": "Apache Kafka topic plugin will transmit message to."
         },
         {
-            "key": "intersectionType",
-            "default": "Carma/stop_controlled_intersection",
-            "description": "The type of intersection"
-        },
-        {
             "key": "intersectionId",
             "default": "9001",
             "description": "The id of intersection."

--- a/src/v2i-hub/CARMAStreetsPlugin/manifest.json
+++ b/src/v2i-hub/CARMAStreetsPlugin/manifest.json
@@ -62,6 +62,11 @@
             "description": "The type of intersection"
         },
         {
+            "key": "intersectionId",
+            "default": "9001",
+            "description": "The id of intersection."
+        },
+        {
             "key": "KafkaBrokerIp",
             "default": "127.0.0.1",
             "description": "IP of Apache Kafka broker."

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -619,7 +619,7 @@ bool CARMAStreetsPlugin::getEncodedtsm3( tsm3EncodedMessage *tsm3EncodedMsg,  Js
 		std::string strategy_params_str  = "null";
 		if( payload_json != Json::nullValue && !payload_json.empty())
 		{
-			std::string strategy_params_str = (payload_json.isMember("st") ? "st:" + std::to_string(payload_json["st"].asUInt64()) + "," : "") + 
+			strategy_params_str = (payload_json.isMember("st") ? "st:" + std::to_string(payload_json["st"].asUInt64()) + "," : "") + 
 											  (payload_json.isMember("et") ? "et:" + std::to_string(payload_json["et"].asUInt64())+ ","  : "") +
 											  (payload_json.isMember("dt") ?  "dt:" + std::to_string(payload_json["dt"].asUInt64())+ ","  : "") + 
 											  (payload_json.isMember("dp") ? "dp:" + std::to_string(payload_json["dp"].asUInt64())+ ","  : "") +

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -47,6 +47,7 @@ void CARMAStreetsPlugin::UpdateConfigSettings() {
  	GetConfigValue<string>("subscribeToSpatTopic", _subscribeToSpatTopic);
 	GetConfigValue<string>("transmitBSMTopic", _transmitBSMTopic);
  	GetConfigValue<string>("intersectionType", _intersectionType);
+	GetConfigValue<string>("intersectionId", _intersectionId);
 	 // Populate strategies config
 	string config;
 	GetConfigValue<string>("MobilityOperationStrategies", config);
@@ -609,20 +610,20 @@ bool CARMAStreetsPlugin::getEncodedtsm3( tsm3EncodedMessage *tsm3EncodedMsg,  Js
 	{			
 		std::lock_guard<std::mutex> lock(data_lock);
 		TestMessage03* mobilityOperation = (TestMessage03 *) calloc(1, sizeof(TestMessage03));
-		std::string sender_id 			 = "UNSET";
+		std::string sender_id 			 = _intersectionId;
 		std::string recipient_id_str 	 = payload_json != Json::nullValue && payload_json.isMember("v_id") ? payload_json["v_id"].asString(): "UNSET";
 		std::string sender_bsm_id_str 	 = "00000000";
 		std::string plan_id_str 		 = "00000000-0000-0000-0000-000000000000";
-		std::string strategy_str 		 = _intersectionType;
+		std::string strategy_str 		 = metadata != Json::nullValue && metadata.isMember("intersection_type")? metadata["intersection_type"].asString(): _intersectionType;
 		
 		std::string strategy_params_str  = "null";
 		if( payload_json != Json::nullValue && !payload_json.empty())
 		{
-			strategy_params_str 	     = "st:"  +  (payload_json.isMember("st") ? std::to_string(payload_json["st"].asUInt64()) : "0")
-														+ ",et:" +  (payload_json.isMember("et") ? std::to_string(payload_json["et"].asUInt64()) : "0")
-														+ ",dt:" +  (payload_json.isMember("dt") ? std::to_string(payload_json["dt"].asUInt64()) : "0")
-														+ ",dp:" +  (payload_json.isMember("dp") ? std::to_string(payload_json["dp"].asUInt64()) : "0")
-														+ ",access:" + (payload_json.isMember("dp") ? std::to_string(payload_json["access"].asUInt64()): "0"); 
+			std::string strategy_params_str = (payload_json.isMember("st") ? "st:" + std::to_string(payload_json["st"].asUInt64()) + "," : "") + 
+											  (payload_json.isMember("et") ? "et:" + std::to_string(payload_json["et"].asUInt64())+ ","  : "") +
+											  (payload_json.isMember("dt") ?  "dt:" + std::to_string(payload_json["dt"].asUInt64())+ ","  : "") + 
+											  (payload_json.isMember("dp") ? "dp:" + std::to_string(payload_json["dp"].asUInt64())+ ","  : "") +
+											  (payload_json.isMember("access") ?  "access:" + std::to_string(payload_json["access"].asUInt64()) : "");
 		}
 		
 		

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -46,7 +46,6 @@ void CARMAStreetsPlugin::UpdateConfigSettings() {
  	GetConfigValue<string>("subscribeToSchedulingPlanTopic", _subscribeToSchedulingPlanTopic);
  	GetConfigValue<string>("subscribeToSpatTopic", _subscribeToSpatTopic);
 	GetConfigValue<string>("transmitBSMTopic", _transmitBSMTopic);
- 	GetConfigValue<string>("intersectionType", _intersectionType);
 	GetConfigValue<string>("intersectionId", _intersectionId);
 	 // Populate strategies config
 	string config;

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.h
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.h
@@ -96,6 +96,7 @@ private:
 	**/
 	int _run_kafka_consumer = 0; 
 	std::string _intersectionType = "NA";
+	std::string _intersectionId = "UNSET";
 };
 std::mutex _cfgLock;
 

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.h
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.h
@@ -95,7 +95,7 @@ private:
 	 * run the consumer if it equals = 1; otherwise = 0
 	**/
 	int _run_kafka_consumer = 0; 
-	std::string _intersectionType = "NA";
+	std::string _intersectionType = "UNSET";
 	std::string _intersectionId = "UNSET";
 };
 std::mutex _cfgLock;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update CARMA-Streets Plugin to be able to consume UC 3 scheduling messages that only include et (entering time) and read intersection type from scheduling message. Also update UC3 and UC1 scheduling messages to include intersection id in Mobility Header. 


<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/412
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
UC3
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
