### PR TITLE
Active ERV status update

### DIFF
--- a/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingWorker.cpp
+++ b/src/v2i-hub/ERVCloudForwardingPlugin/src/ERVCloudForwardingWorker.cpp
@@ -20,9 +20,9 @@ namespace ERVCloudForwardingPlugin
             return xml_str;
         }
         std::stringstream route_ss;
-        //Add vehicle current position to the BSMRequest route point
+        // Add vehicle current position to the BSMRequest route point
         route_ss << "<point><latitude>" << bsmPtr->coreData.lat << "</latitude>"
-                     << "<longitude>" << bsmPtr->coreData.Long << "</longitude></point>";
+                 << "<longitude>" << bsmPtr->coreData.Long << "</longitude></point>";
         // If there is carma related regional extension value that contains the ERV route points, construct the BSM request with the points.
         auto bsmCarmaRegion = bsmPtr->regional->list.array[0]->regExtValue.choice.BasicSafetyMessage_addGrpCarma;
         for (int i = 0; i < bsmCarmaRegion.routeDestinationPoints->list.count; i++)
@@ -56,20 +56,12 @@ namespace ERVCloudForwardingPlugin
         else
         {
             // The ERV broadcast BSM that has the PartII content, and the specical vehicle extension within the PartII has the emergency response type.
-            if (bsm_ptr->partII->list.count > 0 && bsm_ptr->partII->list.array[0]->partII_Value.present == BSMpartIIExtension__partII_Value_PR_SpecialVehicleExtensions )
+            if (bsm_ptr->partII->list.count > 0 && bsm_ptr->partII->list.array[0]->partII_Value.present == BSMpartIIExtension__partII_Value_PR_SpecialVehicleExtensions)
             {
-                if(bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->responseType && *bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->responseType == ResponseType_emergency)
+                if (bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->responseType && *bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->responseType == ResponseType_emergency && bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->lightsUse == LightbarInUse_inUse && bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->sirenUse == SirenInUse_inUse)
                 {
                     return true;
                 }
-                if(bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->lightsUse == LightbarInUse_inUse)
-                {
-                    return true;
-                }    
-                if(bsm_ptr->partII->list.array[0]->partII_Value.choice.SpecialVehicleExtensions.vehicleAlerts->sirenUse == SirenInUse_inUse)
-                {
-                    return true;
-                }             
             }
             return false;
         }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The ERV should be considered activated when all three of these, emergency response type, sirens are active, and lights are active.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/517
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
ERV use case
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
NA
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
