### PR TITLE
Fix compilation errors on Ubuntu 22.04

### DIFF
--- a/src/tmx/TmxApi/tmx/TmxException.hpp
+++ b/src/tmx/TmxApi/tmx/TmxException.hpp
@@ -66,7 +66,7 @@ public:
 		int nptrs = backtrace(btBuffer, BT_BUFFER_SIZE);
 
 		/* overwrite sigaction with caller's address */
-		if (nptrs > 1 && callerAddr > 0)
+		if (nptrs > 1 && callerAddr != 0)
 			btBuffer[1] = callerAddr;
 
 		char **symbols = backtrace_symbols(btBuffer, nptrs);

--- a/src/tmx/TmxCore/src/HistoryManager.cpp
+++ b/src/tmx/TmxCore/src/HistoryManager.cpp
@@ -34,8 +34,10 @@ HistoryManager::HistoryManager(MessageRouter *messageRouter) : Plugin(messageRou
 	info.pluginInfo.description = "Core element that is responsible for purging old log and history data";
 	info.pluginInfo.version = IVPCORE_VERSION;
 
+	ostringstream m = ostringstream() << HISTORYPURGER_CONFIGDFLT_PURGEINTERVAL;
+
 	info.configDefaultEntries.push_back(PluginConfigurationParameterEntry(HISTORYPURGER_CONFIGKEY_PURGEINTERVAL,
-			static_cast<ostringstream*>( &(ostringstream() << HISTORYPURGER_CONFIGDFLT_PURGEINTERVAL) )->str(),
+			static_cast<ostringstream*>( &m )->str(),
 			"Interval between purges of history items"));
 	info.configDefaultEntries.push_back(PluginConfigurationParameterEntry(HISTORYPURGER_CONFIGKEY_MAXEVENTLOGSIZE, "2000", "Maximum number of event log entries to keep.  A value of zero will result in no purging of event log entries"));
 


### PR DESCRIPTION
When compiling on Ubuntu 22.04 the following errors prevented successful compilation: 

`HistoryManager.cpp:38 error: taking address of rvalue`
`TmxException.cpp:69 error: ordered comparison of pointer with integer zero ('void*' and 'int')`

This pull request fixes these two issues. 