### PR TITLE
Telematic bridge: Fix available topic return null value in topics field when there is no topic available

### DIFF
--- a/src/v2i-hub/TelematicBridgePlugin/src/TelematicUnit.cpp
+++ b/src/v2i-hub/TelematicBridgePlugin/src/TelematicUnit.cpp
@@ -219,7 +219,7 @@ namespace TelematicBridge
         message[TESTING_TYPE_KEY] = testingType;
         message[EVENT_NAME_KEY] = eventName;
         message[TIMESTAMP_KEY] = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
-        Json::Value topics;
+        Json::Value topics = Json::arrayValue;
         for (const auto &topic : availableTopicList)
         {
             if (!boost::icontains(excludedTopics, topic))

--- a/src/v2i-hub/TelematicBridgePlugin/test/test_TelematicUnit.cpp
+++ b/src/v2i-hub/TelematicBridgePlugin/test/test_TelematicUnit.cpp
@@ -43,6 +43,10 @@ namespace TelematicBridge
         auto reply = TelematicUnit::constructAvailableTopicsReplyString(unit, eventLocation, testingType, eventName, topics, excluded_topic);
         auto json = TelematicUnit::parseJson(reply);
         ASSERT_EQ("test_topic", json["topics"][0]["name"].asString());
+
+        reply = TelematicUnit::constructAvailableTopicsReplyString(unit, eventLocation, testingType, eventName, {}, excluded_topic);
+        json = TelematicUnit::parseJson(reply);
+        ASSERT_EQ(1, json["topics"].isArray());
     }
 
     TEST_F(test_TelematicUnit, constructPublishedDataString)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Telematic bridge sends null topics when there is no topic available. The idea value for this topics is empty array value [] rather than a null value. This PR is to initialize the topics value with empty array
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/570
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
telematic testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
