### PR TITLE
CARMACloudPlugin: TCR oldest issue in simulation environment

### DIFF
--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -72,7 +72,7 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 		long lat = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->reflat;
 		long longg = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->reflon;
 
-		auto oldest = std::max(tm, 0); // Replace tm with 0 if negative
+		auto oldest = std::max(oldestInMins, 0); // Replace tm with 0 if negative
 
 		long dtx0 = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->offsets.list.array[0]->deltax;
 		long dty0 = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->offsets.list.array[0]->deltay;

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -64,8 +64,7 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 	char bounds_str[5000];
 	strcpy(bounds_str, "");
 
-	//  get current time
-	uint32_t tm = getClock()->nowInSeconds() / 60 - fetchtime * 24 * 60; // T minus 24 hours in min
+	uint32_t oldestInMins = getClock()->nowInSeconds() / 60 - fetchtime * 24 * 60; // T minus 24 hours in min
 
 	while (cnt < totBounds)
 	{

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -64,7 +64,7 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 	char bounds_str[5000];
 	strcpy(bounds_str, "");
 
-	uint32_t oldestInMins = getClock()->nowInSeconds() / 60 - fetchtime * 24 * 60; // T minus 24 hours in min
+	int oldestInMins = getClock()->nowInSeconds() / 60 - fetchtime * 24 * 60; // T minus 24 hours in min
 
 	while (cnt < totBounds)
 	{

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -65,7 +65,7 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 	strcpy(bounds_str, "");
 
 	//  get current time
-	std::time_t tm = getClock()->nowInMilliseconds() / 60 - fetchtime * 24 * 60; // T minus 24 hours in min
+	std::time_t tm = getClock()->nowInMilliseconds() / 1000 / 60 - fetchtime * 24 * 60; // T minus 24 hours in min
 
 	while (cnt < totBounds)
 	{
@@ -73,7 +73,7 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 		long lat = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->reflat;
 		long longg = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->reflon;
 
-		auto oldest = std::max(tm, 0); // Replace tm with 0 if negative
+		auto oldest = std::max(static_cast<uint32_t>(tm), 0); // Replace tm with 0 if negative
 
 		long dtx0 = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->offsets.list.array[0]->deltax;
 		long dty0 = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->offsets.list.array[0]->deltay;

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -65,7 +65,7 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 	strcpy(bounds_str, "");
 
 	//  get current time
-	std::time_t tm = getClock()->nowInMilliseconds() / 1000 / 60 - fetchtime * 24 * 60; // T minus 24 hours in min
+	uint32_t tm = getClock()->nowInSeconds() / 60 - fetchtime * 24 * 60; // T minus 24 hours in min
 
 	while (cnt < totBounds)
 	{
@@ -73,7 +73,7 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 		long lat = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->reflat;
 		long longg = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->reflon;
 
-		auto oldest = std::max(static_cast<uint32_t>(tm), 0); // Replace tm with 0 if negative
+		auto oldest = std::max(tm, 0); // Replace tm with 0 if negative
 
 		long dtx0 = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->offsets.list.array[0]->deltax;
 		long dty0 = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->offsets.list.array[0]->deltay;

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -74,7 +74,7 @@
 #include <curl/curl.h>
 #include <algorithm>
 
-
+#include <simulation/SimulationEnvUtils.h>
 
 using namespace std;
 
@@ -213,7 +213,12 @@ private:
 	std::string list_tcm = "true";
 	//API URL to accept TCM response
 	const QString TCM_REPLY="tcmreply";
-	
+	/**
+	 * @brief Convert the EpochMins to integer type.
+	 * @param oldest Timestamp of oldest traffic control message within bounds.
+	 * @returns Unit of minutes
+	*/
+	uint64_t convertOldest(const EpochMins_t& oldest);
 };
 std::mutex _cfgLock;
 }

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -92,7 +92,8 @@ enum acknowledgement_status {
 	acknowledgement_status__not_acknowledged 	= 3  //CMV does not respond at all within the v2xhub repeatedly broadcast time period
 };
 
-class CARMACloudPlugin: public PluginClient {
+class CARMACloudPlugin : public PluginClientClockAware
+{
 public:
 	CARMACloudPlugin(std::string);
 	virtual ~CARMACloudPlugin();
@@ -212,13 +213,7 @@ private:
     const char *CONTENT_ENCODING_VALUE = "gzip";
 	std::string list_tcm = "true";
 	//API URL to accept TCM response
-	const QString TCM_REPLY="tcmreply";
-	/**
-	 * @brief Convert the EpochMins to integer type.
-	 * @param oldest Timestamp of oldest traffic control message within bounds.
-	 * @returns Unit of minutes
-	*/
-	uint64_t convertOldest(const EpochMins_t& oldest);
+	const QString TCM_REPLY = "tcmreply";
 };
 std::mutex _cfgLock;
 }

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -73,8 +73,7 @@
 
 #include <curl/curl.h>
 #include <algorithm>
-
-#include <simulation/SimulationEnvUtils.h>
+#include <PluginClientClockAware.h>
 
 using namespace std;
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Current TCR message is populated with oldest value based on the epoch timestamp, and defined as how many minutes from now. However, in simulation environment, the clock reference is not epoch time, it is customized clock starting from 0. This can be an issue with the current oldest implementation in v2xhub because the carma-cloud application in simulation environment uses the oldest value generated by V2xHub and reference it based on the simulation time rather than epoch time.  Also, carma-platform running in the vehicle cannot control the oldest value generation. This PR is to update the TCR message oldest field with data sent by carma-platform in simulation mode.

<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
XIL integration testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
integration tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
