### PR TITLE
Add a volume to docker compose file so that MySQL data is not dropped…

### DIFF
--- a/configuration/amd64/docker-compose.yml
+++ b/configuration/amd64/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - ./mysql/localhost.sql:/docker-entrypoint-initdb.d/localhost.sql
       - ./mysql/port_drayage.sql:/docker-entrypoint-initdb.d/port_drayage.sql
+      - mysql-datavolume:/var/lib/mysql
 
   php:
     image: usdotfhwaops/php:7.3.1
@@ -51,3 +52,6 @@ secrets:
         file: ./secrets/mysql_password.txt
     mysql_root_password:
         file: ./secrets/mysql_root_password.txt
+
+volumes:
+  mysql-datavolume:

--- a/configuration/arm64/docker-compose.yml
+++ b/configuration/arm64/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - ./mysql/localhost.sql:/docker-entrypoint-initdb.d/localhost.sql
       - ./mysql/port_drayage.sql:/docker-entrypoint-initdb.d/port_drayage.sql
+      - mysql-datavolume:/var/lib/mysql
 
   php:
     image: usdotfhwaops/php_arm:7.3.1
@@ -51,3 +52,6 @@ secrets:
         file: ./secrets/mysql_password.txt
     mysql_root_password:
         file: ./secrets/mysql_root_password.txt
+
+volumes:
+  mysql-datavolume:


### PR DESCRIPTION
… every time docker container is restarted.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Change docker compose example files to use volumes for MySQL data.

## Related Issue
#444 

## Motivation and Context
Data in the database should not be lost between runs.

## How Has This Been Tested?
Tested locally by myself and by Will on his setup.  Follow the steps in the linked issue and login is now possible after restart using the initially entered credentals.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
