### PR TITLE
Add an error message if the file for the DB password cannot be opened…

### DIFF
--- a/src/tmx/TmxCore/src/ivpcore.cpp
+++ b/src/tmx/TmxCore/src/ivpcore.cpp
@@ -135,7 +135,7 @@ std::string GetPwd(){
 	std::string PwdStr;
 	pwdFile = std::getenv(EnvVar);
 
-	if (pwdFile == NULL){
+	if (pwdFile == nullptr) {
 		LOG_ERROR("Unable to get MYSQL_PASSWORD)");
 	} else{
 		std::ifstream t(pwdFile);

--- a/src/tmx/TmxCore/src/ivpcore.cpp
+++ b/src/tmx/TmxCore/src/ivpcore.cpp
@@ -128,24 +128,27 @@ void addSystemDefinedMessageTypes()
 
 
 std::string GetPwd(){
+	// NOTE this is duplicated in DbConnectionPool.cpp but no good way to reuse for now
+	// env should probably be named MYSQL_PASSWORD_FILE but is left for legacy
 	const char* EnvVar = "MYSQL_PASSWORD";
-	const char* pwd;
-	pwd = std::getenv(EnvVar);
+	const char* pwdFile;
+	std::string PwdStr;
+	pwdFile = std::getenv(EnvVar);
 
-	if(pwd == NULL){
-		LOG_ERROR("Unable to set MYSQL_PASSWORD)");
-		return "";
-	}
-	else{
-		std::ifstream t(pwd);
-		std::stringstream buffer;
-		buffer << t.rdbuf();
-		if ( buffer.str() != "") {
-			std::string PwdStr = buffer.str();
-			return PwdStr;
+	if (pwdFile == NULL){
+		LOG_ERROR("Unable to get MYSQL_PASSWORD)");
+	} else{
+		std::ifstream t(pwdFile);
+		if (t) {
+			std::getline( t, PwdStr);
+			if (PwdStr.length() == 0) {
+				LOG_ERROR("Empty pwd file: " << pwdFile);
+			}
+		} else {
+			LOG_ERROR("Unable to read pwd file: " << pwdFile);
 		}
 	}
-	return  "";
+	return PwdStr;
 }
 
 int main()

--- a/src/tmx/TmxUtils/src/database/DbConnectionPool.cpp
+++ b/src/tmx/TmxUtils/src/database/DbConnectionPool.cpp
@@ -125,16 +125,21 @@ std::string DbConnectionPool::GetPwd(){
 	pwd = std::getenv(EnvVar);
 
 	if(pwd == NULL){
-		PLOG(logERROR) << "Unable to set MYSQL_PASSWORD)";
+		PLOG(logERROR) << "Unable to get MYSQL_PASSWORD";
 		return "";
 	}
 	else{
 		std::ifstream t(pwd);
-		std::stringstream buffer;
-		buffer << t.rdbuf();
-		if ( buffer.str() != "") {
-			std::string PwdStr = buffer.str();
-			return PwdStr;
+		if (t) {
+			std::stringstream buffer;
+			buffer << t.rdbuf();
+			if ( buffer.str() != "") {
+				std::string PwdStr = buffer.str();
+				return PwdStr;
+			}
+			PLOG(logERROR) << "No bytes read from pwd file: " << pwd;
+		} else {
+			PLOG(logERROR) << "Unable to read pwd file: " << pwd;
 		}
 	}
 	return "";

--- a/src/tmx/TmxUtils/src/database/DbConnectionPool.cpp
+++ b/src/tmx/TmxUtils/src/database/DbConnectionPool.cpp
@@ -127,7 +127,7 @@ std::string DbConnectionPool::GetPwd(){
 	std::string PwdStr;
 	pwdFile = std::getenv(EnvVar);
 
-	if (pwdFile == NULL){
+	if (pwdFile == nullptr) {
 		PLOG(logERROR) << "Unable to get MYSQL_PASSWORD";
 	} else{
 		std::ifstream t(pwdFile);

--- a/src/tmx/TmxUtils/src/database/DbConnectionPool.cpp
+++ b/src/tmx/TmxUtils/src/database/DbConnectionPool.cpp
@@ -120,29 +120,27 @@ void DbConnectionPool::SetConnectionUrl(std::string connectionUrl) {
 }
 
 std::string DbConnectionPool::GetPwd(){
+	// NOTE this is duplicated in ivpcore.cpp but no good way to reuse for now
+	// env should probably be named MYSQL_PASSWORD_FILE but is left for legacy
 	const char* EnvVar = "MYSQL_PASSWORD";
-	const char* pwd;
-	pwd = std::getenv(EnvVar);
+	const char* pwdFile;
+	std::string PwdStr;
+	pwdFile = std::getenv(EnvVar);
 
-	if(pwd == NULL){
+	if (pwdFile == NULL){
 		PLOG(logERROR) << "Unable to get MYSQL_PASSWORD";
-		return "";
-	}
-	else{
-		std::ifstream t(pwd);
+	} else{
+		std::ifstream t(pwdFile);
 		if (t) {
-			std::stringstream buffer;
-			buffer << t.rdbuf();
-			if ( buffer.str() != "") {
-				std::string PwdStr = buffer.str();
-				return PwdStr;
+			std::getline( t, PwdStr);
+			if (PwdStr.length() == 0) {
+				PLOG(logERROR) << "Empty pwd file: " << pwdFile;
 			}
-			PLOG(logERROR) << "No bytes read from pwd file: " << pwd;
 		} else {
-			PLOG(logERROR) << "Unable to read pwd file: " << pwd;
+			PLOG(logERROR) << "Unable to read pwd file: " << pwdFile;
 		}
 	}
-	return "";
+	return PwdStr;
 }
 
 } /* namespace utils */


### PR DESCRIPTION
… or is empty.

Without this another error comes later and it is not clear what the underlying issue is.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Change DBConnectionPool to generate error message if password file cannot be read.

## Related Issue

Fixes #442
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
See issue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
