### PR TITLE
Remove Obsolete docker compose file version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	// Docker Compose syntax from https://github.com/devcontainers/templates/blob/main/src/docker-existing-docker-compose/.devcontainer/devcontainer.json
 	// and https://github.com/microsoft/vscode-dev-containers/blob/main/container-templates/docker-compose/.devcontainer/devcontainer.json
-	"name": "V2XHUB Docker Compose Dev",
+	"name": "V2X Hub Docker Compose Dev",
 
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	"dockerComposeFile": "docker-compose-vscode.yml",

--- a/.devcontainer/docker-compose-vscode.yml
+++ b/.devcontainer/docker-compose-vscode.yml
@@ -29,7 +29,7 @@ services:
       - mysql_password
 
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     container_name: mysql
     restart: always
     environment:
@@ -42,7 +42,7 @@ services:
       - mysql_password
       - mysql_root_password
     volumes:
-      - ../configuration/amd64/mysql/localhost.sql:/docker-entrypoint-initdb.d/localhost.sql
+      - ../configuration/mysql/localhost.sql:/docker-entrypoint-initdb.d/localhost.sql
       # include creation of a user (user/user) to be able to log in
       - ./mysql_add_dev_user.sql:/docker-entrypoint-initdb.d/mysql_add_dev_user.sql
       - mysql-datavolume:/var/lib/mysql

--- a/.devcontainer/docker-compose-vscode.yml
+++ b/.devcontainer/docker-compose-vscode.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   v2xhub:
     build: 

--- a/configuration/docker-compose.yml
+++ b/configuration/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   db:
     image: mysql:8.0


### PR DESCRIPTION
	modified:   configuration/docker-compose.yml

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Removed the "version:" tag a the top of the docker-compose files. These are no longer needed and are obsolete in current and future versions of Docker. 

## Related Issue
[VH-1312](https://usdot-carma.atlassian.net/browse/VH-1312)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Because the version tag is obsolete, a warning note is published every time a user uses the docker-compose files to start the V2X Hub containers. Removing this tag will cause no changes in functionality and will remove the warning.

## How Has This Been Tested?

Tags removed and tested locally. Everything worked as intended and warning message was no longer shown. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
