### PR TITLE
Log time for a message received in V2x to forward to carma cloud, and from receiving in Carma Cloud to forward V2xhub

### DIFF
--- a/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingPlugin.cpp
+++ b/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingPlugin.cpp
@@ -19,6 +19,7 @@ namespace ERVCloudForwardingPlugin
 
     void ERVCloudForwardingPlugin::handleBSM(BsmMessage &msg, routeable_message &routableMsg)
     {
+        uint64_t delayStart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         // Check if the BSM is broadcast by an ERV (Emergency Response Vehicle)
         if (ERVCloudForwardingWorker::IsBSMFromERV(msg))
         {
@@ -26,12 +27,14 @@ namespace ERVCloudForwardingPlugin
             auto xml_str = ERVCloudForwardingWorker::constructERVBSMRequest(msg);
             PLOG(logINFO) << "Forward ERV BSM to cloud: " << xml_str << endl;
             CloudSendAsync(xml_str, _CLOUDURL, _CLOUDBSMREQ, _POSTMETHOD);
+            uint64_t delayEnd = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+            PLOG(logINFO) << "Received ERV BSM and forward ERV BSM to cloud delay (ms): " << (delayEnd - delayStart) << endl;
         }
         else
         {
             // If BSM is not from ERV, print debug log
             PLOG(logDEBUG) << "Incoming BSM is not from Emergency Response Vehicle (ERV)." << endl;
-        }
+        }        
     }
 
     void ERVCloudForwardingPlugin::RegisterRSULocation()
@@ -127,6 +130,7 @@ namespace ERVCloudForwardingPlugin
 
     void ERVCloudForwardingPlugin::CARMACloudResponseHandler(QHttpEngine::Socket *socket)
     {
+        uint64_t delayStart = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
         QString st;
         while (socket->bytesAvailable() > 0)
         {
@@ -138,6 +142,8 @@ namespace ERVCloudForwardingPlugin
         string bsmHex = _cloudUpdate;
         PLOG(logINFO) << "Received ERV BSM from cloud:" << bsmHex << endl;
         BroadcastBSM(bsmHex);
+        uint64_t delayEnd = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+        PLOG(logINFO) << "Received ERV BSM from cloud and broadcast ERV BSM delay(ms):" << (delayEnd - delayStart) << endl;
     }
 
     int ERVCloudForwardingPlugin::StartBSMWebService()


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Any general idea how to get the time it takes for a message received in V2x to forward to carma cloud, and from receiving in Carma Cloud to forward V2xhub
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/511
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Freight
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
