### PR TITLE
Update docker compose configuration for some backwards compatibility.

### DIFF
--- a/.devcontainer/Dockerfile.builder
+++ b/.devcontainer/Dockerfile.builder
@@ -1,9 +1,10 @@
-ARG UBUNTU_VERSION=focal-20220113
+ARG UBUNTU_VERSION=jammy
 
 FROM ubuntu:$UBUNTU_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 ADD scripts/install_dependencies.sh /usr/local/bin/
+RUN echo "deb [trusted=yes] http://s3.amazonaws.com/stol-apt-repository develop main" > /etc/apt/sources.list.d/stol-apt-repository.list
 RUN /usr/local/bin/install_dependencies.sh
 
 # build out ext components

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,12 +16,17 @@
 	// connected. Corresponds to a volume mount in .devcontainer/docker-compose.yml
 	"workspaceFolder": "/workspace",
 
-	"extensions": [
-		"ms-vscode.cpptools",
-		"ms-vscode.cpptools-extension-pack",
-		"ms-vscode.cmake-tools",
-		"twxs.cmake"
-	],
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-vscode.cpptools-extension-pack",
+				"ms-vscode.cmake-tools",
+				"twxs.cmake"
+			]
+		}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/docker-compose-vscode.yml
+++ b/.devcontainer/docker-compose-vscode.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.3'
 
 services:
   v2xhub:
@@ -10,6 +10,7 @@ services:
     volumes:
       # This is where VS Code should expect to find your project's source code and the value of "workspaceFolder" in .devcontainer/devcontainer.json
       - ..:/workspace:cached
+      - ./MAP:/var/www/plugins/MAP
     # Overrides default command so things don't shut down after the process ends.
     command: /bin/sh -c "while sleep 1000; do :; done"  
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src/v2i-hub/build
 
 # manually created directories
 secrets
+.devcontainer/MAP
 
 # Compiled source #
 ###################

--- a/docs/Visual_Studio_Code_Setup.md
+++ b/docs/Visual_Studio_Code_Setup.md
@@ -28,6 +28,14 @@ Once a container has been built you should not need to rebuild it again unless s
 
 One of the great features about this setup is that the devcontainer.json file can be configured with a list of extensions to be included any time the container is opener so the list can be configured with what is most commonly used with the project so new users do not need to figure that out by themselves or manually install them.
 
+## Troubleshooting
+
+If you have issues with the setup go to the .devconainer folder and run:
+
+```docker-compose -f docker-compose-vscode.yml config```
+
+to see if there are any problems with your compose configuration compatibility.
+
 ## Tasks
 
 The configuration comes with 3 configured tasks.  These can be run under from the menu via *Terminal -> Run Task...*.  The tasks are described below.


### PR DESCRIPTION
Use Ubuntu jammy for development.
Update documentation on compose troubleshooting.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

These changes address some issues found while troubleshooting the docker compose setup and now using Ubuntu 22 (jammy) as the dev build container.  Specifically someone had an older version of docker-compose which did not recognize the 3.8 version of the yml file.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

David and I have been testing this in his setup and I have also used it.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
