### PR TITLE
Temporary fix for TimeSyncMessage invalid json serialization

### DIFF
--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -105,8 +105,17 @@ void CARMAStreetsPlugin::OnConfigChanged(const char *key, const char *value) {
 void CARMAStreetsPlugin::HandleTimeSyncMessage(tmx::messages::TimeSyncMessage &msg, routeable_message &routeableMsg ) {
 	PluginClientClockAware::HandleTimeSyncMessage(msg, routeableMsg);
 	if ( isSimulationMode()) {
-		PLOG(logINFO) << "Handling TimeSync messages!" << std::endl;
-		produce_kafka_msg(msg.to_string(), "time_sync");
+		// TODO: This is a temporary fix for tmx message container property tree
+		// serializing all attributes as strings. This issue needs to be fixed but
+		// is currently out of scope. TMX Messages should be correctly serialize to 
+		// and from json. This temporary fix simply using regex to look for numeric,
+		// null, and bool values and removes the quotations around them.
+		boost::regex exp("\"(null|true|false|[0-9]+(\\.[0-9]+)?)\"");
+		std::stringstream ss;
+		std::string rv = boost::regex_replace(msg.to_string(), exp, "$1");
+		PLOG(logINFO) << "Sending Time Sync Message " << rv << std::endl;
+
+		produce_kafka_msg(rv, "time_sync");
 	}
 }
 void CARMAStreetsPlugin::HandleMobilityOperationMessage(tsm3Message &msg, routeable_message &routeableMsg ) {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Temporary fix for TMX Message invalid JSON serialization (See Issue https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/561). Fix uses regex to filter out quotations from json string for attributes that are bool, numeric or null.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Maintain simulation time synchronization functionality of V2X-Hub/CARMA-Streets 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in local dev container environment.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
