### PR TITLE
Segmentation fault when the ERV BSM PARTII does not populate emergency type

### DIFF
--- a/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingWorker.cpp
+++ b/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingWorker.cpp
@@ -56,9 +56,20 @@ namespace ERVCloudForwardingPlugin
         else
         {
             // The ERV broadcast BSM that has the PartII content, and the specical vehicle extension within the PartII has the emergency response type.
-            if (bsm_ptr->partII->list.count > 0 && bsm_ptr->partII->list.array[0]->partII_Value.present == BSMpartIIExtension__partII_Value_PR_SpecialVehicleExtensions && *bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->responseType == ResponseType_emergency)
+            if (bsm_ptr->partII->list.count > 0 && bsm_ptr->partII->list.array[0]->partII_Value.present == BSMpartIIExtension__partII_Value_PR_SpecialVehicleExtensions )
             {
-                return true;
+                if(bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->responseType && *bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->responseType == ResponseType_emergency)
+                {
+                    return true;
+                }
+                if(bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->lightsUse == LightbarInUse_inUse)
+                {
+                    return true;
+                }    
+                if(bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->sirenUse == SirenInUse_inUse)
+                {
+                    return true;
+                }             
             }
             return false;
         }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
During the full integration testing, some of the BSMs' PartII from ERV do not have the light in use populated and emergency response type is missing. The below is one of the BSM in XML format shows that there is no emergency response type.
```
[2023-04-12 19:44:48.037] RVCloudForwardingPlugin.cpp (23) - INFO   : <?xml version="1.0" encoding="utf-8"?>
<BasicSafetyMessage><coreData><msgCnt>98</msgCnt><id>08 00 00 00</id><secMark>65535</secMark><lat>281234436</lat><long>-818348846</long><elev>-4096</elev><accuracy><semiMajor>255</semiMajor><semiMinor>255</semiMinor><orientation>65535</orientation></accuracy><transmission><neutral/></transmission><speed>800</speed><heading>28800</heading><angle>127</angle><accelSet><long>2001</long><lat>2001</lat><vert>-127</vert><yaw>0</yaw></accelSet><brakes><wheelBrakes>10000</wheelBrakes><traction><unavailable/></traction><abs><unavailable/></abs><scs><unavailable/></scs><brakeBoost><unavailable/></brakeBoost><auxBrakes><unavailable/></auxBrakes></brakes><size><width>0</width><length>0</length></size></coreData><partII><BSMpartIIExtension><partII-Id>1</partII-Id><partII-Value><SpecialVehicleExtensions><vehicleAlerts><sspRights>0</sspRights><sirenUse><inUse/></sirenUse><lightsUse><unavailable/></lightsUse><multi><unavailable/></multi></vehicleAlerts></SpecialVehicleExtensions></partII-Value></BSMpartIIExtension></partII><regional><Reg-BasicSafetyMessage><regionId>128</regionId><regExtValue><BasicSafetyMessage-addGrpCarma><routeDestinationPoints><Position3D-addGrpCarma><lat>281168537</lat><long>-818327636</long></Position3D-addGrpCarma></routeDestinationPoints></BasicSafetyMessage-addGrpCarma></regExtValue></Reg-BasicSafetyMessage></regional></BasicSafetyMessage>
```
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/517
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Freight integration testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
