### PR TITLE
Fix infrastructure sim message string

### DIFF
--- a/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
@@ -108,6 +108,7 @@ namespace CDASimAdapter{
             return false;
         }
         catch (const std::invalid_argument &e ) {
+            // std::stoul throws invalid arguement exception when provided with a string that contains characters that are not numbers.
             PLOG(logERROR) << "Exception occured attempting to initialize CDASim Connection : " << e.what() << 
                 ". Check environment variables are set to the correct type!";
             return;

--- a/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
@@ -106,6 +106,11 @@ namespace CDASimAdapter{
         catch (const TmxException &e) {
             PLOG(logERROR) << "Exception occured attempting to initialize CDASim Connection : " << e.what() << std::endl;
             return false;
+        }
+        catch (const std::invalid_argument &e ) {
+            PLOG(logERROR) << "Exception occured attempting to initialize CDASim Connection : " << e.what() << 
+                ". Check environment variables are set to the correct type!";
+            return;
         }   
         return connection->connect();
     }

--- a/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
@@ -111,7 +111,7 @@ namespace CDASimAdapter{
             // std::stoul throws invalid arguement exception when provided with a string that contains characters that are not numbers.
             PLOG(logERROR) << "Exception occured attempting to initialize CDASim Connection : " << e.what() << 
                 ". Check environment variables are set to the correct type!";
-            return;
+            return false;
         }   
         return connection->connect();
     }

--- a/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
@@ -86,7 +86,7 @@ namespace CDASimAdapter{
             uint time_sync_port = std::stoul(sim::get_sim_config(sim::TIME_SYNC_PORT));
             uint v2x_port = std::stoul(sim::get_sim_config(sim::V2X_PORT));
             uint sim_v2x_port = std::stoul(sim::get_sim_config(sim::SIM_V2X_PORT));
-            uint infrastructure_id = std::stoul(sim::get_sim_config(sim::INFRASTRUCTURE_ID));;
+            std::string infrastructure_id = sim::get_sim_config(sim::INFRASTRUCTURE_ID);
 
             PLOG(logINFO) << "CDASim connecting " << simulation_ip << 
                     "\nUsing Registration Port : "  << std::to_string( simulation_registration_port) <<

--- a/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
@@ -4,7 +4,7 @@
 using namespace tmx::utils;
 
 namespace CDASimAdapter{ 
-    CDASimConnection::CDASimConnection(const std::string &simulation_ip, const uint infrastructure_id, const uint simulation_registration_port, const uint sim_v2x_port,
+    CDASimConnection::CDASimConnection(const std::string &simulation_ip, const std::string infrastructure_id, const uint simulation_registration_port, const uint sim_v2x_port,
                                                         const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
                                                         const WGS84Point &location) : 
                                                         _simulation_ip(simulation_ip), _infrastructure_id(infrastructure_id), _simulation_registration_port(simulation_registration_port),
@@ -33,7 +33,7 @@ namespace CDASimAdapter{
         return _connected;
     }
 
-    std::string CDASimConnection::get_handshake_json(const uint infrastructure_id, const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
+    std::string CDASimConnection::get_handshake_json(const std::string infrastructure_id, const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
                                 const WGS84Point &location) const
 
     {
@@ -52,7 +52,7 @@ namespace CDASimAdapter{
         return message_str;
     }
 
-    bool CDASimConnection::carma_simulation_handshake(const std::string &simulation_ip, const uint infrastructure_id, const uint simulation_registration_port, 
+    bool CDASimConnection::carma_simulation_handshake(const std::string &simulation_ip, const std::string infrastructure_id, const uint simulation_registration_port, 
                                 const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
                                 const WGS84Point &location) 
     {

--- a/src/v2i-hub/CDASimAdapter/src/include/CDASimConnection.hpp
+++ b/src/v2i-hub/CDASimAdapter/src/include/CDASimConnection.hpp
@@ -32,7 +32,7 @@ namespace CDASimAdapter {
              * @param location Simulationed location of infrastructure.
              * @param producer Kafka Producer for forwarding time synchronization messages.
              */
-            explicit CDASimConnection( const std::string &simulation_ip, const uint infrastructure_id, const uint simulation_registration_port, 
+            explicit CDASimConnection( const std::string &simulation_ip, const std::string infrastructure_id, const uint simulation_registration_port, 
                                 const uint sim_v2x_port, const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
                                 const tmx::utils::WGS84Point &location);
 
@@ -95,7 +95,7 @@ namespace CDASimAdapter {
              * @param location simulated location of infrastructure hardware.
              * @return true if handshake successful and false if handshake unsuccessful.
              */
-            bool carma_simulation_handshake(const std::string &simulation_ip, const uint infrastructure_id, const uint simulation_registration_port,
+            bool carma_simulation_handshake(const std::string &simulation_ip, const std::string infrastructure_id, const uint simulation_registration_port,
                                 const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
                                 const tmx::utils::WGS84Point &location);
             
@@ -131,12 +131,12 @@ namespace CDASimAdapter {
              * @param location simulated location of infrastructure hardware.
              * @return true if handshake successful and false if handshake unsuccessful.
              */
-            std::string get_handshake_json(const uint infrastructure_id, const std::string &local_ip,  const uint time_sync_port, 
+            std::string get_handshake_json(const std::string infrastructure_id, const std::string &local_ip,  const uint time_sync_port, 
                 const uint v2x_port, const tmx::utils::WGS84Point &location) const; 
             
             std::string _simulation_ip;
             uint _simulation_registration_port;
-            uint _infrastructure_id;
+            std::string _infrastructure_id;
             uint _simulation_v2x_port;
             std::string _local_ip;
             uint _time_sync_port;

--- a/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
@@ -88,7 +88,7 @@ namespace CDASimAdapter {
         location.Latitude = 38.955; 
         location.Longitude = -77.149;
         ASSERT_EQ(connection->get_handshake_json("4566", "127.0.0.1", 4567, 4568, location), 
-        "{\n   \"infrastructureId\" : 4566,\n   \"location\" : {\n      \"elevation\" : 1000.0,\n      \"latitude\" : 38.954999999999998,\n      \"longitude\" : -77.149000000000001\n   },\n   \"rxMessageIpAddress\" : \"127.0.0.1\",\n   \"rxMessagePort\" : 4568,\n   \"timeSyncPort\" : 4567\n}\n");
+        "{\n   \"infrastructureId\" : \"4566\",\n   \"location\" : {\n      \"elevation\" : 1000.0,\n      \"latitude\" : 38.954999999999998,\n      \"longitude\" : -77.149000000000001\n   },\n   \"rxMessageIpAddress\" : \"127.0.0.1\",\n   \"rxMessagePort\" : 4568,\n   \"timeSyncPort\" : 4567\n}\n");
     }
 
     TEST_F( TestCARMASimulationConnection, carma_simulation_handshake) {

--- a/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
@@ -24,7 +24,7 @@ namespace CDASimAdapter {
             void SetUp() override {
                 // Initialize CARMA Simulation connection with (0,0,0) location and mock kafka producer.
                 WGS84Point location; 
-                connection = std::make_shared<CDASimConnection>("127.0.0.1", 1212, 4567, 4678, "127.0.0.1", 1213, 1214, location);
+                connection = std::make_shared<CDASimConnection>("127.0.0.1", "1212", 4567, 4678, "127.0.0.1", 1213, 1214, location);
 
             }
             void TearDown() override {
@@ -87,15 +87,14 @@ namespace CDASimAdapter {
         location.Elevation = 1000;
         location.Latitude = 38.955; 
         location.Longitude = -77.149;
-
-        ASSERT_EQ(connection->get_handshake_json(4566, "127.0.0.1", 4567, 4568, location), 
+        ASSERT_EQ(connection->get_handshake_json("4566", "127.0.0.1", 4567, 4568, location), 
         "{\n   \"infrastructureId\" : 4566,\n   \"location\" : {\n      \"elevation\" : 1000.0,\n      \"latitude\" : 38.954999999999998,\n      \"longitude\" : -77.149000000000001\n   },\n   \"rxMessageIpAddress\" : \"127.0.0.1\",\n   \"rxMessagePort\" : 4568,\n   \"timeSyncPort\" : 4567\n}\n");
     }
 
     TEST_F( TestCARMASimulationConnection, carma_simulation_handshake) {
         WGS84Point location;
         // UDP creation error
-        ASSERT_FALSE(connection->carma_simulation_handshake("", 45, NULL, 
+        ASSERT_FALSE(connection->carma_simulation_handshake("", "45", NULL, 
                                 "",  45, 45, location));
     }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
V2X-Hub CDASimAdapter would throw stoul invalid argument exceptions when attempting to set a string for the INFRASTRUCTURE_ID. This id needs to support string since NS-3/Mosiac rsu registration needs the rsu registration id to match the following format `rsu_<id_number>`. This fixed the internal infrastructure id field to be string as well as removing the stoul casting of a string to a long to remove this exception.
## Related Issue
#525
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
See description
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in AWS XIL Cloud deployment and on ubuntu v2xhub deployment.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-  x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
