### PR TITLE
VH 1319 - Make V2X-Hub previous releases to support multi architecture docker images

### DIFF
--- a/configuration/initialization.sh
+++ b/configuration/initialization.sh
@@ -150,6 +150,6 @@ fi
 
 # Create V2X Hub user
 cd "$mysqlDir" || return # return in case cd fails
-./add_v2xhub_user.bash
+./add_v2xhub_user.bash "$V2XHUB_VERSION"
 
 chromium-browser --ignore-certificate-errors localhost > /dev/null 2>&1 &

--- a/configuration/initialization.sh
+++ b/configuration/initialization.sh
@@ -23,15 +23,16 @@ latest_version=$(echo "$release_info" | grep -o '"tag_name": *"[^"]*"' | cut -d 
 # Fetching all tags from Git repository
 tags=$(git ls-remote --tags https://github.com/usdot-fhwa-OPS/V2X-Hub.git | awk -F/ '{print $3}' | sort -V)
 
-# Remove curly braces, Properties found, and duplicate entries
-updated_tags=$(echo "$tags" | sed 's/\^{}//' | grep -v '^Properties_Found$' | awk '!seen[$0]++')
+# Remove curly braces, Properties found, duplicate entries, and show only versions above 7.0
+updated_tags=$(echo "$tags" | sed 's/\^{}//;s/^v//' | grep -v '^Properties_Found$' | awk '!seen[$0]++ && $1 >= "7.0"')
 
 # Displaying all available versions
+echo "Note: V2X-Hub multi architecture deployments only work for the versions 7.0 and above."
 echo "Available versions:"
 echo "$updated_tags"
 
 # select a version or accept the latest version as default
-read -r -p "Enter V2X-Hub Version (choose from the above, or press Enter to use latest version $latest_version): " chosen_version
+read -r -p "Enter V2X-Hub Version (choose from the above, or press Enter to use the latest version $latest_version): " chosen_version
 V2XHUB_VERSION=${chosen_version:-$latest_version}
 
 # Enable Port Drayage functionality

--- a/configuration/mysql/add_v2xhub_user.bash
+++ b/configuration/mysql/add_v2xhub_user.bash
@@ -7,7 +7,7 @@ if [ -n "$1" ]; then
     V2XHUB_VERSION="$1"
 else
     # Prompt user for V2XHUB_VERSION
-    read -p "Enter the deployed V2X-Hub version number: " V2XHUB_VERSION
+    read -r -p "Enter the deployed V2X-Hub version number: " V2XHUB_VERSION
 fi
 
 echo "Adding V2X-Hub user for version: $V2XHUB_VERSION"

--- a/configuration/mysql/add_v2xhub_user.bash
+++ b/configuration/mysql/add_v2xhub_user.bash
@@ -2,6 +2,16 @@
 # Fail when any command fails
 #set -e
 
+# Check if V2XHUB_VERSION is passed
+if [ -n "$1" ]; then
+    V2XHUB_VERSION="$1"
+else
+    # Prompt user for V2XHUB_VERSION
+    read -p "Enter the deployed V2X-Hub version number: " V2XHUB_VERSION
+fi
+
+echo "Adding V2X-Hub user for version: $V2XHUB_VERSION"
+
 # Ensure mysql-client is installed
 arch=$(dpkg --print-architecture)
 # TODO: Add a common mysql-client that works for ARM and AMD devices 
@@ -34,7 +44,12 @@ if [ $PASS_LENGTH -ge 8 ] && echo $PASS | grep -q [a-z] && echo $PASS | grep -q 
     done
     echo "VALID PASSWORD"
     echo "Enter MYSQL ROOT PASSWORD: "
-    mysql -uroot -p --silent -h127.0.0.1 -e "INSERT INTO IVP.user (IVP.user.username, IVP.user.password, IVP.user.accessLevel) VALUES('$USER', SHA2('$PASS', 256), 3)"
+    # Check if V2XHUB_VERSION is >= 7.5.0
+    if [[ "$(echo "$V2XHUB_VERSION 7.5.0" | awk '{print ($1 >= $2)}')" -eq 1 ]]; then
+        mysql -uroot -p --silent -h127.0.0.1 -e "INSERT INTO IVP.user (IVP.user.username, IVP.user.password, IVP.user.accessLevel) VALUES('$USER', SHA2('$PASS', 256), 3)"
+    else    
+        mysql -uroot -p --silent -h127.0.0.1 -e "INSERT INTO IVP.user (IVP.user.username, IVP.user.password, IVP.user.accessLevel) VALUES('$USER', '$PASS', 3)"
+    fi
     echo "V2X Hub user successfully added"
 else
     echo "INVALID PASSWORD"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
In this PR,
- Updated the initialization script to print only versions 7.0  and above that support multi architecture deployment.
- Updated the add user script to create V2X-Hub username and password based on the deployment version.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This work is to improve the V2X-Hub deployment process 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

After creating the multi architecture docker images, they have been tested by deploying them on both AMD and ARM devices.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
