### PR TITLE
ERVRSUPlugin bugfix

### DIFF
--- a/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingPlugin.h
+++ b/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingPlugin.h
@@ -53,8 +53,8 @@ namespace ERVCloudForwardingPlugin
         string _authPassPhrase;
         string _GPSOID;
         const string _CLOUDURL = "http://127.0.0.1:33333";
-        const string _CLOUDBSMREQ = "/carmacloud/bsmreq";
-        const string _CLOUDRSUREQ = "/carmacloud/rsuLocreq";
+        const string _CLOUDBSMREQ = "/carmacloud/rsu/req";
+        const string _CLOUDRSUREQ = "/carmacloud/rsu/register";
         const string _POSTMETHOD = "POST";
         const string _HEXENC = "asn.1-uper/hexstring";
 

--- a/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingWorker.cpp
+++ b/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingWorker.cpp
@@ -89,7 +89,7 @@ namespace ERVCloudForwardingPlugin
     std::string ERVCloudForwardingWorker::constructRSULocationRequest(std::string &rsu_identifier, uint16_t v2xhub_web_port, long latitude, long longitude)
     {
         char xml_str[20000];
-        snprintf(xml_str, sizeof(xml_str), "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RSULocationRequest><id>%s</id><latitude>%ld<latitude><longitude>%ld</longitude><v2xhubPort>%d</v2xhubPort></RSULocationRequest>", rsu_identifier.c_str(), latitude, longitude, v2xhub_web_port);
+        snprintf(xml_str, sizeof(xml_str), "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RSULocationRequest><id>%s</id><latitude>%ld</latitude><longitude>%ld</longitude><v2xhubPort>%d</v2xhubPort></RSULocationRequest>", rsu_identifier.c_str(), latitude, longitude, v2xhub_web_port);
         return xml_str;
     }
 } // namespace  ERVCloudForwardingPlugin

--- a/src/v2i-hub/ERVCloudForwardingPlugin/test/ERVCloudForwardingWorkerTest.cpp
+++ b/src/v2i-hub/ERVCloudForwardingPlugin/test/ERVCloudForwardingWorkerTest.cpp
@@ -239,7 +239,7 @@ namespace unit_test
       long longitude = -7714955667;
       uint16_t v2xhubPort = 44444;
       auto xml_str = ERVCloudForwardingPlugin::ERVCloudForwardingWorker::constructRSULocationRequest(rsu_identifier, v2xhubPort, latitude, longitude);
-      std::string expected_xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RSULocationRequest><id>" + rsu_identifier + "</id><latitude>3895510833<latitude><longitude>-7714955667</longitude><v2xhubPort>" + std::to_string(v2xhubPort) + "</v2xhubPort></RSULocationRequest>";
+      std::string expected_xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><RSULocationRequest><id>" + rsu_identifier + "</id><latitude>3895510833</latitude><longitude>-7714955667</longitude><v2xhubPort>" + std::to_string(v2xhubPort) + "</v2xhubPort></RSULocationRequest>";
       ASSERT_EQ(expected_xml, xml_str);
    }
 } // namespace unit_test


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The bugs are found during the integration testing with carma-cloud instance. The bugs include: 
- Request url has changed
- The RSU request missed an ending / in the end tag.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/467
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Emergency Response Use case
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
