### PR TITLE
Fix/json serialization detected object

### DIFF
--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -706,8 +706,16 @@ void CARMAStreetsPlugin::SubscribeSDSMKafkaTopic(){
 
 void CARMAStreetsPlugin::HandleSimulatedSensorDetectedMessage(simulation::SensorDetectedObject &msg, routeable_message &routeableMsg)
 {
+	// TODO: This is a temporary fix for tmx message container property tree
+	// serializing all attributes as strings. This issue needs to be fixed but
+	// is currently out of scope. TMX Messages should be correctly serialize to 
+	// and from json. This temporary fix simply using regex to look for numeric,
+	// null, and bool values and removes the quotations around them.
 	PLOG(logDEBUG) <<  "Produce sensor detected message in JSON format:  " << msg.to_string() <<std::endl;
-	produce_kafka_msg( msg.to_string(), _transmitSimSensorDetectedObjTopic);
+	boost::regex exp("\"(null|true|false|[0-9]+(\\.[0-9]+)?)\"");
+	std::stringstream ss;
+	std::string rv = boost::regex_replace(msg.to_string(), exp, "$1");
+	produce_kafka_msg( rv, _transmitSimSensorDetectedObjTopic);
 }
 
 bool CARMAStreetsPlugin::getEncodedtsm3( tsm3EncodedMessage *tsm3EncodedMsg,  Json::Value metadata, Json::Value payload_json )

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -712,7 +712,7 @@ void CARMAStreetsPlugin::HandleSimulatedSensorDetectedMessage(simulation::Sensor
 	// and from json. This temporary fix simply using regex to look for numeric,
 	// null, and bool values and removes the quotations around them.
 	PLOG(logDEBUG) <<  "Produce sensor detected message in JSON format:  " << msg.to_string() <<std::endl;
-	boost::regex exp("\"(null|true|false|[0-9]+(\\.[0-9]+)?)\"");
+	boost::regex exp("\"(null|true|false|-?[0-9]+(\\.[0-9]+)?)\"");
 	std::stringstream ss;
 	std::string rv = boost::regex_replace(msg.to_string(), exp, "$1");
 	produce_kafka_msg( rv, _transmitSimSensorDetectedObjTopic);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Temporary fix for JSON serialization for TMX messages. See related issue for more detailed description of error behavior. Using simple regex replacement to correct bool, double and integer values
<!--- Describe your changes in detail -->

## Related Issue
#561 (https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/561)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix for VRU UC 1 testing of SDSM functionality
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration tested in CDASim deployment 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
