### PR TITLE
Fix: Added sleep between connection attempts to avoid excessive failu…

### DIFF
--- a/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
@@ -33,9 +33,11 @@ namespace CDASimAdapter{
            
             // While CARMA Simulation connection is down, attempt to reconnect
             while ( !connection || !connection->is_connected() ) {
-                connect();
+                bool success = connect();
                 // Sleep for 2 seconds in between connection attempts
-                sleep(2);
+                if ( !connection->is_connected() ) {
+                    sleep(2);
+                }
             }
 
             if ( connection->is_connected() ) {

--- a/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
@@ -34,6 +34,8 @@ namespace CDASimAdapter{
             // While CARMA Simulation connection is down, attempt to reconnect
             while ( !connection || !connection->is_connected() ) {
                 connect();
+                // Sleep for 2 seconds in between connection attempts
+                sleep(2);
             }
 
             if ( connection->is_connected() ) {


### PR DESCRIPTION
…res and logs

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fix for CDASimAdapter Plugin which was excessively logging connection failures and CDASim crashes. Added a sleep period inbetween connection attempts
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Avoid excessive failed connection attempts and resulting excessive failed connection logs.
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In progress
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
