### PR TITLE
Fix tcm intermittent reception

### DIFF
--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -464,9 +464,9 @@ int CARMACloudPlugin::StartWebService()
 	quint16 port = static_cast<quint16>(webport);
 
 	QHttpEngine::QObjectHandler apiHandler;
-	apiHandler.registerMethod(TCM_REPLY, [&](QHttpEngine::Socket *socket)
+	apiHandler.registerMethod(TCM_REPLY, [this](QHttpEngine::Socket *socket)
 							  { 
-							CARMAResponseHandler(socket);
+							this->CARMAResponseHandler(socket);
 							socket->close(); });
 	QHttpEngine::Server server(&apiHandler);
 

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -100,6 +100,7 @@ public:
 	uint16_t webport;
 	std::string webip;
 	uint16_t fetchtime;
+	void CARMAResponseHandler(QHttpEngine::Socket *socket);
 protected:
 
 	void UpdateConfigSettings();
@@ -110,7 +111,6 @@ protected:
 	void OnStateChange(IvpPluginState state);
 
 	int  StartWebService();
-	void CARMAResponseHandler(QHttpEngine::Socket *socket);
 	int CloudSend(const string& msg,const string& url, const string& base, const string& method);
 	//Send HTTP request async
 	void CloudSendAsync(const string& msg,const string& url, const string& base, const string& method);

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -67,6 +67,7 @@
 #include <unistd.h>
 #endif
 #include <qhttpengine/server.h>
+#include <qhttpengine/qobjecthandler.h>
 #include <v2xhubWebAPI/OAIApiRouter.h>
 
 
@@ -210,6 +211,8 @@ private:
 	const char *CONTENT_ENCODING_KEY = "Content-Encoding";
     const char *CONTENT_ENCODING_VALUE = "gzip";
 	std::string list_tcm = "true";
+	//API URL to accept TCM response
+	const std::string TCM_REPLY="tcmreply";
 	
 };
 std::mutex _cfgLock;

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -212,7 +212,7 @@ private:
     const char *CONTENT_ENCODING_VALUE = "gzip";
 	std::string list_tcm = "true";
 	//API URL to accept TCM response
-	const std::string TCM_REPLY="tcmreply";
+	const QString TCM_REPLY="tcmreply";
 	
 };
 std::mutex _cfgLock;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix the TCM intermittent reception issue where carma cloud sends TCMs in an http request and v2xhub CARMACloudPlugin sometimes does not receive the TCMs. Replace the OpenAI generated code with QhttpEngine recommended functional call, refer to: https://ci.quickmediasolutions.com/job/qhttpengine-documentation/doxygen/classQHttpEngine_1_1QObjectHandler.html.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/601
https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/603
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
CARMA cloud integration testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
