### PR TITLE
Change error messages for file upload to ERROR so they can be seen on…

### DIFF
--- a/src/v2i-hub/CommandPlugin/src/CommandPlugin.cpp
+++ b/src/v2i-hub/CommandPlugin/src/CommandPlugin.cpp
@@ -176,7 +176,7 @@ int CommandPlugin::FileUploadCB(void *data, const char *name, const char *filena
 		}
 		catch (exception & ex)
 		{
-			FILE_LOG(logDEBUG) << "CommandPlugin::FileUploadCB: Failed to create download folder";
+			FILE_LOG(logERROR) << "CommandPlugin::FileUploadCB: Failed to create download folder";
 			_uploadRequests[pss->filename].message = "Failed to create download folder";
 			return 1;
 		}
@@ -188,7 +188,7 @@ int CommandPlugin::FileUploadCB(void *data, const char *name, const char *filena
 				O_CREAT | O_TRUNC | O_RDWR, 0600);
 		if (pss->fd < 0)
 		{
-			FILE_LOG(logDEBUG) << "CommandPlugin::FileUploadCB: Failed to create or open file";
+			FILE_LOG(logERROR) << "CommandPlugin::FileUploadCB: Failed to create or open file";
 			_uploadRequests[pss->filename].message = "Failed to create or open file";
 			return 1;
 		}
@@ -266,7 +266,7 @@ int CommandPlugin::FileUploadCB(void *data, const char *name, const char *filena
 					}
 					catch (exception & ex)
 					{
-						FILE_LOG(logDEBUG) << "CommandPlugin::FileUploadCB: Failed to create destination folder";
+						FILE_LOG(logERROR) << "CommandPlugin::FileUploadCB: Failed to create destination folder";
 						_uploadRequests[pss->filename].message = "Failed to create destination folder";
 						return 1;
 					}
@@ -279,12 +279,12 @@ int CommandPlugin::FileUploadCB(void *data, const char *name, const char *filena
 				}
 				catch (exception & ex)
 				{
-					FILE_LOG(logDEBUG) << "CommandPlugin::FileUploadCB: Failed to copy file to destination folder.";
+					FILE_LOG(logERROR) << "CommandPlugin::FileUploadCB: Failed to copy file to destination folder: " << toFile;
 					_uploadRequests[pss->filename].message = "Failed to copy file to destination folder.";
 					try
 					{
 						boost::filesystem::remove(fromFile);
-						FILE_LOG(logDEBUG) << "CommandPlugin::FileUploadCB: Failed to delete download file.";
+						FILE_LOG(logERROR) << "CommandPlugin::FileUploadCB: Failed to delete download file: " << fromFile;
 						_uploadRequests[pss->filename].message.append(" Failed to delete download file.");
 					}
 					catch (exception & ex2)
@@ -298,7 +298,7 @@ int CommandPlugin::FileUploadCB(void *data, const char *name, const char *filena
 				}
 				catch (exception & ex)
 				{
-					FILE_LOG(logDEBUG) << "CommandPlugin::FileUploadCB: Failed to delete download file.";
+					FILE_LOG(logERROR) << "CommandPlugin::FileUploadCB: Failed to delete download file.";
 					_uploadRequests[pss->filename].message = "Failed to delete download file.";
 					return 1;
 				}


### PR DESCRIPTION
… the command line

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Sets some error message in the CommandPlugin for file upload operations to ERROR instead of DEBUG so they can be seen on the command line by default.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This does not resolve #145 but can provide more info on the failure that is occurring and is a good overall enhancement.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
