### PR TITLE
Fix for development image throwing exception unknown source stoul

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,5 @@
 Dockerfile
 docker-compose.yml
 *.md
+**/build
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN ldconfig
 COPY --from=dependencies /usr/local/plugins/ /usr/local/plugins/
 COPY --from=dependencies /usr/local/lib/ /usr/local/lib/
 COPY --from=dependencies /usr/local/bin/ /usr/local/bin/
+COPY --from=dependencies /usr/lib/ /usr/lib/
+COPY --from=dependencies /usr/bin/ /usr/bin/
 COPY --from=dependencies /usr/local/share/ /usr/local/share/
 COPY --from=dependencies /var/www/plugins/ /var/www/plugins/
 COPY --from=dependencies /var/log/tmx/ /var/log/tmx/

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -13,7 +13,6 @@ DEPENDENCIES="build-essential \
     cmake \
     git \
     libboost-all-dev \
-    libcpprest-dev \
     libcurl4-openssl-dev \
     libev-dev \
     libgps-dev \

--- a/src/v2i-hub/CARMACloudPlugin/CMakeLists.txt
+++ b/src/v2i-hub/CARMACloudPlugin/CMakeLists.txt
@@ -30,7 +30,7 @@ BuildTmxPlugin ()
 
 TARGET_INCLUDE_DIRECTORIES ( ${PROJECT_NAME} PUBLIC ${XercesC_INCLUDE_DIRS} ${NETSNMP_INCLUDE_DIRS} ${Qt5Core_INCLUDE_DIRS} ${Qt5Network_INCLUDE_DIRS} ${CURL_INCLUDE_DIRS})
 
-TARGET_LINK_LIBRARIES ( ${PROJECT_NAME} PUBLIC tmxutils ${XercesC_LIBRARY} ${NETSNMP_LIBRARIES} ${QHttpEngine_LIBRARY}  ${Boost_SYSTEM_LIBRARY} ZLIB::ZLIB curl cpprest Qt5Widgets Qt5Core Qt5Network ssl crypto qhttpengine v2xhubWebAPI) 
+TARGET_LINK_LIBRARIES ( ${PROJECT_NAME} PUBLIC tmxutils ${XercesC_LIBRARY} ${NETSNMP_LIBRARIES} ${QHttpEngine_LIBRARY}  ${Boost_SYSTEM_LIBRARY} ZLIB::ZLIB curl Qt5Widgets Qt5Core Qt5Network ssl crypto qhttpengine v2xhubWebAPI) 
 
 
 link_directories(${CMAKE_PREFIX_PATH}/lib)

--- a/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
@@ -193,6 +193,7 @@ namespace CDASimAdapter{
 
     void CDASimConnection::forward_message( const std::string &msg, const std::shared_ptr<UdpClient> _client ) const {
         if ( !msg.empty() && _client) {
+            PLOG(logDEBUG) << "Sending UDP msg " << msg << " to host " << _client->GetAddress() << _client->GetPort() << "." << std::endl;
             int ret =_client->Send(msg);
             if ( ret < 0) {
                 throw UdpClientRuntimeError(("Failed to send message " + msg + " to " + _client->GetAddress() + 

--- a/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
@@ -201,6 +201,12 @@ namespace CDASimAdapter{
                             ":" + std::to_string(_client->GetPort()) + " with error code : " + std::to_string(errno)).c_str());
             }
         }
+        else if ( msg.empty() ) {
+            PLOG(logWARNING) << "Unable to send empty message to " << _client->GetAddress() << ":" << _client->GetPort() << "." << std::endl;
+        }
+        else {
+            PLOG(logWARNING) << "Unable to send message from uninitialized client." << std::endl;
+        }
     }
 
     void CDASimConnection::forward_v2x_message_to_simulation(const std::string &msg) const {

--- a/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
@@ -193,7 +193,8 @@ namespace CDASimAdapter{
 
     void CDASimConnection::forward_message( const std::string &msg, const std::shared_ptr<UdpClient> _client ) const {
         if ( !msg.empty() && _client) {
-            PLOG(logDEBUG) << "Sending UDP msg " << msg << " to host " << _client->GetAddress() << _client->GetPort() << "." << std::endl;
+            PLOG(logDEBUG) << "Sending UDP msg " << msg << " to host " << _client->GetAddress() 
+                << ":" << _client->GetPort() << "." << std::endl;
             int ret =_client->Send(msg);
             if ( ret < 0) {
                 throw UdpClientRuntimeError(("Failed to send message " + msg + " to " + _client->GetAddress() + 

--- a/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
@@ -47,6 +47,18 @@ namespace CDASimAdapter {
         connection->forward_message(test_message, client);
     }
 
+    TEST_F( TestCARMASimulationConnection, forward_message_invalid ) {
+        std::shared_ptr<MockUpdClient> client = std::make_shared<MockUpdClient>();
+        std::string test_message = "";
+        // ASSERT that we never call Send message.
+        EXPECT_CALL( *client, Send(test_message) ).Times(0);
+        // sent empty message
+        connection->forward_message(test_message,client);
+        test_message = "message";
+        client = nullptr;
+        connection->forward_message(test_message, client);
+    } 
+
     TEST_F( TestCARMASimulationConnection, consume_msg){
 
         std::shared_ptr<MockUpdServer> server = std::make_shared<MockUpdServer>();


### PR DESCRIPTION
+ Added /usr/lib and /usr/bin to deployed image
+ Adding log statement for handshake
+ Removing cpprest library dependency which is unused

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

## Related Issue
#525 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Fix CDASimAdapterPlugin functionality in development image
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally integration tested using steps in the related issue.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
