### PR TITLE
Fixed X and Z coordinate configuration loading

### DIFF
--- a/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
+++ b/src/v2i-hub/CDASimAdapter/src/CDASimAdapter.cpp
@@ -13,9 +13,9 @@ namespace CDASimAdapter{
     }
 
     void CDASimAdapter::UpdateConfigSettings() {
-        GetConfigValue<double>("X", location.Z);
+        GetConfigValue<double>("X", location.X);
         GetConfigValue<double>("Y", location.Y);
-        GetConfigValue<double>("Z", location.X);
+        GetConfigValue<double>("Z", location.Z);
         PLOG(logINFO) << "Location of Simulated V2X-Hub updated to : {" << location.X << ", " 
             << location.Y << ", " << location.Z << "}." << std::endl;
     }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fix configuration parameters to correctly map x,y,z coordinates to Point for Infrastructure registration.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix configuration parameters to correctly map x,y,z coordinates to Point for Infrastructure registration.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
