### PR TITLE
MustSensorDriverPlugin: Convert the classification confidence to decimal from percentage unit  %

### DIFF
--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -711,7 +711,7 @@ void CARMAStreetsPlugin::HandleSimulatedSensorDetectedMessage(SensorDetectedObje
 	// is currently out of scope. TMX Messages should be correctly serialize to 
 	// and from json. This temporary fix simply using regex to look for numeric,
 	// null, and bool values and removes the quotations around them.
-	PLOG(logDEBUG) <<  "Produce sensor detected message in JSON format:  " << msg.to_string() <<std::endl;
+	PLOG(logDEBUG) <<  "Receive sensor detected message in JSON format:  " << msg.to_string() <<std::endl;
 	boost::regex exp("\"(null|true|false|-?[0-9]+(\\.[0-9]+)?)\"");
 	std::stringstream ss;
 	std::string rv = boost::regex_replace(msg.to_string(), exp, "$1");

--- a/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDetection.cpp
+++ b/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDetection.cpp
@@ -34,7 +34,7 @@ namespace MUSTSensorDriverPlugin {
         detectedObject.set_objectId(detection.trackID);
         tmx::messages::Position pos(detection.position_x, detection.position_y, 0);
         detectedObject.set_position(pos);
-        detectedObject.set_confidence(detection.confidence/PERCENTAGE_TO_DECIMAL);
+        detectedObject.set_confidence(detection.confidence/100.0);
         detectedObject.set_timestamp(static_cast<long>(detection.timestamp*1000)); // convert decimal seconds to int milliseconds.
         detectedObject.set_velocity(headingSpeedToVelocity(detection.heading, detection.speed));
         detectedObject.set_type(detectionClassificationToSensorDetectedObjectType(detection.cl));

--- a/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDetection.cpp
+++ b/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDetection.cpp
@@ -34,7 +34,7 @@ namespace MUSTSensorDriverPlugin {
         detectedObject.set_objectId(detection.trackID);
         tmx::messages::Position pos(detection.position_x, detection.position_y, 0);
         detectedObject.set_position(pos);
-        detectedObject.set_confidence(detection.confidence);
+        detectedObject.set_confidence(detection.confidence/PERCENTAGE_TO_DECIMAL);
         detectedObject.set_timestamp(static_cast<long>(detection.timestamp*1000)); // convert decimal seconds to int milliseconds.
         detectedObject.set_velocity(headingSpeedToVelocity(detection.heading, detection.speed));
         detectedObject.set_type(detectionClassificationToSensorDetectedObjectType(detection.cl));

--- a/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDetection.h
+++ b/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDetection.h
@@ -94,7 +94,6 @@ namespace MUSTSensorDriverPlugin {
         DetectionSize size = DetectionSize::NA;
         // Confidence in type
         double confidence = 0;
-        int PERCENTAGE_TO_DECIMAL = 100.0;
         // Unique ID
         unsigned int trackID = 0;
         // Timestamp in seconds

--- a/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDetection.h
+++ b/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDetection.h
@@ -94,6 +94,7 @@ namespace MUSTSensorDriverPlugin {
         DetectionSize size = DetectionSize::NA;
         // Confidence in type
         double confidence = 0;
+        int PERCENTAGE_TO_DECIMAL = 100.0;
         // Unique ID
         unsigned int trackID = 0;
         // Timestamp in seconds

--- a/src/v2i-hub/MUSTSensorDriverPlugin/test/TestMUSTSensorDetection.cpp
+++ b/src/v2i-hub/MUSTSensorDriverPlugin/test/TestMUSTSensorDetection.cpp
@@ -66,7 +66,7 @@ TEST(TestMUSTSensorDetection, mustDetectionToSensorDetectedObject ) {
     auto sensorDetectedObject = mustDetectionToSensorDetectedObject(detection, "MUSTSensor1", "PROJ String");
 
     EXPECT_EQ(detection.trackID, sensorDetectedObject.get_objectId());
-    EXPECT_DOUBLE_EQ(detection.confidence, sensorDetectedObject.get_confidence());
+    EXPECT_DOUBLE_EQ(detection.confidence/100.0, sensorDetectedObject.get_confidence());
     EXPECT_DOUBLE_EQ(detection.position_x, sensorDetectedObject.get_position().x);
     EXPECT_DOUBLE_EQ(detection.position_y, sensorDetectedObject.get_position().y);
     EXPECT_NEAR(4.33, sensorDetectedObject.get_velocity().y, 0.001);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The MUST Sensor provides classification confidence as a decimal value between 0 and 100 % while the Sensor Detected Object message expects confidence as a decimal value between 0 and 1. PR includes appropriate conversion logic
<!--- Describe your changes in detail -->

## Related Issue
[FCP-30](https://usdot-carma.atlassian.net/browse/FCP-30)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Provide correct data translation between MUST sensor output and Sensor Detected Object message for data accuracy in the SDMS Pipeline
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit Testing and Local Integration Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[FCP-30]: https://usdot-carma.atlassian.net/browse/FCP-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ