### PR TITLE
CARMACloudPlugin: Fix the issue to unzip the compressed TCMs

### DIFF
--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -240,6 +240,7 @@ void CARMACloudPlugin::CARMAResponseHandler(QHttpEngine::Socket *socket)
 	tcm=updateTags(tcm,"TrafficControlParams","params");
 	tcm=updateTags(tcm,"TrafficControlGeometry","geometry");
 	tcm=updateTags(tcm,"TrafficControlPackage","package");
+	PLOG(logDEBUG2) << "Received TCM: " << tcm << std::endl;
 
 	std::list<std::string> tcmSL = {};
 	if (isCompressed)

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -219,7 +219,7 @@ void CARMACloudPlugin::CARMAResponseHandler(QHttpEngine::Socket *socket)
 	}
 	PLOG(logINFO) << "Received TCM bytes size: " << st.size()<< std::endl;
 
-	string tcm = "";
+	std::string tcm = "";
 	bool isCompressed = socket->headers().keys().contains(CONTENT_ENCODING_KEY) && std::string(socket->headers().constFind(CONTENT_ENCODING_KEY).value().data()) == CONTENT_ENCODING_VALUE;
 	if (isCompressed)
 	{

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -205,30 +205,27 @@ string CARMACloudPlugin::updateTags(string str,string tagout, string tagin)
 
 void CARMACloudPlugin::CARMAResponseHandler(QHttpEngine::Socket *socket)
 {
-	QString st; 
+	QByteArray st; 
 	while(socket->bytesAvailable()>0)
 	{	
 		auto readBytes = socket->readAll();
-		if (socket->headers().keys().contains(CONTENT_ENCODING_KEY) && std::string(socket->headers().constFind(CONTENT_ENCODING_KEY).value().data()) == CONTENT_ENCODING_VALUE)
-        {
-			//readBytes is compressed in gzip format
-            st.append(UncompressBytes(readBytes));			
-        }else{
-			st.append(readBytes);
-		}
+		st.append(readBytes);
 	}
-	QByteArray array = st.toLocal8Bit();
 
-	char* _cloudUpdate = array.data(); // would be the cloud update packet, needs parsing
-	
-	
-	string tcm = _cloudUpdate;
-
-	PLOG(logINFO) << "Received TCM from cloud" << tcm << std::endl;
-	if(tcm.length() == 0)
+	if(st.size() == 0)
 	{
-		PLOG(logERROR) << "Received TCM length is zero, and skipped." << std::endl;
+		PLOG(logERROR) << "Received TCM is empty, and skipped." << std::endl;
 		return;
+	}
+	PLOG(logINFO) << "Received TCM bytes size: " << st.size()<< std::endl;
+
+	string tcm = "";
+	bool isCompressed = socket->headers().keys().contains(CONTENT_ENCODING_KEY) && std::string(socket->headers().constFind(CONTENT_ENCODING_KEY).value().data()) == CONTENT_ENCODING_VALUE;
+	if (isCompressed)
+	{
+		tcm = UncompressBytes(st).data();
+	}else{
+		tcm = st.data();		
 	}
 
 	//Transform carma-cloud TCM XML to J2735 compatible TCM XML by updating tags
@@ -237,16 +234,20 @@ void CARMACloudPlugin::CARMAResponseHandler(QHttpEngine::Socket *socket)
 	tcm=updateTags(tcm,"TrafficControlParams","params");
 	tcm=updateTags(tcm,"TrafficControlGeometry","geometry");
 	tcm=updateTags(tcm,"TrafficControlPackage","package");
-	
-	//List of tcm in string format
-	std::list<std::string> tcm_sl = FilterTCMs(tcm);	
+
+	std::list<std::string> tcm_sl = {};
+	if (isCompressed)
+	{
+		tcm_sl = FilterTCMs(tcm);
+	}else{
+		tcm_sl.push_back(tcm);
+	}
 
 	for(const auto tcm_s: tcm_sl)
 	{
 		tsm5Message tsm5message;
 		tsm5EncodedMessage tsm5ENC;
 		tmx::message_container_type container;
-
 
 		std::stringstream ss;
 		ss << tcm_s;
@@ -376,7 +377,7 @@ void CARMACloudPlugin::TCMAckCheckAndRebroadcastTCM()
 		}
 		else
 		{
-			PLOG(logDEBUG) << "NO TCMs to broadcast." << std::endl;
+			PLOG(logDEBUG4) << "NO TCMs to broadcast." << std::endl;
 			_tcm_broadcast_times->clear();
 			_tcm_broadcast_starting_time->clear();
 		}
@@ -604,13 +605,13 @@ void CARMACloudPlugin::ConvertString2Pair(std::pair<string,string> &str_pair, co
 QByteArray CARMACloudPlugin::UncompressBytes(const QByteArray compressedBytes) const
 {
     z_stream strm;
-	strm.zalloc = nullptr;//Refer to zlib docs (https://zlib.net/zlib_how.html)
-	strm.zfree = nullptr; 
-    strm.opaque = nullptr;
+	strm.zalloc = Z_NULL;//Refer to zlib docs (https://zlib.net/zlib_how.html)
+	strm.zfree = Z_NULL; 
+    strm.opaque = Z_NULL;
     strm.avail_in = compressedBytes.size();
-    strm.next_in = (Byte *)compressedBytes.data();
+	strm.next_in = (Byte *)compressedBytes.data();
 	//checking input z_stream to see if there is any error, eg: invalid data etc.
-    auto err = inflateInit2(&strm, MAX_WBITS + 16); // gzip input
+    auto err = inflateInit2(&strm, MAX_WBITS+32); // gzip input https://stackoverflow.com/questions/1838699/how-can-i-decompress-a-gzip-stream-with-zlib
     QByteArray outBuf;
 	//MAX numbers of bytes stored in a buffer 
     const int BUFFER_SIZE = 4092;
@@ -623,11 +624,10 @@ QByteArray CARMACloudPlugin::UncompressBytes(const QByteArray compressedBytes) c
             char buffer[BUFFER_SIZE] = {0};
             strm.avail_out = BUFFER_SIZE;
             strm.next_out = (Byte *)buffer;
-			//Uncompress finished
-            isDone = inflate(&strm, Z_FINISH);
-            outBuf.append(buffer);
-        } while (Z_STREAM_END != isDone); //Reach the end of stream to be uncompressed 
-    }else{
+            isDone = inflate(&strm, Z_NO_FLUSH);
+			outBuf.append(buffer, BUFFER_SIZE - strm.avail_out);
+		} while (Z_STREAM_END != isDone); // Reach the end of stream to be uncompressed
+	}else{
 		PLOG(logWARNING) << "Error initalize stream. Err code = " << err << std::endl;
 	}
 	//Finished decompress data stream

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -625,7 +625,7 @@ QByteArray CARMACloudPlugin::UncompressBytes(const QByteArray compressedBytes) c
             strm.avail_out = BUFFER_SIZE;
             strm.next_out = (Byte *)buffer;
             isDone = inflate(&strm, Z_NO_FLUSH);
-			outBuf.append(buffer, BUFFER_SIZE - strm.avail_out);
+            outBuf.append(buffer, BUFFER_SIZE - strm.avail_out);
 		} while (Z_STREAM_END != isDone); // Reach the end of stream to be uncompressed
 	}else{
 		PLOG(logWARNING) << "Error initalize stream. Err code = " << err << std::endl;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix issue with CARMACloudPlugin unzip the compressed TCM payload. The unzip function did not append the correct numbers of characters. Add 32 to WinBits to allow header detection. Remove toLocal8Bit() conversion as the xml is by default sent as utf-8 encoding.
<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
