### PR TITLE
Added Point class and used as cartesian point for

### DIFF
--- a/src/tmx/TmxUtils/src/Point.h
+++ b/src/tmx/TmxUtils/src/Point.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace tmx::utils {
+
+
+    /// Cartesian Coordinates on a .
+    typedef struct Point
+    {
+        Point() : X(0), Y(0), Z(0) {}
+
+        Point(double x, double y, double z = 0.0):
+            X(x), Y(y), Z(z) { }
+
+        double X;
+        double Y;
+        double Z;
+    } Point;
+
+} // namespace tmx::utils

--- a/src/v2i-hub/CDASimAdapter/manifest.json
+++ b/src/v2i-hub/CDASimAdapter/manifest.json
@@ -14,19 +14,19 @@
             "description":"The log level for this plugin"
         },
 		{
-			"key":"Longitude",
+			"key":"X",
 			"default":"0.0",
-			"description":"Longitude (in degrees) of the location of the simulated infrastructure."
+			"description":"Cartesian X coordinate in simulated map (in meters)."
 		},
 		{
-			"key":"Latitude",
+			"key":"Y",
 			"default":"0.0",
-			"description":"Latitude (in degrees) of the location of the simulated infrastructure."
+			"description":"Cartesian Y coordinate in simulated map (in meters)."
 		},
 		{
-			"key":"Elevation",
+			"key":"Z",
 			"default":"0.0",
-			"description":"Elevation (in degrees) of the location of the simulated infrastructure."
+			"description":"Cartesian Z coordinate in simulated map (in meters)."
 		}
 		
 	]

--- a/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
@@ -13,11 +13,11 @@ namespace CDASimAdapter{
     }
 
     void CDASimAdapter::UpdateConfigSettings() {
-        GetConfigValue<double>("Longitude", location.Longitude);
-        GetConfigValue<double>("Latitude", location.Latitude);
-        GetConfigValue<double>("Elevation", location.Elevation);
-        PLOG(logINFO) << "Location of Simulated V2X-Hub updated to : {" << location.Longitude << ", " 
-            << location.Latitude << ", " << location.Elevation << "}." << std::endl;
+        GetConfigValue<double>("X", location.Z);
+        GetConfigValue<double>("Y", location.Y);
+        GetConfigValue<double>("Z", location.X);
+        PLOG(logINFO) << "Location of Simulated V2X-Hub updated to : {" << location.X << ", " 
+            << location.Y << ", " << location.Z << "}." << std::endl;
     }
 
     void CDASimAdapter::OnConfigChanged(const char *key, const char *value) {

--- a/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimConnection.cpp
@@ -6,7 +6,7 @@ using namespace tmx::utils;
 namespace CDASimAdapter{ 
     CDASimConnection::CDASimConnection(const std::string &simulation_ip, const uint infrastructure_id, const uint simulation_registration_port, const uint sim_v2x_port,
                                                         const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
-                                                        const WGS84Point &location) : 
+                                                        const Point &location) : 
                                                         _simulation_ip(simulation_ip), _infrastructure_id(infrastructure_id), _simulation_registration_port(simulation_registration_port),
                                                         _simulation_v2x_port(sim_v2x_port), _local_ip(local_ip), _time_sync_port(time_sync_port), _v2x_port(v2x_port),
                                                         _location(location)  {
@@ -34,7 +34,7 @@ namespace CDASimAdapter{
     }
 
     std::string CDASimConnection::get_handshake_json(const uint infrastructure_id, const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
-                                const WGS84Point &location) const
+                                const Point &location) const
 
     {
         Json::Value message;   
@@ -44,9 +44,9 @@ namespace CDASimAdapter{
         message["infrastructureId"] = infrastructure_id;
         message["rxMessagePort"] = v2x_port;
         message["timeSyncPort"] = time_sync_port;
-        message["location"]["latitude"] = location.Latitude;
-        message["location"]["longitude"] = location.Longitude;
-        message["location"]["elevation"] = location.Elevation;
+        message["location"]["x"] = location.X;
+        message["location"]["y"] = location.Y;
+        message["location"]["z"] = location.Z;
         Json::StyledWriter writer;
         message_str = writer.write(message);
         return message_str;
@@ -54,7 +54,7 @@ namespace CDASimAdapter{
 
     bool CDASimConnection::carma_simulation_handshake(const std::string &simulation_ip, const uint infrastructure_id, const uint simulation_registration_port, 
                                 const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
-                                const WGS84Point &location) 
+                                const Point &location) 
     {
         // Create JSON message with the content 
         std::string payload = "";

--- a/src/v2i-hub/CDASimAdapter/src/include/CDASimAdapter.hpp
+++ b/src/v2i-hub/CDASimAdapter/src/include/CDASimAdapter.hpp
@@ -110,7 +110,7 @@ namespace CDASimAdapter {
         
     private:
 
-        tmx::utils::WGS84Point location;
+        tmx::utils::Point location;
         std::shared_ptr<tmx::utils::kafka_producer_worker> time_producer;
         std::unique_ptr<CDASimConnection> connection;
         std::mutex _lock;

--- a/src/v2i-hub/CDASimAdapter/src/include/CDASimConnection.hpp
+++ b/src/v2i-hub/CDASimAdapter/src/include/CDASimConnection.hpp
@@ -2,7 +2,7 @@
 #include <UdpServer.h>
 #include <UdpClient.h>
 #include <tmx/tmx.h>
-#include <WGS84Point.h>
+#include <Point.h>
 #include <TimeSyncMessage.h>
 #include <jsoncpp/json/json.h>
 #include <PluginLog.h>
@@ -34,7 +34,7 @@ namespace CDASimAdapter {
              */
             explicit CDASimConnection( const std::string &simulation_ip, const uint infrastructure_id, const uint simulation_registration_port, 
                                 const uint sim_v2x_port, const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
-                                const tmx::utils::WGS84Point &location);
+                                const tmx::utils::Point &location);
 
              /**
              * @brief Method to forward v2x message to CARMA Simulation
@@ -97,7 +97,7 @@ namespace CDASimAdapter {
              */
             bool carma_simulation_handshake(const std::string &simulation_ip, const uint infrastructure_id, const uint simulation_registration_port,
                                 const std::string &local_ip,  const uint time_sync_port, const uint v2x_port, 
-                                const tmx::utils::WGS84Point &location);
+                                const tmx::utils::Point &location);
             
             /**
              * @brief Method to setup UDP Servers and Clients after handshake to facilate message forwarding.
@@ -132,7 +132,7 @@ namespace CDASimAdapter {
              * @return true if handshake successful and false if handshake unsuccessful.
              */
             std::string get_handshake_json(const uint infrastructure_id, const std::string &local_ip,  const uint time_sync_port, 
-                const uint v2x_port, const tmx::utils::WGS84Point &location) const; 
+                const uint v2x_port, const tmx::utils::Point &location) const; 
             
             std::string _simulation_ip;
             uint _simulation_registration_port;
@@ -141,7 +141,7 @@ namespace CDASimAdapter {
             std::string _local_ip;
             uint _time_sync_port;
             uint _v2x_port;
-            tmx::utils::WGS84Point _location;
+            tmx::utils::Point _location;
             bool _connected = false;
 
             std::shared_ptr<tmx::utils::UdpServer> carma_simulation_listener;

--- a/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
@@ -23,7 +23,7 @@ namespace CDASimAdapter {
         protected:
             void SetUp() override {
                 // Initialize CARMA Simulation connection with (0,0,0) location and mock kafka producer.
-                WGS84Point location; 
+                Point location; 
                 connection = std::make_shared<CDASimConnection>("127.0.0.1", 1212, 4567, 4678, "127.0.0.1", 1213, 1214, location);
 
             }
@@ -83,17 +83,17 @@ namespace CDASimAdapter {
     }
 
     TEST_F( TestCARMASimulationConnection, get_handshake_json) {
-        WGS84Point location;
-        location.Elevation = 1000;
-        location.Latitude = 38.955; 
-        location.Longitude = -77.149;
+        Point location;
+        location.X = 1000;
+        location.Y = 38.955; 
+        location.Z = -77.149;
 
         ASSERT_EQ(connection->get_handshake_json(4566, "127.0.0.1", 4567, 4568, location), 
         "{\n   \"infrastructureId\" : 4566,\n   \"location\" : {\n      \"elevation\" : 1000.0,\n      \"latitude\" : 38.954999999999998,\n      \"longitude\" : -77.149000000000001\n   },\n   \"rxMessageIpAddress\" : \"127.0.0.1\",\n   \"rxMessagePort\" : 4568,\n   \"timeSyncPort\" : 4567\n}\n");
     }
 
     TEST_F( TestCARMASimulationConnection, carma_simulation_handshake) {
-        WGS84Point location;
+        Point location;
         // UDP creation error
         ASSERT_FALSE(connection->carma_simulation_handshake("", 45, NULL, 
                                 "",  45, 45, location));

--- a/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
+++ b/src/v2i-hub/CDASimAdapter/test/TestCARMASimulationConnection.cpp
@@ -89,7 +89,7 @@ namespace CDASimAdapter {
         location.Z = -77.149;
 
         ASSERT_EQ(connection->get_handshake_json(4566, "127.0.0.1", 4567, 4568, location), 
-        "{\n   \"infrastructureId\" : 4566,\n   \"location\" : {\n      \"elevation\" : 1000.0,\n      \"latitude\" : 38.954999999999998,\n      \"longitude\" : -77.149000000000001\n   },\n   \"rxMessageIpAddress\" : \"127.0.0.1\",\n   \"rxMessagePort\" : 4568,\n   \"timeSyncPort\" : 4567\n}\n");
+        "{\n   \"infrastructureId\" : 4566,\n   \"location\" : {\n      \"x\" : 1000.0,\n      \"y\" : 38.954999999999998,\n      \"z\" : -77.149000000000001\n   },\n   \"rxMessageIpAddress\" : \"127.0.0.1\",\n   \"rxMessagePort\" : 4568,\n   \"timeSyncPort\" : 4567\n}\n");
     }
 
     TEST_F( TestCARMASimulationConnection, carma_simulation_handshake) {


### PR DESCRIPTION
CDASim Infrastructure registration

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Updated infrastructure registration to use a cartesian point as location over a geodetic point to allow for easier configuration of simulated location of rsu
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested using dev-container
1) Started up dev container with SIMULATION_MODE true
2) Saw log message for sending Infrastructure Registration Message
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
