### PR TITLE
Issue-420:Skip messages that fail to encode

### DIFF
--- a/src/v2i-hub/CARMAStreetsPlugin/manifest.json
+++ b/src/v2i-hub/CARMAStreetsPlugin/manifest.json
@@ -24,46 +24,22 @@
         "type":"J2735",
         "subtype":"MAP-P",
         "description":"Full geometric layout of the intersection."
-    }],
+    },
+    {
+        "type":"J2735",
+        "subtype":"SPAT-P",
+        "description":"Signal Phase and Timing (SPAT) status for the signalized intersection."
+    }
+    ],
     "configuration": [
         {
-            "key": "transmitMobilityOperationTopic",
-            "default": "v2xhub_mobility_operation_in",
-            "description": "Apache Kafka topic plugin will transmit message to."
+            "key": "LogLevel",
+            "default": "INFO",
+            "description": "The log level for this plugin"
         },
         {
-            "key": "transmitBSMTopic",
-            "default": "v2xhub_bsm_in",
-            "description": "Apache Kafka topic plugin will transmit message to."
-        },
-        {
-            "key": "transmitMapTopic",
-            "default": "v2xhub_map_msg_in",
-            "description": "Apache Kafka topic plugin will transmit message to."
-        },
-        {
-            "key": "runKafkaConsumer",
-            "default": "1",
-            "description": "indicator for consuming kafka messages."
-        },
-        {
-            "key": "subscribeToSchedulingPlanTopic",
-            "default": "v2xhub_scheduling_plan_sub",
-            "description": "Apache Kafka topic plugin will transmit message to."
-        },
-        {
-            "key": "subscribeToSpatTopic",
-            "default": "modified_spat",
-            "description": "Apache Kafka topic plugin will transmit message to."
-        },
-        {
-            "key": "transmitMobilityPathTopic",
-            "default": "v2xhub_mobility_path_in",
-            "description": "Apache Kafka topic plugin will transmit message to."
-        },
-        {
-            "key": "intersectionId",
-            "default": "9001",
+            "key": "IntersectionId",
+            "default": "9945",
             "description": "The id of intersection."
         },
         {
@@ -82,9 +58,45 @@
             "description": "A comma separated list of strategies of MobilityOperation messages to send to CARMA Streets"
         },
         {
-            "key": "LogLevel",
-            "default": "INFO",
-            "description": "The log level for this plugin"
+            "key": "MobilityOperationTopic",
+            "default": "v2xhub_mobility_operation_in",
+            "description": "Apache Kafka topic plugin will transmit message to."
+        },
+        {
+            "key": "MobilityPathTopic",
+            "default": "v2xhub_mobility_path_in",
+            "description": "Apache Kafka topic plugin will transmit message to."
+        }, 
+        {
+            "key": "BSMTopic",
+            "default": "v2xhub_bsm_in",
+            "description": "Apache Kafka topic plugin will transmit message to."
+        },
+        {
+            "key": "MapTopic",
+            "default": "v2xhub_map_msg_in",
+            "description": "Apache Kafka topic plugin will transmit message to."
+        },
+        {
+            "key": "SchedulingPlanTopic",
+            "default": "v2xhub_scheduling_plan_sub",
+            "description": "Apache Kafka topic plugin will transmit message to."
+        },
+        {
+            "key": "SchedulingPlanGroupId",
+            "default": "v2xhub_scheduling_plan",
+            "description": "Apache Kafka consumer group ID for scheduling plan consumer."
+        },
+        {
+            "key": "SpatTopic",
+            "default": "modified_spat",
+            "description": "Apache Kafka topic plugin will transmit message to."
+        },
+        {
+            "key": "SpatConsumerGroupId",
+            "default": "v2xhub_spat",
+            "description": "Apache Kafka consumer group ID for spat consumer."
         }
+        
     ]
 }

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -594,8 +594,11 @@ void CARMAStreetsPlugin::SubscribeSpatKafkaTopic(){
 					}
 					catch (TmxException &ex) 
 					{
-						PLOG(logERROR) << "Failed to encoded SPAT message" << ex.what()<<std::endl;
-						return;
+						// Skip messages that fail to encode.
+						PLOG(logERROR) << "Failed to encoded SPAT message : \n" << payload_str << std::endl << "Exception encountered: " 
+							<< ex.what() << std::endl;
+						ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_SPAT, spat_ptr.get());
+						continue;
 					}
 					
 					ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_SPAT, spat_ptr.get());

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.h
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.h
@@ -71,8 +71,10 @@ private:
 	tmx::messages::J2735MessageFactory factory;
 	std::string _receiveTopic;
 	std::string _transmitMobilityOperationTopic;
-	std::string _subscribeToSchedulingPlanTopic = "";
-	std::string _subscribeToSpatTopic = "";
+	std::string _subscribeToSchedulingPlanTopic;
+	std::string _subscribeToSchedulingPlanConsumerGroupId;
+	std::string _subscribeToSpatTopic;
+	std::string _subscribeToSpatConsumerGroupId;
 	std::string _transmitMobilityPathTopic;
 	std::string _transmitBSMTopic;
 	std::string _transmitMAPTopic;
@@ -94,8 +96,6 @@ private:
 	 * Configurable indicator to run consumer and consume messages from kafka topics
 	 * run the consumer if it equals = 1; otherwise = 0
 	**/
-	int _run_kafka_consumer = 0; 
-	std::string _intersectionType = "UNSET";
 	std::string _intersectionId = "UNSET";
 };
 std::mutex _cfgLock;

--- a/src/v2i-hub/CARMAStreetsPlugin/test/test_JsonToJ2735SpatConverter.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/test/test_JsonToJ2735SpatConverter.cpp
@@ -125,4 +125,32 @@ namespace CARMAStreetsPlugin
         ASSERT_EQ(encoded_spat_str, encodedSpat.get_payload_str());
         ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_SPAT, spat_ptr.get());
     }
+
+    /**
+     * @brief Unit test to ensure encodeSpat will throw and exception attempting to encode timing
+     * data that exceeds max value of 36001 (see ASN1 documentation for TimeMark).
+     * 
+     */
+    TEST_F(test_JsonToJ2735SpatConverter, time_mark_over_max_value) {
+        std::string spat_json_string = "{\"time_stamp\":387178,\"name\":\"\",\"intersections\":[{\"name\":\"East Intersection\",\"id\":9945,\"revision\":1,\"status\":0,\"moy\":387178,\"time_stamp\":32248,\"states\":["
+            "{\"movement_name\":\"\",\"signal_group\":8,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":34975,\"min_end_time\":35405,\"max_end_time\":35405,\"confidence\":0}},{\"event_state\":6,\"timing\":{\"start_time\":35405,\"min_end_time\":35505,\"max_end_time\":35505,\"confidence\":0}},{\"event_state\":8,\"timing\":{\"start_time\":35505,\"min_end_time\":35535,\"max_end_time\":35535,\"confidence\":0}},{\"event_state\":3,\"timing\":{\"start_time\":35535,\"min_end_time\":35965,\"max_end_time\":35965,\"confidence\":0}}]},"
+            "{\"movement_name\":\"\",\"signal_group\":2,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":34695,\"min_end_time\":35125,\"max_end_time\":35125,\"confidence\":0}},{\"event_state\":6,\"timing\":{\"start_time\":35125,\"min_end_time\":35225,\"max_end_time\":35225,\"confidence\":0}},{\"event_state\":8,\"timing\":{\"start_time\":35225,\"min_end_time\":35255,\"max_end_time\":35255,\"confidence\":0}},{\"event_state\":3,\"timing\":{\"start_time\":35255,\"min_end_time\":35685,\"max_end_time\":35685,\"confidence\":0}}]},"
+            "{\"movement_name\":\"\",\"signal_group\":1,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":35115,\"min_end_time\":35545,\"max_end_time\":35545,\"confidence\":0}},{\"event_state\":6,\"timing\":{\"start_time\":35545,\"min_end_time\":35645,\"max_end_time\":35645,\"confidence\":0}},{\"event_state\":8,\"timing\":{\"start_time\":35645,\"min_end_time\":35675,\"max_end_time\":35675,\"confidence\":0}},{\"event_state\":3,\"timing\":{\"start_time\":35675,\"min_end_time\":36105,\"max_end_time\":36105,\"confidence\":0}}]},"
+            "{\"movement_name\":\"\",\"signal_group\":3,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":34835,\"min_end_time\":35265,\"max_end_time\":35265,\"confidence\":0}},{\"event_state\":6,\"timing\":{\"start_time\":35265,\"min_end_time\":35365,\"max_end_time\":35365,\"confidence\":0}},{\"event_state\":8,\"timing\":{\"start_time\":35365,\"min_end_time\":35395,\"max_end_time\":35395,\"confidence\":0}},{\"event_state\":3,\"timing\":{\"start_time\":35395,\"min_end_time\":35825,\"max_end_time\":35825,\"confidence\":0}}]},"
+            "{\"movement_name\":\"\",\"signal_group\":4,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":34975,\"min_end_time\":35405,\"max_end_time\":35405,\"confidence\":0}},{\"event_state\":6,\"timing\":{\"start_time\":35405,\"min_end_time\":35505,\"max_end_time\":35505,\"confidence\":0}},{\"event_state\":8,\"timing\":{\"start_time\":35505,\"min_end_time\":35535,\"max_end_time\":35535,\"confidence\":0}},{\"event_state\":3,\"timing\":{\"start_time\":35535,\"min_end_time\":35965,\"max_end_time\":35965,\"confidence\":0}}]},"
+            "{\"movement_name\":\"\",\"signal_group\":5,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":35115,\"min_end_time\":35545,\"max_end_time\":35545,\"confidence\":0}},{\"event_state\":6,\"timing\":{\"start_time\":35545,\"min_end_time\":35645,\"max_end_time\":35645,\"confidence\":0}},{\"event_state\":8,\"timing\":{\"start_time\":35645,\"min_end_time\":35675,\"max_end_time\":35675,\"confidence\":0}},{\"event_state\":3,\"timing\":{\"start_time\":35675,\"min_end_time\":36105,\"max_end_time\":36105,\"confidence\":0}}]},"
+            "{\"movement_name\":\"\",\"signal_group\":6,\"state_time_speed\":[{\"event_state\":3,\"timing\":{\"start_time\":34695,\"min_end_time\":35125,\"max_end_time\":35125,\"confidence\":0}},{\"event_state\":6,\"timing\":{\"start_time\":35125,\"min_end_time\":35225,\"max_end_time\":35225,\"confidence\":0}},{\"event_state\":8,\"timing\":{\"start_time\":35225,\"min_end_time\":35255,\"max_end_time\":35255,\"confidence\":0}},{\"event_state\":3,\"timing\":{\"start_time\":35255,\"min_end_time\":35685,\"max_end_time\":35685,\"confidence\":0}}]}]}]}";
+        Json::Reader reader;
+        auto spat_ptr = std::make_shared<SPAT>();
+        auto parse_success = reader.parse(spat_json_string, spat_json, true);
+        JsonToJ2735SpatConverter converter;
+        converter.convertJson2Spat(spat_json, spat_ptr.get());
+        tmx::messages::SpatEncodedMessage encodedSpat;
+       
+        ASSERT_THROW( converter.encodeSpat(spat_ptr, encodedSpat), tmx::TmxException );
+        
+        
+
+    }
+
 }


### PR DESCRIPTION
+ Added unit test to assert that ASN1 encoding library will through exception for invalid TimeMark values (0 - 36001 is valid)

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fixing CARMAStreets Plugin to continue consuming SPaT messages after encoding exceptions. Removing any unnecessary configuration parameters and adding a configuration parameter for consumer group id 
## Related Issue
#420 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
