### PR TITLE
Implement functionality to connect RSU Health Monitor to multiple RSUs(4) from same instance

### DIFF
--- a/src/v2i-hub/RSUHealthMonitorPlugin/CMakeLists.txt
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/CMakeLists.txt
@@ -13,7 +13,7 @@ TARGET_LINK_LIBRARIES(${PROJECT_NAME} PUBLIC tmxutils jsoncpp NemaTode)
 #############
 enable_testing()
 include_directories(${PROJECT_SOURCE_DIR}/src)
-add_library(${PROJECT_NAME}_lib src/RSUHealthMonitorWorker.cpp)
+add_library(${PROJECT_NAME}_lib src/RSUHealthMonitorWorker.cpp src/RSUConfigurationList)
 target_link_libraries(${PROJECT_NAME}_lib PUBLIC 
                                         tmxutils
                                         NemaTode

--- a/src/v2i-hub/RSUHealthMonitorPlugin/manifest.json
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/manifest.json
@@ -17,35 +17,10 @@
             "default":"1",
             "description": "Sending RSU SNMP GET request at every configured interval. Default every 1 second. Unit of measure: second."
         },
-		{
-            "key":"RSUIp",//RSUConfiguration ->RSUS
-            "default":"192.168.XX.XX",
-            "description":"An IP address of the RSU the V2X hub is connected to."
-        },
-		{
-            "key":"SNMPPort",
-            "default":"161",
-            "description":"The SNMP port for sending message or command."
-        },
-		{
-            "key":"AuthPassPhrase",
-            "default":"dummy",
-            "description":"SNMP v3 authentication passphrase"
-        },
-		{
-            "key":"SecurityUser", // user
-            "default":"authOnlyUser",
-            "description":"SNMP Security Name"
-        },
-		{
-            "key":"SecurityLevel", 
-            "default":"authPriv", //Make this constant
-            "description":"SNMP Security level"
-        },
-		{
-            "key":"RSUMIBVersion",//mibVersion
-            "default":"RSU4.1",
-            "description":"The version of RSU MIB (Management Information Base). E.G. RSU4.1 or RSU1218. Currently only support RSU4.1"
+        {
+            "key":"RSUConfigurationList",
+            "default":"{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }",
+            "description":"Configurations of the RSUs the V2X hub is connected to."
         }
     ]
 }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/manifest.json
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/manifest.json
@@ -18,7 +18,7 @@
             "description": "Sending RSU SNMP GET request at every configured interval. Default every 1 second. Unit of measure: second."
         },
 		{
-            "key":"RSUIp",
+            "key":"RSUIp",//RSUConfiguration ->RSUS
             "default":"192.168.XX.XX",
             "description":"An IP address of the RSU the V2X hub is connected to."
         },
@@ -33,17 +33,17 @@
             "description":"SNMP v3 authentication passphrase"
         },
 		{
-            "key":"SecurityUser",
+            "key":"SecurityUser", // user
             "default":"authOnlyUser",
             "description":"SNMP Security Name"
         },
 		{
-            "key":"SecurityLevel",
-            "default":"authPriv",
+            "key":"SecurityLevel", 
+            "default":"authPriv", //Make this constant
             "description":"SNMP Security level"
         },
 		{
-            "key":"RSUMIBVersion",
+            "key":"RSUMIBVersion",//mibVersion
             "default":"RSU4.1",
             "description":"The version of RSU MIB (Management Information Base). E.G. RSU4.1 or RSU1218. Currently only support RSU4.1"
         }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
@@ -5,6 +5,6 @@ namespace RSUHealthMonitor
     class RSUConfigurationException : public std::runtime_error
     {
     public:
-        explicit RSUConfigurationException(const std::string &msg) : std::runtime_error(msg){};
+        using runtime_error::runtime_error;
     };
 }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
@@ -5,11 +5,7 @@ namespace RSUHealthMonitor
 {
     class RSUConfigurationException : public std::runtime_error
     {
-    private:
-        std::string message;
-
     public:
         RSUConfigurationException(const char *msg) : runtime_error(msg){};
     };
-
 }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
@@ -6,6 +6,6 @@ namespace RSUHealthMonitor
     class RSUConfigurationException : public std::runtime_error
     {
     public:
-        RSUConfigurationException(const char *msg) : runtime_error(msg){};
+        explicit RSUConfigurationException(const char *msg) : runtime_error(msg){};
     };
 }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
@@ -3,17 +3,13 @@
 
 namespace RSUHealthMonitor
 {
-    class RSUConfigurationException : public std::exception
+    class RSUConfigurationException : public std::runtime_error
     {
     private:
         std::string message;
 
     public:
-        RSUConfigurationException(const char *msg) : message(msg){};
-        const char *what()
-        {
-            return message.c_str();
-        }
+        RSUConfigurationException(const char *msg) : runtime_error(msg){};
     };
 
 }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
@@ -1,11 +1,11 @@
 #pragma once
-#include <iostream>
+#include <tmx/TmxException.hpp>
 
 namespace RSUHealthMonitor
 {
-    class RSUConfigurationException : public std::runtime_error
+    class RSUConfigurationException : public tmx::TmxException
     {
     public:
-        explicit RSUConfigurationException(const char *msg) : runtime_error(msg){};
+        using TmxException::TmxException;
     };
 }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
@@ -5,6 +5,6 @@ namespace RSUHealthMonitor
     class RSUConfigurationException : public std::runtime_error
     {
     public:
-        RSUConfigurationException(const std::string &msg) : std::runtime_error(msg){};
+        explicit RSUConfigurationException(const std::string &msg) : std::runtime_error(msg){};
     };
 }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <iostream>
+
+namespace RSUHealthMonitor
+{
+    class RSUConfigurationException : public std::exception
+    {
+    private:
+        std::string message;
+
+    public:
+        RSUConfigurationException(const char *msg) : message(msg){};
+        const char *what()
+        {
+            return message.c_str();
+        }
+    };
+
+}

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationException.h
@@ -1,11 +1,10 @@
 #pragma once
-#include <tmx/TmxException.hpp>
 
 namespace RSUHealthMonitor
 {
-    class RSUConfigurationException : public tmx::TmxException
+    class RSUConfigurationException : public std::runtime_error
     {
     public:
-        using TmxException::TmxException;
+        RSUConfigurationException(const std::string &msg) : std::runtime_error(msg){};
     };
 }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
@@ -3,7 +3,7 @@
 
 namespace RSUHealthMonitor
 {
-    Json::Value RSUConfigurationList::parseJson(std::string &rsuConfigsStr) const
+    Json::Value RSUConfigurationList::parseJson(const std::string &rsuConfigsStr) const
     {
         JSONCPP_STRING err;
         Json::Value root;
@@ -19,12 +19,12 @@ namespace RSUHealthMonitor
         return root;
     }
 
-    void RSUConfigurationList::parseRSUs(std::string &rsuConfigsStr)
+    void RSUConfigurationList::parseRSUs(const std::string &rsuConfigsStr)
     {
         auto json = parseJson(rsuConfigsStr);
         std::vector<RSUConfiguration> tempConfigs;
         RSUConfiguration config;
-        auto rsuArray = json["RSUS"];
+        auto rsuArray = json[RSUSKey];
         if (!rsuArray.isArray())
         {
             throw RSUConfigurationException("RSUS is not an array.");
@@ -84,7 +84,7 @@ namespace RSUHealthMonitor
         configs.assign(tempConfigs.begin(), tempConfigs.end());
     }
 
-    RSUMibVersion RSUConfigurationList::strToMibVersion(std::string &mibVersionStr) const
+    RSUMibVersion RSUConfigurationList::strToMibVersion(const std::string &mibVersionStr) const
     {
         boost::trim_left(mibVersionStr);
         boost::trim_right(mibVersionStr);
@@ -101,7 +101,7 @@ namespace RSUHealthMonitor
         }
     }
 
-    std::vector<RSUConfiguration> RSUConfigurationList::getConfigs()
+    std::vector<RSUConfiguration> RSUConfigurationList::getConfigs() const
     {
         return configs;
     }
@@ -109,8 +109,8 @@ namespace RSUHealthMonitor
     std::ostream &operator<<(std::ostream &os, const RSUMibVersion &mib)
     {
         const std::vector<std::string> nameMibs = {"UNKOWN MIB",
-                                                   "RSU 4.1",
-                                                   "NTCIP 1218"};
+                                                   "RSU4.1",
+                                                   "NTCIP1218"};
         return os << nameMibs[static_cast<int>(mib)];
     }
 

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
@@ -19,7 +19,7 @@ namespace RSUHealthMonitor
         return root;
     }
 
-    void RSUConfigurationList::parseRSUs(const std::string &rsuConfigsStr)
+    void RSUConfigurationList::parseRSUs(std::string &rsuConfigsStr)
     {
         auto json = parseJson(rsuConfigsStr);
         std::vector<RSUConfiguration> tempConfigs;
@@ -84,7 +84,7 @@ namespace RSUHealthMonitor
         configs.assign(tempConfigs.begin(), tempConfigs.end());
     }
 
-    RSUMibVersion RSUConfigurationList::strToMibVersion(const std::string &mibVersionStr) const
+    RSUMibVersion RSUConfigurationList::strToMibVersion(std::string &mibVersionStr) const
     {
         boost::trim_left(mibVersionStr);
         boost::trim_right(mibVersionStr);

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
@@ -1,0 +1,84 @@
+
+#include "RSUConfigurationList.h"
+
+namespace RSUHealthMonitor
+{
+    Json::Value RSUConfigurationList::parseJson(std::string rsuConfigsStr)
+    {
+        JSONCPP_STRING err;
+        Json::Value root;
+        auto length = static_cast<int>(rsuConfigsStr.length());
+        Json::CharReaderBuilder builder;
+        std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+        if (!reader->parse(rsuConfigsStr.c_str(), rsuConfigsStr.c_str() + length, &root, &err))
+        {
+            std::stringstream oss;
+            oss << "Parse RSUs raw string error: ";
+            oss << err.c_str();
+            throw RSUConfigurationException(oss.str().c_str());
+        }
+        return root;
+    }
+    void RSUConfigurationList::parseRSUs(std::string rsuConfigsStr)
+    {
+        auto json = parseJson(rsuConfigsStr);
+        RSUConfiguration config;
+        auto rsuArray = json["RSUS"];
+        if (!rsuArray.isArray())
+        {
+            throw RSUConfigurationException("RSUS is not an array.");
+        }
+        for (auto i = 0; i != rsuArray.size(); i++)
+        {
+            if (rsuArray[i].isMember(RSUIpKey))
+            {
+                config.rsuIp = rsuArray[i][RSUIpKey].asString();
+            }
+            else
+            {
+                throw RSUConfigurationException("RSU IP does not exist.");
+            }
+
+            if (rsuArray[i].isMember(SNMPPortKey))
+            {
+                config.snmpPort = atoi(rsuArray[i][SNMPPortKey].asCString());
+            }
+            else
+            {
+                throw RSUConfigurationException("SNMP port does not exist.");
+            }
+
+            if (rsuArray[i].isMember(AuthPassPhraseKey))
+            {
+                config.authPassPhrase = rsuArray[i][AuthPassPhraseKey].asString();
+            }
+            else
+            {
+                throw RSUConfigurationException("Authentication pass phrase does not exist.");
+            }
+
+            if (rsuArray[i].isMember(UserKey))
+            {
+                config.user = rsuArray[i][UserKey].asString();
+            }
+            else
+            {
+                throw RSUConfigurationException("User does not exist.");
+            }
+
+            if (rsuArray[i].isMember(RSUMIBVersionKey))
+            {
+                config.mibVersion = rsuArray[i][RSUMIBVersionKey].asString();
+            }
+            else
+            {
+                throw RSUConfigurationException("RSU mib version does not exist.");
+            }
+            configs.push_back(config);
+        }
+    }
+    std::vector<RSUConfiguration> RSUConfigurationList::getConfigs()
+    {
+        return configs;
+    }
+}

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
@@ -27,7 +27,7 @@ namespace RSUHealthMonitor
         auto rsuArray = json[RSUSKey];
         if (!rsuArray.isArray())
         {
-            throw RSUConfigurationException("RSUS is not an array.");
+            throw RSUConfigurationException("RSUConfigurationList: Missing RSUS array.");
         }
         for (auto i = 0; i != rsuArray.size(); i++)
         {
@@ -37,17 +37,20 @@ namespace RSUHealthMonitor
             }
             else
             {
-                throw RSUConfigurationException("RSU IP does not exist.");
+                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: RSU IP [" + std::string(RSUIpKey) + "] is required.";
+                throw RSUConfigurationException(errMsg);
             }
 
             if (rsuArray[i].isMember(SNMPPortKey))
             {
                 auto port = static_cast<uint16_t>(atoi(rsuArray[i][SNMPPortKey].asCString()));
-                port != 0 ? config.snmpPort = port : throw RSUConfigurationException("Invalid port number in string format.");
+                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: Invalid SNMP port number in string format.";
+                port != 0 ? config.snmpPort = port : throw RSUConfigurationException(errMsg);
             }
             else
             {
-                throw RSUConfigurationException("Either SNMP port does not exist.");
+                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: SNMP port [" + std::string(SNMPPortKey) + "] is required.";
+                throw RSUConfigurationException(errMsg);
             }
 
             if (rsuArray[i].isMember(AuthPassPhraseKey))
@@ -56,7 +59,8 @@ namespace RSUHealthMonitor
             }
             else
             {
-                throw RSUConfigurationException("Authentication pass phrase does not exist.");
+                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: Authentication pass phrase [" + std::string(AuthPassPhraseKey) + "] is required.";
+                throw RSUConfigurationException(errMsg);
             }
 
             if (rsuArray[i].isMember(UserKey))
@@ -65,7 +69,8 @@ namespace RSUHealthMonitor
             }
             else
             {
-                throw RSUConfigurationException("User does not exist.");
+                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: User [" + std::string(UserKey) + "] is required.";
+                throw RSUConfigurationException(errMsg);
             }
 
             if (rsuArray[i].isMember(RSUMIBVersionKey))
@@ -75,7 +80,8 @@ namespace RSUHealthMonitor
             }
             else
             {
-                throw RSUConfigurationException("RSU mib version does not exist.");
+                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: RSU MIB version [" + std::string(RSUMIBVersionKey) + "] is required.";
+                throw RSUConfigurationException(errMsg);
             }
             tempConfigs.push_back(config);
         }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
@@ -37,19 +37,19 @@ namespace RSUHealthMonitor
             }
             else
             {
-                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: RSU IP [" + std::string(RSUIpKey) + "] is required.";
+                auto errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: RSU IP [" + std::string(RSUIpKey) + "] is required.";
                 throw RSUConfigurationException(errMsg);
             }
 
             if (rsuArray[i].isMember(SNMPPortKey))
             {
                 auto port = static_cast<uint16_t>(atoi(rsuArray[i][SNMPPortKey].asCString()));
-                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: Invalid SNMP port number in string format.";
+                auto errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: Invalid SNMP port number in string format.";
                 port != 0 ? config.snmpPort = port : throw RSUConfigurationException(errMsg);
             }
             else
             {
-                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: SNMP port [" + std::string(SNMPPortKey) + "] is required.";
+                auto errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: SNMP port [" + std::string(SNMPPortKey) + "] is required.";
                 throw RSUConfigurationException(errMsg);
             }
 
@@ -59,7 +59,7 @@ namespace RSUHealthMonitor
             }
             else
             {
-                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: Authentication pass phrase [" + std::string(AuthPassPhraseKey) + "] is required.";
+                auto errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: Authentication pass phrase [" + std::string(AuthPassPhraseKey) + "] is required.";
                 throw RSUConfigurationException(errMsg);
             }
 
@@ -69,7 +69,7 @@ namespace RSUHealthMonitor
             }
             else
             {
-                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: User [" + std::string(UserKey) + "] is required.";
+                auto errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: User [" + std::string(UserKey) + "] is required.";
                 throw RSUConfigurationException(errMsg);
             }
 
@@ -80,7 +80,7 @@ namespace RSUHealthMonitor
             }
             else
             {
-                std::string errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: RSU MIB version [" + std::string(RSUMIBVersionKey) + "] is required.";
+                auto errMsg = "RSUConfigurationList [" + std::to_string(i + 1) + "]: RSU MIB version [" + std::string(RSUMIBVersionKey) + "] is required.";
                 throw RSUConfigurationException(errMsg);
             }
             tempConfigs.push_back(config);

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
@@ -19,7 +19,7 @@ namespace RSUHealthMonitor
         return root;
     }
 
-    void RSUConfigurationList::parseRSUs(std::string &rsuConfigsStr)
+    void RSUConfigurationList::parseRSUs(const std::string &rsuConfigsStr)
     {
         auto json = parseJson(rsuConfigsStr);
         std::vector<RSUConfiguration> tempConfigs;
@@ -70,8 +70,8 @@ namespace RSUHealthMonitor
 
             if (rsuArray[i].isMember(RSUMIBVersionKey))
             {
-                auto _rsuMIBVersionStr = rsuArray[i][RSUMIBVersionKey].asString();
-                config.mibVersion = strToMibVersion(_rsuMIBVersionStr);
+                auto rsuMIBVersionStr = rsuArray[i][RSUMIBVersionKey].asString();
+                config.mibVersion = strToMibVersion(rsuMIBVersionStr);
             }
             else
             {

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.cpp
@@ -3,7 +3,7 @@
 
 namespace RSUHealthMonitor
 {
-    Json::Value RSUConfigurationList::parseJson(std::string rsuConfigsStr)
+    Json::Value RSUConfigurationList::parseJson(std::string &rsuConfigsStr) const
     {
         JSONCPP_STRING err;
         Json::Value root;
@@ -19,7 +19,7 @@ namespace RSUHealthMonitor
         return root;
     }
 
-    void RSUConfigurationList::parseRSUs(std::string rsuConfigsStr)
+    void RSUConfigurationList::parseRSUs(std::string &rsuConfigsStr)
     {
         auto json = parseJson(rsuConfigsStr);
         std::vector<RSUConfiguration> tempConfigs;
@@ -42,7 +42,7 @@ namespace RSUHealthMonitor
 
             if (rsuArray[i].isMember(SNMPPortKey))
             {
-                auto port = atoi(rsuArray[i][SNMPPortKey].asCString());
+                auto port = static_cast<uint16_t>(atoi(rsuArray[i][SNMPPortKey].asCString()));
                 port != 0 ? config.snmpPort = port : throw RSUConfigurationException("Invalid port number in string format.");
             }
             else
@@ -84,7 +84,7 @@ namespace RSUHealthMonitor
         configs.assign(tempConfigs.begin(), tempConfigs.end());
     }
 
-    RSUMibVersion RSUConfigurationList::strToMibVersion(std::string &mibVersionStr)
+    RSUMibVersion RSUConfigurationList::strToMibVersion(std::string &mibVersionStr) const
     {
         boost::trim_left(mibVersionStr);
         boost::trim_right(mibVersionStr);
@@ -108,10 +108,10 @@ namespace RSUHealthMonitor
 
     std::ostream &operator<<(std::ostream &os, const RSUMibVersion &mib)
     {
-        const std::string nameMibs[] = {"UNKOWN MIB",
-                                        "RSU 4.1",
-                                        "NTCIP 1218"};
-        return os << nameMibs[mib];
+        const std::vector<std::string> nameMibs = {"UNKOWN MIB",
+                                                   "RSU 4.1",
+                                                   "NTCIP 1218"};
+        return os << nameMibs[static_cast<int>(mib)];
     }
 
     std::ostream &operator<<(std::ostream &os, const RSUConfiguration &config)

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
@@ -8,6 +8,7 @@
 
 namespace RSUHealthMonitor
 {
+    static constexpr const char *RSUSKey = "RSUS";
     static constexpr const char *RSUIpKey = "RSUIp";
     static constexpr const char *SNMPPortKey = "SNMPPort";
     static constexpr const char *UserKey = "User";
@@ -44,8 +45,8 @@ namespace RSUHealthMonitor
          * @param rsuConfigsStr  A JSON string includes all RSUs related configrations.
          * @return JSON::Value A JSON object that includes RSUS information.
          */
-        Json::Value parseJson(std::string &rsuConfigsStr) const;
-        RSUMibVersion strToMibVersion(std::string &mibVersionStr) const;
+        Json::Value parseJson(const std::string &rsuConfigsStr) const;
+        RSUMibVersion strToMibVersion(const std::string &mibVersionStr) const;
 
     public:
         RSUConfigurationList() = default;
@@ -54,11 +55,11 @@ namespace RSUHealthMonitor
          * @brief Parse RSUs configrations in JSON string representation, and update the memeber of list of RSUConfiguration struct.
          * @param rsuConfigsStr A JSON string includes all RSUs related configrations.
          */
-        void parseRSUs(std::string &rsuConfigsStr);
+        void parseRSUs(const std::string &rsuConfigsStr);
         /**
          * @brief Get a list of RSUConfiguration struct.
          */
-        std::vector<RSUConfiguration> getConfigs();
+        std::vector<RSUConfiguration> getConfigs() const;
     };
 
 } // namespace RSUHealthMonitor

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <iostream>
 #include <jsoncpp/json/json.h>
+#include <boost/algorithm/string.hpp>
 #include "RSUConfigurationException.h"
 
 namespace RSUHealthMonitor
@@ -13,6 +14,16 @@ namespace RSUHealthMonitor
     static constexpr const char *AuthPassPhraseKey = "AuthPassPhrase";
     static constexpr const char *RSUMIBVersionKey = "RSUMIBVersion";
     static constexpr const char *SecurityLevelKey = "SecurityLevel";
+    static constexpr const char *RSU4_1_str = "RSU4.1";
+    static constexpr const char *RSU1218_str = "RSU1218";
+
+    enum RSUMibVersion
+    {
+        UNKOWN_MIB_V = 0,
+        RSUMIB_V_4_1 = 1,
+        RSUMIB_V_1218 = 2
+    };
+
     struct RSUConfiguration
     {
         std::string rsuIp;
@@ -20,12 +31,8 @@ namespace RSUHealthMonitor
         std::string user;
         std::string authPassPhrase;
         std::string securityLevel = "authPriv";
-        std::string mibVersion;
-        friend std::ostream &operator<<(std::ostream &os, const RSUConfiguration &config)
-        {
-            os << RSUIpKey << ": " << config.rsuIp << ", " << SNMPPortKey << ": " << config.snmpPort << ", " << UserKey << ": " << config.user << ", " << AuthPassPhraseKey << ": " << config.authPassPhrase << ", " << SecurityLevelKey << ": " << config.securityLevel << ", " << RSUMIBVersionKey << ": " << config.mibVersion;
-            return os;
-        }
+        RSUMibVersion mibVersion;
+        friend std::ostream &operator<<(std::ostream &os, const RSUConfiguration &config);
     };
 
     class RSUConfigurationList
@@ -38,6 +45,7 @@ namespace RSUHealthMonitor
          * @return JSON::Value A JSON object that includes RSUS information.
          */
         Json::Value parseJson(std::string rsuConfigsStr);
+        RSUMibVersion strToMibVersion(std::string &mibVersionStr);
 
     public:
         RSUConfigurationList() = default;

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <iostream>
+#include <jsoncpp/json/json.h>
+#include "RSUConfigurationException.h"
+
+namespace RSUHealthMonitor
+{
+    static constexpr const char *RSUIpKey = "RSUIp";
+    static constexpr const char *SNMPPortKey = "SNMPPort";
+    static constexpr const char *UserKey = "User";
+    static constexpr const char *AuthPassPhraseKey = "AuthPassPhrase";
+    static constexpr const char *RSUMIBVersionKey = "RSUMIBVersion";
+    static constexpr const char *SecurityLevelKey = "SecurityLevel";
+    struct RSUConfiguration
+    {
+        std::string rsuIp;
+        uint16_t snmpPort;
+        std::string user;
+        std::string authPassPhrase;
+        std::string securityLevel = "authPriv";
+        std::string mibVersion;
+        friend std::ostream &operator<<(std::ostream &os, const RSUConfiguration &config)
+        {
+            os << RSUIpKey << ": " << config.rsuIp << ", " << SNMPPortKey << ": " << config.snmpPort << ", " << UserKey << ": " << config.user << ", " << AuthPassPhraseKey << ": " << config.authPassPhrase << ", " << SecurityLevelKey << ": " << config.securityLevel << ", " << RSUMIBVersionKey << ": " << config.mibVersion;
+            return os;
+        }
+    };
+
+    class RSUConfigurationList
+    {
+    private:
+        std::vector<RSUConfiguration> configs;
+        /***
+         * @brief Parse JSON string and return the corresponding JSON value.
+         * @param rsuConfigsStr  A JSON string includes all RSUs related configrations.
+         * @return JSON::Value A JSON object that includes RSUS information.
+         */
+        Json::Value parseJson(std::string rsuConfigsStr);
+
+    public:
+        RSUConfigurationList() = default;
+        ~RSUConfigurationList() = default;
+        /**
+         * @brief Parse RSUs configrations in JSON string representation, and update the memeber of list of RSUConfiguration struct.
+         * @param rsuConfigsStr A JSON string includes all RSUs related configrations.
+         */
+        void parseRSUs(std::string rsuConfigsStr);
+        /**
+         * @brief Get a list of RSUConfiguration struct.
+         */
+        std::vector<RSUConfiguration> getConfigs();
+    };
+
+} // namespace RSUHealthMonitor

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
@@ -46,7 +46,7 @@ namespace RSUHealthMonitor
          * @return JSON::Value A JSON object that includes RSUS information.
          */
         Json::Value parseJson(const std::string &rsuConfigsStr) const;
-        RSUMibVersion strToMibVersion(const std::string &mibVersionStr) const;
+        RSUMibVersion strToMibVersion(std::string &mibVersionStr) const;
 
     public:
         RSUConfigurationList() = default;
@@ -55,7 +55,7 @@ namespace RSUHealthMonitor
          * @brief Parse RSUs configrations in JSON string representation, and update the memeber of list of RSUConfiguration struct.
          * @param rsuConfigsStr A JSON string includes all RSUs related configrations.
          */
-        void parseRSUs(const std::string &rsuConfigsStr);
+        void parseRSUs(std::string &rsuConfigsStr);
         /**
          * @brief Get a list of RSUConfiguration struct.
          */

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
@@ -55,7 +55,7 @@ namespace RSUHealthMonitor
          * @brief Parse RSUs configrations in JSON string representation, and update the memeber of list of RSUConfiguration struct.
          * @param rsuConfigsStr A JSON string includes all RSUs related configrations.
          */
-        void parseRSUs(std::string &rsuConfigsStr);
+        void parseRSUs(const std::string &rsuConfigsStr);
         /**
          * @brief Get a list of RSUConfiguration struct.
          */

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUConfigurationList.h
@@ -17,7 +17,7 @@ namespace RSUHealthMonitor
     static constexpr const char *RSU4_1_str = "RSU4.1";
     static constexpr const char *RSU1218_str = "RSU1218";
 
-    enum RSUMibVersion
+    enum class RSUMibVersion
     {
         UNKOWN_MIB_V = 0,
         RSUMIB_V_4_1 = 1,
@@ -44,8 +44,8 @@ namespace RSUHealthMonitor
          * @param rsuConfigsStr  A JSON string includes all RSUs related configrations.
          * @return JSON::Value A JSON object that includes RSUS information.
          */
-        Json::Value parseJson(std::string rsuConfigsStr);
-        RSUMibVersion strToMibVersion(std::string &mibVersionStr);
+        Json::Value parseJson(std::string &rsuConfigsStr) const;
+        RSUMibVersion strToMibVersion(std::string &mibVersionStr) const;
 
     public:
         RSUConfigurationList() = default;
@@ -54,7 +54,7 @@ namespace RSUHealthMonitor
          * @brief Parse RSUs configrations in JSON string representation, and update the memeber of list of RSUConfiguration struct.
          * @param rsuConfigsStr A JSON string includes all RSUs related configrations.
          */
-        void parseRSUs(std::string rsuConfigsStr);
+        void parseRSUs(std::string &rsuConfigsStr);
         /**
          * @brief Get a list of RSUConfiguration struct.
          */

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorPlugin.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorPlugin.cpp
@@ -38,11 +38,15 @@ namespace RSUHealthMonitor
         lock_guard<mutex> lock(_configMutex);
         GetConfigValue<uint16_t>("Interval", _interval);
         GetConfigValue<string>("RSUConfigurationList", _rsuConfigListStr);
-        _rsuConfigListPtr->parseRSUs(_rsuConfigListStr);
 
         try
         {
+            _rsuConfigListPtr->parseRSUs(_rsuConfigListStr);
             _rsuStatusTimer->ChangeFrequency(_timerThId, std::chrono::milliseconds(_interval * SEC_TO_MILLI));
+        }
+        catch (const RSUConfigurationException &ex)
+        {
+            PLOG(logERROR) << "Cannot update RSU configurations due to error: " << ex.what();
         }
         catch (const tmx::TmxException &ex)
         {

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorPlugin.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorPlugin.cpp
@@ -17,7 +17,7 @@ namespace RSUHealthMonitor
         _timerThId = _rsuStatusTimer->AddPeriodicTick([this]()
                                                       {
                         this->monitorRSUs();
-                        PLOG(logINFO) << "Updating RSU _interval: " << _interval; },
+                        PLOG(logINFO) << "Monitoring RSU at interval (second): " << _interval; },
                                                       std::chrono::milliseconds(_interval * SEC_TO_MILLI));
         _rsuStatusTimer->Start();
     }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorPlugin.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorPlugin.h
@@ -18,13 +18,6 @@ namespace RSUHealthMonitor
     private:
         mutex _configMutex;
         uint16_t _interval;
-        // string _rsuIp;
-        // uint16_t _snmpPort;
-        // string _authPassPhrase;
-        // string _securityUser;
-        // string _securityLevel;
-        // string _rsuMIBVersionStr;
-        // RSUMibVersion _rsuMibVersion;
         string _rsuConfigListStr;
         shared_ptr<RSUConfigurationList> _rsuConfigListPtr;
         shared_ptr<RSUHealthMonitorWorker> _rsuWorker;

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorPlugin.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorPlugin.h
@@ -5,6 +5,7 @@
 #include <jsoncpp/json/json.h>
 #include "RSUStatusMessage.h"
 #include "RSUHealthMonitorWorker.h"
+#include "RSUConfigurationList.h"
 
 using namespace tmx::utils;
 using namespace std;
@@ -17,15 +18,15 @@ namespace RSUHealthMonitor
     private:
         mutex _configMutex;
         uint16_t _interval;
-        string _rsuIp;
-        uint16_t _snmpPort;
-        string _authPassPhrase;
-        string _securityUser;
-        string _securityLevel;
-        string _rsuMIBVersionStr;
-        RSUMibVersion _rsuMibVersion;
-        const char *RSU4_1_str = "RSU4.1";
-        const char *RSU1218_str = "RSU1218";
+        // string _rsuIp;
+        // uint16_t _snmpPort;
+        // string _authPassPhrase;
+        // string _securityUser;
+        // string _securityLevel;
+        // string _rsuMIBVersionStr;
+        // RSUMibVersion _rsuMibVersion;
+        string _rsuConfigListStr;
+        shared_ptr<RSUConfigurationList> _rsuConfigListPtr;
         shared_ptr<RSUHealthMonitorWorker> _rsuWorker;
         unique_ptr<ThreadTimer> _rsuStatusTimer;
         uint _timerThId;
@@ -35,12 +36,13 @@ namespace RSUHealthMonitor
          * @brief Broadcast RSU status
          * @param Json::Value RSU status in JSON format
          */
-        void BroadcastRSUStatus(const Json::Value& rsuStatusJson);
+        void BroadcastRSUStatus(const Json::Value &rsuStatusJson, const RSUMibVersion &mibVersion);
 
     public:
         explicit RSUHealthMonitorPlugin(const std::string &name);
         void UpdateConfigSettings();
         void OnConfigChanged(const char *key, const char *value) override;
+        void monitorRSUs();
     };
 
 } // namespace RSUHealthMonitorPlugin

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorWorker.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorWorker.cpp
@@ -125,7 +125,7 @@ namespace RSUHealthMonitor
         try
         {
             // Create SNMP client and use SNMP V3 protocol
-            PLOG(logINFO) << "Update SNMP client: RSU IP: " << _rsuIp << ", RSU port: " << _snmpPort << ", User: " << _securityUser << ", auth pass phrase: " << _authPassPhrase << ", security level: "
+            PLOG(logINFO) << "SNMP client: RSU IP: " << _rsuIp << ", RSU port: " << _snmpPort << ", User: " << _securityUser << ", auth pass phrase: " << _authPassPhrase << ", security level: "
                           << _securityLevel;
             auto _snmpClientPtr = std::make_unique<snmp_client>(_rsuIp, _snmpPort, "", _securityUser, _securityLevel, _authPassPhrase, SNMP_VERSION_3, timeout);
 

--- a/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorWorker.h
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/src/RSUHealthMonitorWorker.h
@@ -11,6 +11,7 @@
 #include "SNMPClient.h"
 #include <boost/algorithm/string/predicate.hpp>
 #include "RSUStatusMessage.h"
+#include "RSUConfigurationList.h"
 
 using namespace std;
 using namespace tmx::utils;
@@ -19,12 +20,6 @@ using namespace tmx::messages;
 
 namespace RSUHealthMonitor
 {
-    enum class RSUMibVersion
-    {
-        UNKOWN_MIB_V = 0,
-        RSUMIB_V_4_1 = 1,
-        RSUMIB_V_1218 = 2
-    };
 
     struct RSUFieldOIDStruct
     {

--- a/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
@@ -46,7 +46,7 @@ namespace RSUHealthMonitor
 
     TEST_F(test_RSUConfigurationList, parseAndGetConfigs_INVALID_SNMPPORT)
     {
-        auto rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.01.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"INVALID_PORT\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.01.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"INVALID_PORT\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
         ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
     }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
@@ -24,7 +24,7 @@ namespace RSUHealthMonitor
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
     }
 
-    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_RSUS)
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_Missing_RSUS)
     {
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
         std::string rsuConfigsStr = "{ \"ERROR\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
@@ -32,7 +32,7 @@ namespace RSUHealthMonitor
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
     }
 
-    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_SNMPPORT)
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_Missing_SNMPPORT)
     {
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
         std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort_Missing\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
@@ -40,7 +40,7 @@ namespace RSUHealthMonitor
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
     }
 
-    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_AuthPassPhrase)
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_Missing_AuthPassPhrase)
     {
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
         std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase_Missing\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
@@ -48,17 +48,26 @@ namespace RSUHealthMonitor
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
     }
 
-    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_User)
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_Missing_User)
     {
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
         std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User_Missing\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
         ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
     }
-    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_MibVersion)
+
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_Missing_MibVersion)
     {
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
         std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion_Missing\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+    }
+
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_Invalid_MibVersion)
+    {
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+        std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"INVALID_RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
         ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
     }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
@@ -15,6 +15,10 @@ namespace RSUHealthMonitor
         std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
         rsuConfigList->parseRSUs(rsuConfigsStr);
         ASSERT_EQ(2, rsuConfigList->getConfigs().size());
+        std::stringstream ss;
+        ss << rsuConfigList->getConfigs()[0];
+        std::string expected = "RSUIp: 192.168.XX.XX, SNMPPort: 161, User: authOnlyUser, AuthPassPhrase: dummy, SecurityLevel: authPriv, RSUMIBVersion: RSU 4.1";
+        ASSERT_EQ(expected, ss.str());
     }
     TEST_F(test_RSUConfigurationList, parseAndGetConfigs_MalformatJSON)
     {
@@ -36,6 +40,13 @@ namespace RSUHealthMonitor
     {
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
         std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort_Missing\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+    }
+
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_INVALID_SNMPPORT)
+    {
+        auto rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.01.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"INVALID_PORT\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
         ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
         ASSERT_EQ(0, rsuConfigList->getConfigs().size());
     }

--- a/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
@@ -17,7 +17,7 @@ namespace RSUHealthMonitor
         ASSERT_EQ(2, rsuConfigList->getConfigs().size());
         std::stringstream ss;
         ss << rsuConfigList->getConfigs()[0];
-        std::string expected = "RSUIp: 192.168.XX.XX, SNMPPort: 161, User: authOnlyUser, AuthPassPhrase: dummy, SecurityLevel: authPriv, RSUMIBVersion: RSU 4.1";
+        std::string expected = "RSUIp: 192.168.XX.XX, SNMPPort: 161, User: authOnlyUser, AuthPassPhrase: dummy, SecurityLevel: authPriv, RSUMIBVersion: RSU4.1";
         ASSERT_EQ(expected, ss.str());
     }
     TEST_F(test_RSUConfigurationList, parseAndGetConfigs_MalformatJSON)

--- a/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
+++ b/src/v2i-hub/RSUHealthMonitorPlugin/test/test_RSUConfigurationList.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+#include "RSUConfigurationList.h"
+
+namespace RSUHealthMonitor
+{
+    class test_RSUConfigurationList : public ::testing::Test
+    {
+    public:
+        std::shared_ptr<RSUConfigurationList> rsuConfigList = std::make_shared<RSUConfigurationList>();
+    };
+
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs)
+    {
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+        std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        rsuConfigList->parseRSUs(rsuConfigsStr);
+        ASSERT_EQ(2, rsuConfigList->getConfigs().size());
+    }
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_MalformatJSON)
+    {
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+        std::string rsuConfigsStr = "{ \"RSUS { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+    }
+
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_RSUS)
+    {
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+        std::string rsuConfigsStr = "{ \"ERROR\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+    }
+
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_SNMPPORT)
+    {
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+        std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort_Missing\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+    }
+
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_AuthPassPhrase)
+    {
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+        std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase_Missing\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+    }
+
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_User)
+    {
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+        std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User_Missing\": \"authOnlyUser\", \"RSUMIBVersion\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+    }
+    TEST_F(test_RSUConfigurationList, parseAndGetConfigs_missing_MibVersion)
+    {
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+        std::string rsuConfigsStr = "{ \"RSUS\": [ { \"RSUIp\": \"192.168.XX.XX\", \"SNMPPort\": \"161\", \"AuthPassPhrase\": \"dummy\", \"User\": \"authOnlyUser\", \"RSUMIBVersion_Missing\": \"RSU4.1\" },{ \"RSUIp\": \"192.168.00.XX\", \"SNMPPort\": \"162\", \"AuthPassPhrase\": \"tester\", \"User\": \"authPrivUser\", \"RSUMIBVersion\": \"RSU4.1\" }] }";
+        ASSERT_THROW(rsuConfigList->parseRSUs(rsuConfigsStr), RSUHealthMonitor::RSUConfigurationException);
+        ASSERT_EQ(0, rsuConfigList->getConfigs().size());
+    }
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update the V2X Hub's RSU Health Monitor plugin supports monitoring the health status of multiple Roadside Units (RSUs) per V2X Hub instance.

<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
NA
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
