### PR TITLE
Routable metadata

### DIFF
--- a/ext/build.sh
+++ b/ext/build.sh
@@ -3,6 +3,9 @@
 # exit on errors
 set -e
 
+# Find number of cores available
+numCPU=$(nproc)
+
 # An OPENAPI based Qt webservice is needed by the plugins for http requests processing. A custom generated code using OPENAPI framework is located in GitHub.
 pushd /tmp
 QHTTPENGINE_VERSION=1.0.1
@@ -10,7 +13,7 @@ wget -O qhttpengine-${QHTTPENGINE_VERSION}.tar.gz https://github.com/nitroshare/
 tar xvf qhttpengine-${QHTTPENGINE_VERSION}.tar.gz
 cd qhttpengine-${QHTTPENGINE_VERSION}/
 cmake .
-make 
+make -j${numCPU}
 make install
 popd
 
@@ -20,7 +23,7 @@ wget -O date-${DATELIB_VERSION}.tar.gz https://github.com/HowardHinnant/date/arc
 tar xvf date-${DATELIB_VERSION}.tar.gz
 cd date-${DATELIB_VERSION}/
 cmake .
-make
+make -j${numCPU}
 make install
 popd
 
@@ -29,19 +32,19 @@ ldconfig
 # Server for the Qt webservice
 pushd server
 cmake .
-make
+make -j${numCPU}
 make install
 popd
 
 pushd ccserver
 cmake . 
-make
+make -j${numCPU}
 make install
 popd
 
 pushd pdclient
 cmake .
-make
+make -j${numCPU}
 make install
 popd
 
@@ -50,6 +53,6 @@ pushd /tmp
 git clone https://github.com/ckgt/NemaTode.git
 cd NemaTode
 cmake .
-make
+make -j${numCPU}
 make install
 popd

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -41,9 +41,12 @@ LIBRARY_DEPENDENCIES=" \
 # install all things needed for deployment, always done
 apt-get install -y $DEPENDENCIES ${LIBRARY_DEPENDENCIES}
 
+numCPU=$(nproc)
+
 # install gtest
 cd /usr/src/googletest/
 mkdir -p build/
 cd build
 cmake ..
+make -j${numCPU}
 make install

--- a/src/build.sh
+++ b/src/build.sh
@@ -18,6 +18,8 @@ set -e
 # script executes all tmx and v2i build and coverage steps so that they can be singularly
 # wrapped by the sonarcloud build-wrapper
 
+numCPU=$(nproc)
+
 RELEASE_BUILD=0
 if [ "$1" = "release" ]; then
     RELEASE_BUILD=1
@@ -36,7 +38,7 @@ fi
 pushd tmx
 cmake -Bbuild -DCMAKE_PREFIX_PATH=\"/usr/local/share/tmx\;\/opt/carma/cmake\;\" -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_C_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .
 pushd build
-make
+make -j${numCPU}
 make install
 popd
 popd
@@ -44,6 +46,7 @@ popd
 pushd v2i-hub
 cmake -Bbuild  -DCMAKE_PREFIX_PATH=\"/usr/local/share/tmx\;\/opt/carma/cmake\;\" -DqserverPedestrian_DIR=/usr/local/share/qserverPedestrian/cmake -Dv2xhubWebAPI_DIR=/usr/local/share/v2xhubWebAPI/cmake/ -DCMAKE_CXX_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_C_FLAGS="${COVERAGE_FLAGS}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .
 pushd build
+make -j${numCPU}
 make install
 popd
 popd

--- a/src/tmx/TmxApi/tmx/IvpMessage.h
+++ b/src/tmx/TmxApi/tmx/IvpMessage.h
@@ -20,8 +20,8 @@ typedef unsigned int IvpMsgFlags;
 #define IvpMsgFlags_RouteDSRC 0x01
 
 typedef struct IvpDsrcMetadata {
-	int channel;
 	int psid;
+	int channel;
 } IvpDsrcMetadata;
 
 typedef struct IvpMessage {
@@ -64,7 +64,7 @@ typedef enum {
  */
 IvpMessage *ivpMsg_create(const char *type, const char *subtype, const char *encoding, IvpMsgFlags flags, cJSON *payload);
 
-IvpMessage *ivpMsg_addDsrcMetadata(IvpMessage *msg, int channel, int psid);
+IvpMessage *ivpMsg_addDsrcMetadata(IvpMessage *msg, int psid, int channel);
 
 /*!
  * Creates a new IvpMessage from a json string.

--- a/src/tmx/TmxApi/tmx/TmxApiMessages.h
+++ b/src/tmx/TmxApi/tmx/TmxApiMessages.h
@@ -177,7 +177,56 @@ static CONSTEXPR const char *STATUS_STARTED_STRING = "Started, waiting for conne
 static CONSTEXPR const char *STATUS_RUNNING_STRING = "Running";
 static CONSTEXPR const char *STATUS_STALE_STRING = "Connection going stale";
 static CONSTEXPR const char *STATUS_STOPPED_STRING = "Stopped / Disconnected";
-			
+
+enum msgPSID
+{
+	None_PSID = 0x00,
+	mapData_PSID = 0x8002,
+	signalPhaseAndTimingMessage_PSID = 0x8002,
+	basicSafetyMessage_PSID = 0x20,
+	commonSafetyRequest_PSID = 0x20,
+	emergencyVehicleAlert_PSID = 0x8005,
+	intersectionCollision_PSID = 0x8002,
+	nmeaCorrections_PSID = 0x8000,
+	probeDataManagement_PSID = 0x8004,
+	probeVehicleData_PSID = 0x8004,
+	roadSideAlert_PSID = 0x8003,
+	rtcmCorrections_PSID = 0x8000,
+	signalRequestMessage_PSID = 0xE0000016,
+	signalStatusMessage_PSID = 0x8002,
+	travelerInformation_PSID = 0x8003,
+	personalSafetyMessage_PSID = 0x27,
+	testMessage00_PSID = 0xBFEE,
+	testMessage01_PSID = 0xBFEE,
+	testMessage02_PSID = 0xBFEE,
+	testMessage03_PSID = 0xBFEE,
+	testMessage04_PSID = 0x8003,
+	testMessage05_PSID = 0x8003
+};
+
+static CONSTEXPR const char *MSGPSID_NONE_PSID_STRING = "None";
+static CONSTEXPR const char *MSGPSID_MAPDATA_PSID_STRING = "0x8002";
+static CONSTEXPR const char *MSGPSID_SIGNALPHASEANDTIMINGMESSAGE_PSID_STRING = "0x8002";
+static CONSTEXPR const char *MSGPSID_BASICSAFETYMESSAGE_PSID_STRING = "0x20";
+static CONSTEXPR const char *MSGPSID_COMMONSAFETYREQUEST_PSID_STRING = "0x20";
+static CONSTEXPR const char *MSGPSID_EMERGENCYVEHICLEALERT_PSID_STRING = "0x8005";
+static CONSTEXPR const char *MSGPSID_INTERSECTIONCOLLISION_PSID_STRING = "0x8002";
+static CONSTEXPR const char *MSGPSID_NMEACORRECTIONS_PSID_STRING = "0x8000";
+static CONSTEXPR const char *MSGPSID_PROBEDATAMANAGEMENT_PSID_STRING = "0x8004";
+static CONSTEXPR const char *MSGPSID_PROBEVEHICLEDATA_PSID_STRING = "0x8004";
+static CONSTEXPR const char *MSGPSID_ROADSIDEALERT_PSID_STRING = "0x8003";
+static CONSTEXPR const char *MSGPSID_RTCMCORRECTIONS_PSID_STRING = "0x8000";
+static CONSTEXPR const char *MSGPSID_SIGNALREQUESTMESSAGE_PSID_STRING = "0xE0000016";
+static CONSTEXPR const char *MSGPSID_SIGNALSTATUSMESSAGE_PSID_STRING = "0x8002";
+static CONSTEXPR const char *MSGPSID_TRAVELERINFORMATION_PSID_STRING = "0x8003";
+static CONSTEXPR const char *MSGPSID_PERSONALSAFETYMESSAGE_PSID_STRING = "0x27";
+static CONSTEXPR const char *MSGPSID_TESTMESSAGE00_PSID_STRING = "0xBFEE";
+static CONSTEXPR const char *MSGPSID_TESTMESSAGE01_PSID_STRING = "0xBFEE";
+static CONSTEXPR const char *MSGPSID_TESTMESSAGE02_PSID_STRING = "0xBFEE";
+static CONSTEXPR const char *MSGPSID_TESTMESSAGE03_PSID_STRING = "0xBFEE";
+static CONSTEXPR const char *MSGPSID_TESTMESSAGE04_PSID_STRING = "0x8003";
+static CONSTEXPR const char *MSGPSID_TESTMESSAGE05_PSID_STRING = "0x8003";
+
 } /* End namespace api */
 		
 } /* End namespace messages */

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -428,7 +428,7 @@ void ImmediateForwardPlugin::SendMessageToRadio(IvpMessage *msg)
 	if (!foundMessageType)
 	{
 		SetStatus<uint>(Key_SkippedNoMessageRoute, ++_skippedNoMessageRoute);
-		PLOG(logWARNING)<<" WARNINNG TMX Subtype not found in configuration.  Message Ignored: " <<
+		PLOG(logWARNING)<<" WARNING TMX Subtype not found in configuration. Message Ignored: " <<
 				"Type: " << msg->type << ", Subtype: " << msg->subtype;
 		return;
 	}

--- a/src/v2i-hub/MessageReceiverPlugin/manifest.json
+++ b/src/v2i-hub/MessageReceiverPlugin/manifest.json
@@ -29,9 +29,9 @@
 			"description":"Port for the incoming message network connection."
 		},
 		{
-			"key":"RouteDSRC",
+			"key":"RouteMessage",
 			"default":"false",
-			"description":"Set the flag to route a received J2735 message."
+			"description":"Set the flag to route/broadcast a received J2735 message to TMX Core."
 		},
 		{
 			"key":"EnableSimulatedBSM",

--- a/src/v2i-hub/MessageReceiverPlugin/manifest.json
+++ b/src/v2i-hub/MessageReceiverPlugin/manifest.json
@@ -29,7 +29,7 @@
 			"description":"Port for the incoming message network connection."
 		},
 		{
-			"key":"RouteMessage",
+			"key":"RouteJ2735",
 			"default":"false",
 			"description":"Set the flag to route/broadcast a received J2735 message to TMX Core."
 		},

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -166,7 +166,7 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 	BsmEncodedMessage encodedBsm;
 	SrmEncodedMessage encodedSrm;
 
-	uint16_t msgPSID = NULL;
+	char msgPSID;
 
 	if (msg.get_type() == "Unknown" && msg.get_subtype() == "Unknown")
 	{
@@ -263,7 +263,7 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 								}
 
 								sendMsg = encode(encodedBsm, bsm);
-								msgPSID = 0x20;
+								msgPSID = api::msgPSID::basicSafetyMessage_PSID;
 								if (!simBSM) return;
 							}
 							break;
@@ -281,8 +281,7 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 										ntohl(*((uint32_t*)&(bytes.data()[24]))),
 										ntohl(*((uint32_t*)&(bytes.data()[28]))));
 								sendMsg = encode(encodedSrm, srm);
-								msgPSID = 0xE0000016;
-
+								msgPSID = api::msgPSID::signalRequestMessage_PSID;
 							}
 							break;
 						default:
@@ -348,7 +347,7 @@ void MessageReceiverPlugin::UpdateConfigSettings()
 	lock_guard<mutex> lock(syncLock);
 
 	// Atomic flags
-	GetConfigValue("RouteMessage", routeDsrc);
+	GetConfigValue("RouteJ2735", routeDsrc);
 	GetConfigValue("EnableSimulatedBSM", simBSM);
 	GetConfigValue("EnableSimulatedSRM", simSRM);
 	GetConfigValue("EnableSimulatedLocation", simLoc);
@@ -468,7 +467,6 @@ int MessageReceiverPlugin::Main()
 						SetStatus<uint>(Key_SkippedSignVerifyError, ++_skippedSignVerifyErrorResponse);
 						PLOG(logERROR) << "Error parsing Messages: " << ex.what();
 						continue;
-; 
 					}
 					PLOG(logDEBUG1) << "SCMS Contain response = " << result << std::endl;
 					cJSON *root   = cJSON_Parse(result.c_str());

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -166,7 +166,7 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 	BsmEncodedMessage encodedBsm;
 	SrmEncodedMessage encodedSrm;
 
-	char msgPSID;
+	int msgPSID = api::msgPSID::None_PSID;
 
 	if (msg.get_type() == "Unknown" && msg.get_subtype() == "Unknown")
 	{

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -348,7 +348,7 @@ void MessageReceiverPlugin::UpdateConfigSettings()
 	lock_guard<mutex> lock(syncLock);
 
 	// Atomic flags
-	GetConfigValue("RouteDSRC", routeDsrc);
+	GetConfigValue("RouteMessage", routeDsrc);
 	GetConfigValue("EnableSimulatedBSM", simBSM);
 	GetConfigValue("EnableSimulatedSRM", simSRM);
 	GetConfigValue("EnableSimulatedLocation", simLoc);

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -330,13 +330,14 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 		if (routeDsrc)
 		{	
 			sendMsg->set_flags(IvpMsgFlags_RouteDSRC);
+			this->OutgoingMessage(*sendMsg, true);
 		}
 		else
 		{
 			
 			sendMsg->set_flags(IvpMsgFlags_None);
+			this->OutgoingMessage(*sendMsg);
 		}
-		this->OutgoingMessage(*sendMsg);
 	}
 }
 

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -166,7 +166,7 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 	BsmEncodedMessage encodedBsm;
 	SrmEncodedMessage encodedSrm;
 
-
+	uint16_t msgPSID = NULL;
 
 	if (msg.get_type() == "Unknown" && msg.get_subtype() == "Unknown")
 	{
@@ -263,6 +263,7 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 								}
 
 								sendMsg = encode(encodedBsm, bsm);
+								msgPSID = 0x20;
 								if (!simBSM) return;
 							}
 							break;
@@ -280,6 +281,7 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 										ntohl(*((uint32_t*)&(bytes.data()[24]))),
 										ntohl(*((uint32_t*)&(bytes.data()[28]))));
 								sendMsg = encode(encodedSrm, srm);
+								msgPSID = 0xE0000016;
 
 							}
 							break;
@@ -330,14 +332,14 @@ void MessageReceiverPlugin::OnMessageReceived(routeable_message &msg)
 		if (routeDsrc)
 		{	
 			sendMsg->set_flags(IvpMsgFlags_RouteDSRC);
-			this->OutgoingMessage(*sendMsg, true);
+			sendMsg->addDsrcMetadata(msgPSID);
 		}
 		else
 		{
 			
 			sendMsg->set_flags(IvpMsgFlags_None);
-			this->OutgoingMessage(*sendMsg);
 		}
+		this->OutgoingMessage(*sendMsg);
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Adds PSID metadata to BSMs and SRMs that are sent to the Message Receiver plugin. If "RouteMessage" is enabled, the messages will be available for the Immediate Forward plugin to use. 

Additional changes were made to build process to speed up process.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Sent BSMs and SRMs to Message Receiver plugin. Messages were transmitted by Immediate Forward plugin when "RouteMessage" was enabled and not routed when disabled. Previously, messages were skipped or not routed, respectively. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
