### PR TITLE
5gaa ode plugin udp socket  support

### DIFF
--- a/src/v2i-hub/ODEForwardPlugin/CMakeLists.txt
+++ b/src/v2i-hub/ODEForwardPlugin/CMakeLists.txt
@@ -5,3 +5,18 @@ SET (TMX_PLUGIN_NAME "ODEForwardPlugin")
 BuildTmxPlugin ( )
 
 TARGET_LINK_LIBRARIES (${PROJECT_NAME} tmxutils rdkafka++)
+
+#############
+## Testing ##
+#############
+enable_testing()
+include_directories(${PROJECT_SOURCE_DIR}/src)
+file(GLOB_RECURSE LIB_SOURCES LIST_DIRECTORIES false  src/*.cpp)
+add_library(${PROJECT_NAME}_lib ${LIB_SOURCES})
+target_link_libraries(${PROJECT_NAME}_lib PUBLIC tmxutils)
+set(BINARY ${PROJECT_NAME}_test)
+file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false test/*.h test/*.cpp)
+set(SOURCES ${TEST_SOURCES} WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
+add_executable(${BINARY} ${TEST_SOURCES})
+add_test(NAME ${BINARY} COMMAND ${BINARY})
+target_link_libraries(${BINARY} PUBLIC ${PROJECT_NAME}_lib gtest)

--- a/src/v2i-hub/ODEForwardPlugin/manifest.json
+++ b/src/v2i-hub/ODEForwardPlugin/manifest.json
@@ -8,7 +8,12 @@
 	"messageTypes":[
 		
 	],
-	"configuration":[
+	"configuration":[ 
+		{
+			"key": "LogLevel",
+			"default": "INFO",
+			"description": "The log level for this plugin"
+		},
 		{
 			"key":"instance",
 			"default":"1",
@@ -23,6 +28,11 @@
 			"key":"ForwardMSG",
 			"default":"1",
 			"description":"Enable forwarding of messages"
+		},
+		{
+			"key": "CommunicationMode",
+			"default": "UDP",
+			"description":"Communication mode to be used for UDP socket connection. Modes: Kafka or UDP"
 		},
 		{
 			"key":"BSMKafkaTopic",
@@ -45,28 +55,28 @@
 			"description":"Port number to be used for KAFKA broker"
 		},
 		{
-			"key": "CommunicationMode",
-			"default": "UDP",
-			"description":"Communication mode to be used for UDP socket connection. Modes: Kafka or UDP"
+			"key": "UDPServerIpAddress",
+			"default": "127.0.0.1",
+			"description":"IP address to be used for UDP socket connection."
 		},
 		{
 			"key": "TIMUDPPort",
-			"default": "24601",
+			"default": "47900",
 			"description":"Port number to be used for sending TIM message via UDP socket."
 		},
 		{
 			"key": "BSMUDPPort",
-			"default": "24601",
+			"default": "46800",
 			"description":"Port number to be used for sending BSM message via UDP socket."
 		},
 		{
 			"key": "MAPUDPPort",
-			"default": "24601",
+			"default": "44920",
 			"description":"Port number to be used for sending MAP message via UDP socket."
 		},
 		{
 			"key": "SPATUDPPort",
-			"default": "24601",
+			"default": "44910",
 			"description":"Port number to be used for sending SPAT message via UDP socket."
 		}
 	]

--- a/src/v2i-hub/ODEForwardPlugin/manifest.json
+++ b/src/v2i-hub/ODEForwardPlugin/manifest.json
@@ -43,8 +43,31 @@
 			"key":"KafkaBrokerPort",
 			"default":"9092",
 			"description":"Port number to be used for KAFKA broker"
+		},
+		{
+			"key": "CommunicationMode",
+			"default": "UDP",
+			"description":"Communication mode to be used for UDP socket connection. Modes: Kafka or UDP"
+		},
+		{
+			"key": "TIMUDPPort",
+			"default": "24601",
+			"description":"Port number to be used for sending TIM message via UDP socket."
+		},
+		{
+			"key": "BSMUDPPort",
+			"default": "24601",
+			"description":"Port number to be used for sending BSM message via UDP socket."
+		},
+		{
+			"key": "MAPUDPPort",
+			"default": "24601",
+			"description":"Port number to be used for sending MAP message via UDP socket."
+		},
+		{
+			"key": "SPATUDPPort",
+			"default": "24601",
+			"description":"Port number to be used for sending SPAT message via UDP socket."
 		}
-
-
 	]
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.cpp
@@ -16,11 +16,11 @@ namespace ODEForwardPlugin{
         _isUDPMode = compareCommunicationMode(modeSource, CommunicationMode::UDP);
     }
 
-    bool CommunicationModeHelper::getKafkaMode(){
+    bool CommunicationModeHelper::getKafkaMode() const{
         return _isKAFKAMode;
     }
 
-    bool CommunicationModeHelper::getUDPMode(){
+    bool CommunicationModeHelper::getUDPMode() const{
         return _isUDPMode;
     }
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.cpp
@@ -1,0 +1,26 @@
+#include "CommunicationModeHelper.h"
+
+namespace ODEForwardPlugin{
+
+    bool CommunicationModeHelper::compareCommunicationMode(std::string& modeSource, CommunicationMode modeDest){
+        boost::algorithm::trim(modeSource);
+        boost::algorithm::to_upper(modeSource);
+        if(boost::iequals(modeSource, _communicationModeMap.at(modeDest))){
+            return true;
+        }
+        return false;
+    }
+
+    void CommunicationModeHelper::setMode(std::string& modeSource){
+        _isKAFKAMode = compareCommunicationMode(modeSource, CommunicationMode::KAFKA);
+        _isUDPMode = compareCommunicationMode(modeSource, CommunicationMode::UDP);
+    }
+
+    bool CommunicationModeHelper::getKafkaMode(){
+        return _isKAFKAMode;
+    }
+
+    bool CommunicationModeHelper::getUDPMode(){
+        return _isUDPMode;
+    }
+}

--- a/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.cpp
@@ -12,15 +12,16 @@ namespace ODEForwardPlugin{
     }
 
     void CommunicationModeHelper::setMode(std::string& modeSource){
-        _isKAFKAMode = compareCommunicationMode(modeSource, CommunicationMode::KAFKA);
-        _isUDPMode = compareCommunicationMode(modeSource, CommunicationMode::UDP);
+        if(compareCommunicationMode(modeSource, CommunicationMode::KAFKA)){
+            _currentMode = CommunicationMode::KAFKA;
+        }else if(compareCommunicationMode(modeSource, CommunicationMode::UDP)){
+            _currentMode = CommunicationMode::UDP;
+        }else{
+            _currentMode = CommunicationMode::UNSUPPORTED;
+        }
     }
 
-    bool CommunicationModeHelper::getKafkaMode() const{
-        return _isKAFKAMode;
-    }
-
-    bool CommunicationModeHelper::getUDPMode() const{
-        return _isUDPMode;
+    CommunicationMode CommunicationModeHelper::getCurrentMode() const{
+        return _currentMode;
     }
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.h
@@ -49,13 +49,13 @@ namespace ODEForwardPlugin
          * @brief Get the Kafka mode
          * @return true if the communication mode is Kafka, false otherwise
          */
-        bool getKafkaMode();
+        bool getKafkaMode() const;
 
         /**
          * @brief Get the UDP mode
          * @return true if the communication mode is UDP, false otherwise
          **/
-        bool getUDPMode();
+        bool getUDPMode() const;
     };
     
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.h
@@ -13,15 +13,15 @@ namespace ODEForwardPlugin
      */
     enum class CommunicationMode{
         UDP,
-        KAFKA
+        KAFKA,
+        UNSUPPORTED
     };
 
     class CommunicationModeHelper
     {
     private:
-        //Indicator for the communication mode
-        bool _isKAFKAMode = false;
-        bool _isUDPMode = false;
+        //Indicator for the communication mode and default value is UNSUPPORTED
+        CommunicationMode _currentMode = CommunicationMode::UNSUPPORTED;
 
         //Map for communication mode to string
         std::unordered_map<CommunicationMode, std::string> _communicationModeMap = {
@@ -46,16 +46,10 @@ namespace ODEForwardPlugin
          */
         void setMode(std::string& modeSource);
         /**
-         * @brief Get the Kafka mode
-         * @return true if the communication mode is Kafka, false otherwise
+         * @brief Get the current communication mode
+         * @return CommunicationMode enum
          */
-        bool getKafkaMode() const;
-
-        /**
-         * @brief Get the UDP mode
-         * @return true if the communication mode is UDP, false otherwise
-         **/
-        bool getUDPMode() const;
+        CommunicationMode getCurrentMode() const;
     };
     
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/CommunicationModeHelper.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <unordered_map>
+#include <string>
+#include <boost/algorithm/string.hpp>
+#include <tmx/TmxException.hpp>
+
+using tmx::TmxException;
+
+namespace ODEForwardPlugin
+{
+    /**
+     * @brief Communication mode: UDP or Kafka
+     */
+    enum class CommunicationMode{
+        UDP,
+        KAFKA
+    };
+
+    class CommunicationModeHelper
+    {
+    private:
+        //Indicator for the communication mode
+        bool _isKAFKAMode = false;
+        bool _isUDPMode = false;
+
+        //Map for communication mode to string
+        std::unordered_map<CommunicationMode, std::string> _communicationModeMap = {
+            {CommunicationMode::UDP, "UDP"},
+            {CommunicationMode::KAFKA, "KAFKA"}
+        };
+    public:
+        CommunicationModeHelper()=default;
+        ~CommunicationModeHelper()=default;
+        /**
+         * @brief Compare the communication mode with the given mode
+         * @param modeSource The communication mode to be compared
+         * @param modeDest The communication mode to be compared with
+         * @return true if the communication mode matches, false otherwise
+         * @throws TmxException if the communication mode is unknown
+         */
+        bool compareCommunicationMode(std::string& modeSource, CommunicationMode modeDest);
+        /**
+         * @brief Set the mode (UDP or KAFKA) of the communication
+         * @param modeSource The communication mode to be set
+         * @throws TmxException if the communication mode is unknown
+         */
+        void setMode(std::string& modeSource);
+        /**
+         * @brief Get the Kafka mode
+         * @return true if the communication mode is Kafka, false otherwise
+         */
+        bool getKafkaMode();
+
+        /**
+         * @brief Get the UDP mode
+         * @return true if the communication mode is UDP, false otherwise
+         **/
+        bool getUDPMode();
+    };
+    
+}

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
@@ -219,6 +219,7 @@ void ODEForwardPlugin::sendBsmKafkaMessage(BsmMessage &msg, routeable_message &r
 
 void ODEForwardPlugin::sendUDPMessage(routeable_message &routeableMsg, UDPMessageType udpMessageType) const{
 	std::string message = routeableMsg.get_payload_str().c_str();
+	PLOG(logDEBUG) << "Sending UDP Message: " << message;
 	_udpMessageForwarder->sendMessage(udpMessageType, message);
 }
 

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
@@ -81,13 +81,13 @@
 	_communicationModeHelper->setMode(_communicationMode);	
 
 	//Throw an error if the communication mode is neither KAFKA not UDP
-	if(!(_communicationModeHelper->getKafkaMode() || _communicationModeHelper->getUDPMode())){
-		PLOG(logERROR) << "Unknown communication mode: " << _communicationMode;
-		throw TmxException("Unknown communication mode: " +_communicationMode);
+	if(_communicationModeHelper->getCurrentMode() == CommunicationMode::UNSUPPORTED){
+		PLOG(logERROR) << "Unsuppported communication mode: " << _communicationMode;
+		throw TmxException("Unsuppported communication mode: " +_communicationMode);
 	}
 	PLOG(logINFO) << "Communication Mode: " << _communicationMode;
 	
-	if(_communicationModeHelper->getUDPMode()){
+	if(_communicationModeHelper->getCurrentMode()==CommunicationMode::UDP){
 		//Create UDP clients for different messages
 		_udpMessageForwarder->attachUdpClient(UDPMessageType::BSM, std::make_shared<UdpClient>(_udpServerIpAddress, _BSMUDPPort));
 		_udpMessageForwarder->attachUdpClient(UDPMessageType::MAP, std::make_shared<UdpClient>(_udpServerIpAddress, _MAPUDPPort));
@@ -95,7 +95,7 @@
 		_udpMessageForwarder->attachUdpClient(UDPMessageType::SPAT, std::make_shared<UdpClient>(_udpServerIpAddress, _SPATUDPPort));
 	}
 
-	if(_communicationModeHelper->getKafkaMode()){
+	if(_communicationModeHelper->getCurrentMode() == CommunicationMode::KAFKA){
 		kafkaConnectString = _kafkaBrokerIp + ':' + _kafkaBrokerPort;
 		std::string error_string;
 		_freqCounter=1;
@@ -166,39 +166,39 @@
   * @routeable_message not used
   */
  void ODEForwardPlugin::HandleRealTimePublish(BsmMessage &msg, routeable_message &routeableMsg) {
-	if(_communicationModeHelper->getUDPMode()){
+	if(_communicationModeHelper->getCurrentMode()== CommunicationMode::UDP){
 		sendUDPMessage(routeableMsg, UDPMessageType::BSM);
-	}else if(_communicationModeHelper->getKafkaMode()){
+	}else if(_communicationModeHelper->getCurrentMode() == CommunicationMode::KAFKA){
 		sendBsmKafkaMessage(msg, routeableMsg);
 	}else{
-		PLOG(logERROR) << "Unknown communication mode: " << _communicationMode;
+		PLOG(logERROR) << "Unsuppported communication mode: " << _communicationMode;
 	}
  }
 
  void ODEForwardPlugin::HandleSPaTPublish(SpatMessage &msg, routeable_message &routeableMsg) {
-	if(_communicationModeHelper->getUDPMode()){
+	if(_communicationModeHelper->getCurrentMode() == CommunicationMode::UDP){
 		sendUDPMessage(routeableMsg, UDPMessageType::SPAT);
-	}else if(_communicationModeHelper->getKafkaMode()){
+	}else if(_communicationModeHelper->getCurrentMode() == CommunicationMode::KAFKA){
 		sendSpatKafkaMessage(msg, routeableMsg);
 	}else{
-		PLOG(logERROR) << "Unknown communication mode: " << _communicationMode;
+		PLOG(logERROR) << "Unsuppported communication mode: " << _communicationMode;
 	}
  }
 
  void ODEForwardPlugin::HandleTimPublish(TimMessage &msg, routeable_message &routeableMsg) {
-	if(_communicationModeHelper->getUDPMode()){
+	if(_communicationModeHelper->getCurrentMode() == CommunicationMode::UDP){
 		sendUDPMessage(routeableMsg, UDPMessageType::TIM);
 	}else{
-		PLOG(logERROR) << "Unknown communication mode: " << _communicationMode;
+		PLOG(logERROR) << "Unsuppported communication mode: " << _communicationMode;
 	}
  }
 
 
  void ODEForwardPlugin::HandleMapPublish(MapDataMessage &msg, routeable_message &routeableMsg) {
-	if(_communicationModeHelper->getUDPMode()){
+	if(_communicationModeHelper->getCurrentMode() == CommunicationMode::UDP){
 		sendUDPMessage(routeableMsg, UDPMessageType::MAP);
 	}else{
-		PLOG(logERROR) << "Unknown communication mode: " << _communicationMode;
+		PLOG(logERROR) << "Unsuppported communication mode: " << _communicationMode;
 	}
  }
 

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
@@ -167,7 +167,7 @@
   */
  void ODEForwardPlugin::HandleRealTimePublish(BsmMessage &msg, routeable_message &routeableMsg) {
 	if(_communicationModeHelper->getUDPMode()){
-		sendBsmUDPMessage(msg, routeableMsg);
+		sendUDPMessage(routeableMsg, UDPMessageType::BSM);
 	}else if(_communicationModeHelper->getKafkaMode()){
 		sendBsmKafkaMessage(msg, routeableMsg);
 	}else{
@@ -177,7 +177,7 @@
 
  void ODEForwardPlugin::HandleSPaTPublish(SpatMessage &msg, routeable_message &routeableMsg) {
 	if(_communicationModeHelper->getUDPMode()){
-		sendSpatUDPMessage(msg, routeableMsg);
+		sendUDPMessage(routeableMsg, UDPMessageType::SPAT);
 	}else if(_communicationModeHelper->getKafkaMode()){
 		sendSpatKafkaMessage(msg, routeableMsg);
 	}else{
@@ -187,7 +187,7 @@
 
  void ODEForwardPlugin::HandleTimPublish(TimMessage &msg, routeable_message &routeableMsg) {
 	if(_communicationModeHelper->getUDPMode()){
-		sendTimUDPMessage(msg, routeableMsg);
+		sendUDPMessage(routeableMsg, UDPMessageType::TIM);
 	}else{
 		PLOG(logERROR) << "Unknown communication mode: " << _communicationMode;
 	}
@@ -196,7 +196,7 @@
 
  void ODEForwardPlugin::HandleMapPublish(MapDataMessage &msg, routeable_message &routeableMsg) {
 	if(_communicationModeHelper->getUDPMode()){
-		sendMapUDPMessage(msg, routeableMsg);
+		sendUDPMessage(routeableMsg, UDPMessageType::MAP);
 	}else{
 		PLOG(logERROR) << "Unknown communication mode: " << _communicationMode;
 	}
@@ -217,28 +217,9 @@ void ODEForwardPlugin::sendBsmKafkaMessage(BsmMessage &msg, routeable_message &r
 		delete [] teststring;
 }
 
-void ODEForwardPlugin::sendBsmUDPMessage(BsmMessage &msg, routeable_message &routeableMsg) const{
+void ODEForwardPlugin::sendUDPMessage(routeable_message &routeableMsg, UDPMessageType udpMessageType) const{
 	std::string message = routeableMsg.get_payload_str().c_str();
-	PLOG(logDEBUG1) << "BSM: " << message;
-	_udpMessageForwarder->sendMessage(UDPMessageType::BSM, message);
-}
-
-void ODEForwardPlugin::sendSpatUDPMessage(SpatMessage &msg, routeable_message &routeableMsg) const{
-	std::string message = routeableMsg.get_payload_str().c_str();
-	PLOG(logDEBUG1) << "SPAT: " << message;
-	_udpMessageForwarder->sendMessage(UDPMessageType::SPAT, message);
-}
-
-void ODEForwardPlugin::sendTimUDPMessage(TimMessage &msg, routeable_message &routeableMsg) const{
-	std::string message = routeableMsg.get_payload_str().c_str();
-	PLOG(logDEBUG1) << "TIM: " << message;
-	_udpMessageForwarder->sendMessage(UDPMessageType::TIM, message);
-}
-
-void ODEForwardPlugin::sendMapUDPMessage(MapDataMessage &msg, routeable_message &routeableMsg) const{
-	std::string message = routeableMsg.get_payload_str().c_str();
-	PLOG(logDEBUG1) << "MAP: " << message;
-	_udpMessageForwarder->sendMessage(UDPMessageType::MAP, message);
+	_udpMessageForwarder->sendMessage(udpMessageType, message);
 }
 
  void ODEForwardPlugin::sendSpatKafkaMessage(SpatMessage &msg, routeable_message &routeableMsg){

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
@@ -83,11 +83,11 @@
 
  	void QueueKafkaMessage(RdKafka::Producer *producer, std::string topic, std::string message);
 	void sendSpatKafkaMessage(SpatMessage &msg, routeable_message &routeableMsg);
-	void sendSpatUDPMessage(SpatMessage &msg, routeable_message &routeableMsg);
+	void sendSpatUDPMessage(SpatMessage &msg, routeable_message &routeableMsg) const;
 	void sendBsmKafkaMessage(BsmMessage &msg, routeable_message &routeableMsg);
-	void sendBsmUDPMessage(BsmMessage &msg, routeable_message &routeableMsg);
-	void sendTimUDPMessage(TimMessage &msg, routeable_message &routeableMsg);
-	void sendMapUDPMessage(MapDataMessage &msg, routeable_message &routeableMsg);
+	void sendBsmUDPMessage(BsmMessage &msg, routeable_message &routeableMsg) const;
+	void sendTimUDPMessage(TimMessage &msg, routeable_message &routeableMsg) const;
+	void sendMapUDPMessage(MapDataMessage &msg, routeable_message &routeableMsg) const;
 
  	uint16_t _scheduleFrequency;
 	uint16_t _freqCounter;

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
@@ -29,14 +29,20 @@
  #include <chrono>
  #include <atomic>
  #include <thread>
+ #include <boost/algorithm/string.hpp>
  #include <tmx/messages/IvpJ2735.h>
  #include <tmx/j2735_messages/BasicSafetyMessage.hpp>
  #include <tmx/j2735_messages/SpatMessage.hpp>
+ #include <tmx/j2735_messages/TravelerInformationMessage.hpp>
+ #include <tmx/j2735_messages/MapDataMessage.hpp>
  #include <BasicSafetyMessage.h>
  #include <tmx/messages/auto_message.hpp>
  #include <librdkafka/rdkafkacpp.h>
  #include <tmx/json/cJSON.h>
  #include "/usr/local/include/date/date.h"
+ #include "UDPMessageForwarder.h"
+ #include "CommunicationModeHelper.h"
+
  
  using namespace std;
  using namespace tmx;
@@ -68,12 +74,20 @@
 
  	void HandleRealTimePublish(BsmMessage &msg, routeable_message &routeableMsg);
  	void HandleSPaTPublish(SpatMessage &msg, routeable_message &routeableMsg);
+ 	void HandleTimPublish(TimMessage &msg, routeable_message &routeableMsg);
+ 	void HandleMapPublish(MapDataMessage &msg, routeable_message &routeableMsg);
 
  private:
  	std::atomic<uint64_t> _frequency{0};
  	DATA_MONITOR(_frequency);   // Declares the
 
  	void QueueKafkaMessage(RdKafka::Producer *producer, std::string topic, std::string message);
+	void sendSpatKafkaMessage(SpatMessage &msg, routeable_message &routeableMsg);
+	void sendSpatUDPMessage(SpatMessage &msg, routeable_message &routeableMsg);
+	void sendBsmKafkaMessage(BsmMessage &msg, routeable_message &routeableMsg);
+	void sendBsmUDPMessage(BsmMessage &msg, routeable_message &routeableMsg);
+	void sendTimUDPMessage(TimMessage &msg, routeable_message &routeableMsg);
+	void sendMapUDPMessage(MapDataMessage &msg, routeable_message &routeableMsg);
 
  	uint16_t _scheduleFrequency;
 	uint16_t _freqCounter;
@@ -85,6 +99,14 @@
  	std::string kafkaConnectString;
  	RdKafka::Conf *kafka_conf;
  	RdKafka::Producer *kafka_producer;
+	int _MAPUDPPort;
+	int _TIMUDPPort;
+	int _BSMUDPPort;
+	int _SPATUDPPort;
+	std::string _communicationMode;
+	std::string _udpServerIpAddress;
+	std::shared_ptr<UDPMessageForwarder> _udpMessageForwarder;
+	std::shared_ptr<CommunicationModeHelper> _communicationModeHelper;
  };
  std::mutex _cfgLock;
 

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
@@ -83,11 +83,8 @@
 
  	void QueueKafkaMessage(RdKafka::Producer *producer, std::string topic, std::string message);
 	void sendSpatKafkaMessage(SpatMessage &msg, routeable_message &routeableMsg);
-	void sendSpatUDPMessage(SpatMessage &msg, routeable_message &routeableMsg) const;
 	void sendBsmKafkaMessage(BsmMessage &msg, routeable_message &routeableMsg);
-	void sendBsmUDPMessage(BsmMessage &msg, routeable_message &routeableMsg) const;
-	void sendTimUDPMessage(TimMessage &msg, routeable_message &routeableMsg) const;
-	void sendMapUDPMessage(MapDataMessage &msg, routeable_message &routeableMsg) const;
+	void sendUDPMessage(routeable_message &routeableMsg, UDPMessageType udpMessageType) const;
 
  	uint16_t _scheduleFrequency;
 	uint16_t _freqCounter;

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
@@ -29,6 +29,10 @@ namespace ODEForwardPlugin
     }
 
     std::shared_ptr<UdpClient> UDPMessageForwarder::getUdpClient(UDPMessageType messageType){
-        return _udpClientsMap[messageType];
+        try{
+            return _udpClientsMap.at(messageType);
+        }catch(const std::out_of_range& oor){
+            throw TmxException("UDP Client not found for message type");
+        }
     }
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
@@ -5,9 +5,12 @@ namespace ODEForwardPlugin
 {
     void UDPMessageForwarder::sendMessage(UDPMessageType messageType, const std::string& message){
         try{
-            _udpClientsMap.at(messageType)->Send(message);
+            auto messageBytes = hexToBytes(message);
+            _udpClientsMap.at(messageType)->Send(messageBytes);
         }catch(const std::out_of_range& ex){
             throw TmxException("UDP Client not found for message type. Error message: " + std::string(ex.what()));
+        }catch(const std::invalid_argument& ex){
+            throw TmxException("Invalid hex string. Error message: " + std::string(ex.what()));
         }
     }
 
@@ -34,5 +37,16 @@ namespace ODEForwardPlugin
         }catch(const std::out_of_range& ex){
             throw TmxException("UDP Client not found for message type. Error message: " + std::string(ex.what()));
         }
+    }
+
+    std::string UDPMessageForwarder::hexToBytes(const std::string& hex) const{
+        std::vector<unsigned char> bytes;
+        for (size_t i = 0; i < hex.length(); i += 2) {
+            std::string byteString = hex.substr(i, 2);
+            unsigned char byte = static_cast<unsigned char>(std::stoul(byteString, nullptr, 16));
+            bytes.push_back(byte);
+        }
+        std::cout << std::endl;
+        return std::string(bytes.begin(), bytes.end());
     }
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
@@ -6,8 +6,8 @@ namespace ODEForwardPlugin
     void UDPMessageForwarder::sendMessage(UDPMessageType messageType, const std::string& message){
         try{
             _udpClientsMap.at(messageType)->Send(message);
-        }catch(const std::out_of_range& oor){
-            throw TmxException("UDP Client not found for message type");
+        }catch(const std::out_of_range& ex){
+            throw TmxException("UDP Client not found for message type. Error message: " + std::string(ex.what()));
         }
     }
 
@@ -19,16 +19,16 @@ namespace ODEForwardPlugin
         _udpClientsMap.insert(std::make_pair(messageType, udpClient));
     }
 
-    std::vector<UDPMessageType> UDPMessageForwarder::getAllUdpClientMessageTypes(){
+    std::vector<UDPMessageType> UDPMessageForwarder::getAllUdpClientMessageTypes() const{
         std::vector<UDPMessageType> udpClientTypes;
-        for(auto& udpClient : _udpClientsMap){
+        for(const auto& udpClient : _udpClientsMap){
             //Push the udp message type to the vector
             udpClientTypes.push_back(udpClient.first);
         }
         return udpClientTypes;
     }
 
-    std::shared_ptr<UdpClient> UDPMessageForwarder::getUdpClient(UDPMessageType messageType){
+    std::shared_ptr<UdpClient> UDPMessageForwarder::getUdpClient(UDPMessageType messageType) const{
         try{
             return _udpClientsMap.at(messageType);
         }catch(const std::out_of_range& oor){

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
@@ -31,8 +31,8 @@ namespace ODEForwardPlugin
     std::shared_ptr<UdpClient> UDPMessageForwarder::getUdpClient(UDPMessageType messageType) const{
         try{
             return _udpClientsMap.at(messageType);
-        }catch(const std::out_of_range& oor){
-            throw TmxException("UDP Client not found for message type");
+        }catch(const std::out_of_range& ex){
+            throw TmxException("UDP Client not found for message type. Error message: " + std::string(ex.what()));
         }
     }
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
@@ -46,7 +46,6 @@ namespace ODEForwardPlugin
             unsigned char byte = static_cast<unsigned char>(std::stoul(byteString, nullptr, 16));
             bytes.push_back(byte);
         }
-        std::cout << std::endl;
         return std::string(bytes.begin(), bytes.end());
     }
 }

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.cpp
@@ -1,0 +1,34 @@
+#include "UDPMessageForwarder.h"
+
+
+namespace ODEForwardPlugin
+{
+    void UDPMessageForwarder::sendMessage(UDPMessageType messageType, const std::string& message){
+        try{
+            _udpClientsMap.at(messageType)->Send(message);
+        }catch(const std::out_of_range& oor){
+            throw TmxException("UDP Client not found for message type");
+        }
+    }
+
+    void UDPMessageForwarder::attachUdpClient(UDPMessageType messageType, std::shared_ptr<UdpClient> udpClient){
+        //If udp client exists for a message type, remove it first
+        if(_udpClientsMap.find(messageType) != _udpClientsMap.end()){
+            _udpClientsMap.erase(messageType);
+        }
+        _udpClientsMap.insert(std::make_pair(messageType, udpClient));
+    }
+
+    std::vector<UDPMessageType> UDPMessageForwarder::getAllUdpClientMessageTypes(){
+        std::vector<UDPMessageType> udpClientTypes;
+        for(auto& udpClient : _udpClientsMap){
+            //Push the udp message type to the vector
+            udpClientTypes.push_back(udpClient.first);
+        }
+        return udpClientTypes;
+    }
+
+    std::shared_ptr<UdpClient> UDPMessageForwarder::getUdpClient(UDPMessageType messageType){
+        return _udpClientsMap[messageType];
+    }
+}

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <UdpClient.h>
+#include <unordered_map>
+#include <tmx/TmxException.hpp>
+#include <vector>
+
+using tmx::utils::UdpClient;
+using tmx::TmxException;
+
+namespace ODEForwardPlugin
+{
+    /**
+     * @brief UDP message type: TIM, MAP, SPAT, BSM
+     */
+    enum class UDPMessageType{
+        TIM,
+        MAP,
+        SPAT,
+        BSM
+    };
+
+    class UDPMessageForwarder
+    {
+    private:
+        //Map for udp client and udp message type
+        std::unordered_map<UDPMessageType, std::shared_ptr<UdpClient>> _udpClientsMap;
+    public:
+        explicit UDPMessageForwarder() = default;
+        ~UDPMessageForwarder() = default;
+        /**
+         * @brief Send difference type of messages to via their corresponding udp client
+         * @param messageType The message type to be sent
+         * @param message The message to be sent
+         */
+        void sendMessage(UDPMessageType messageType, const std::string& message);
+        /***
+         * @brief Attach the corresponding udp client to the message type
+         * @param messageType Given message type
+         * @param udpClient The udp client to be attached
+         */
+        void attachUdpClient(UDPMessageType messageType, std::shared_ptr<UdpClient> udpClient);
+
+        /**
+         * @brief Get all udp client message types
+         * @return A vector of all udp client message types
+         */
+        std::vector<UDPMessageType> getAllUdpClientMessageTypes();
+
+        /**
+         * @brief Get the udp client for a given message type
+         * @return The udp client for the given message type
+         */
+        std::shared_ptr<UdpClient> getUdpClient(UDPMessageType messageType);
+
+    };    
+} 

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.h
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include <tmx/TmxException.hpp>
 #include <vector>
+#include <bitset>
 
 using tmx::utils::UdpClient;
 using tmx::TmxException;
@@ -51,6 +52,12 @@ namespace ODEForwardPlugin
          * @return The udp client for the given message type
          */
         std::shared_ptr<UdpClient> getUdpClient(UDPMessageType messageType) const;
+        /**
+         * @brief Convert hex string to bytes string
+         * @param hex The hex string to be converted
+         * @return The bytes string
+         */
+        std::string hexToBytes(const std::string& hex) const;
 
     };    
 } 

--- a/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/UDPMessageForwarder.h
@@ -44,13 +44,13 @@ namespace ODEForwardPlugin
          * @brief Get all udp client message types
          * @return A vector of all udp client message types
          */
-        std::vector<UDPMessageType> getAllUdpClientMessageTypes();
+        std::vector<UDPMessageType> getAllUdpClientMessageTypes() const;
 
         /**
          * @brief Get the udp client for a given message type
          * @return The udp client for the given message type
          */
-        std::shared_ptr<UdpClient> getUdpClient(UDPMessageType messageType);
+        std::shared_ptr<UdpClient> getUdpClient(UDPMessageType messageType) const;
 
     };    
 } 

--- a/src/v2i-hub/ODEForwardPlugin/test/main.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/test/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv){
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/v2i-hub/ODEForwardPlugin/test/test_CommunicationModeHelper.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/test/test_CommunicationModeHelper.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include "CommunicationModeHelper.h"
+
+namespace ODEForwardPlugin{
+    class test_CommunicationModeHelper: public ::testing::Test{
+        protected:
+            std::shared_ptr<ODEForwardPlugin::CommunicationModeHelper>  _communicationModeHelper = std::make_shared<CommunicationModeHelper>();
+    };
+
+    TEST_F(test_CommunicationModeHelper, test_compareCommunicationMode_Kafka){
+        std::string modeSource = "KAFKA";
+        EXPECT_TRUE(_communicationModeHelper->compareCommunicationMode(modeSource, CommunicationMode::KAFKA));
+    }
+
+    TEST_F(test_CommunicationModeHelper, test_compareCommunicationMode_UDP){
+        std::string modeSource = "UDP";
+        EXPECT_TRUE(_communicationModeHelper->compareCommunicationMode(modeSource, CommunicationMode::UDP));
+    }
+
+    TEST_F(test_CommunicationModeHelper, test_compareCommunicationMode_Unknown){
+        std::string modeSource = "UNKNOWN";
+        EXPECT_FALSE(_communicationModeHelper->compareCommunicationMode(modeSource, CommunicationMode::UDP));
+    }
+
+    TEST_F(test_CommunicationModeHelper, test_setMode_Kafka){
+        std::string modeSource = "KAFKA";
+        _communicationModeHelper->setMode(modeSource);
+        EXPECT_TRUE(_communicationModeHelper->getKafkaMode());
+        EXPECT_FALSE(_communicationModeHelper->getUDPMode());
+    }
+
+    TEST_F(test_CommunicationModeHelper, test_setMode_UDP){
+        std::string modeSource = "UDP";
+        _communicationModeHelper->setMode(modeSource);
+        EXPECT_TRUE(_communicationModeHelper->getUDPMode());
+        EXPECT_FALSE(_communicationModeHelper->getKafkaMode());
+    }
+
+    TEST_F(test_CommunicationModeHelper, test_setMode_Unknown){
+        std::string modeSource = "UNKNOWN";
+        _communicationModeHelper->setMode(modeSource);
+        EXPECT_FALSE(_communicationModeHelper->getKafkaMode());
+        EXPECT_FALSE(_communicationModeHelper->getUDPMode());
+    }
+
+    TEST_F(test_CommunicationModeHelper, test_getKafkaMode){
+        std::string modeSource = "KAFKA";
+        _communicationModeHelper->setMode(modeSource);
+        EXPECT_TRUE(_communicationModeHelper->getKafkaMode());
+    }
+    
+    TEST_F(test_CommunicationModeHelper, test_getKafkaMode_UDP){
+        std::string modeSource = "UDP";
+        _communicationModeHelper->setMode(modeSource);
+        EXPECT_FALSE(_communicationModeHelper->getKafkaMode());
+    }
+}

--- a/src/v2i-hub/ODEForwardPlugin/test/test_CommunicationModeHelper.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/test/test_CommunicationModeHelper.cpp
@@ -17,41 +17,41 @@ namespace ODEForwardPlugin{
         EXPECT_TRUE(_communicationModeHelper->compareCommunicationMode(modeSource, CommunicationMode::UDP));
     }
 
-    TEST_F(test_CommunicationModeHelper, test_compareCommunicationMode_Unknown){
-        std::string modeSource = "UNKNOWN";
+    TEST_F(test_CommunicationModeHelper, test_compareCommunicationMode_UNSUPPORTED){
+        std::string modeSource = "UNSUPPORTED";
         EXPECT_FALSE(_communicationModeHelper->compareCommunicationMode(modeSource, CommunicationMode::UDP));
     }
 
     TEST_F(test_CommunicationModeHelper, test_setMode_Kafka){
         std::string modeSource = "KAFKA";
         _communicationModeHelper->setMode(modeSource);
-        EXPECT_TRUE(_communicationModeHelper->getKafkaMode());
-        EXPECT_FALSE(_communicationModeHelper->getUDPMode());
+        EXPECT_TRUE(_communicationModeHelper->getCurrentMode()==CommunicationMode::KAFKA);
+        EXPECT_FALSE(_communicationModeHelper->getCurrentMode()==CommunicationMode::UDP);
     }
 
     TEST_F(test_CommunicationModeHelper, test_setMode_UDP){
         std::string modeSource = "UDP";
         _communicationModeHelper->setMode(modeSource);
-        EXPECT_TRUE(_communicationModeHelper->getUDPMode());
-        EXPECT_FALSE(_communicationModeHelper->getKafkaMode());
+        EXPECT_TRUE(_communicationModeHelper->getCurrentMode()==CommunicationMode::UDP);
+        EXPECT_FALSE(_communicationModeHelper->getCurrentMode()==CommunicationMode::KAFKA);
     }
 
-    TEST_F(test_CommunicationModeHelper, test_setMode_Unknown){
-        std::string modeSource = "UNKNOWN";
+    TEST_F(test_CommunicationModeHelper, test_setMode_UNSUPPORTED){
+        std::string modeSource = "UNSUPPORTED";
         _communicationModeHelper->setMode(modeSource);
-        EXPECT_FALSE(_communicationModeHelper->getKafkaMode());
-        EXPECT_FALSE(_communicationModeHelper->getUDPMode());
+        EXPECT_FALSE(_communicationModeHelper->getCurrentMode()==CommunicationMode::KAFKA);
+        EXPECT_FALSE(_communicationModeHelper->getCurrentMode()==CommunicationMode::UDP);
     }
 
     TEST_F(test_CommunicationModeHelper, test_getKafkaMode){
         std::string modeSource = "KAFKA";
         _communicationModeHelper->setMode(modeSource);
-        EXPECT_TRUE(_communicationModeHelper->getKafkaMode());
+        EXPECT_TRUE(_communicationModeHelper->getCurrentMode()==CommunicationMode::KAFKA);
     }
     
     TEST_F(test_CommunicationModeHelper, test_getKafkaMode_UDP){
         std::string modeSource = "UDP";
         _communicationModeHelper->setMode(modeSource);
-        EXPECT_FALSE(_communicationModeHelper->getKafkaMode());
+        EXPECT_FALSE(_communicationModeHelper->getCurrentMode()==CommunicationMode::KAFKA);
     }
 }

--- a/src/v2i-hub/ODEForwardPlugin/test/test_UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/test/test_UDPMessageForwarder.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+#include "UDPMessageForwarder.h"
+
+namespace ODEForwardPlugin{
+    class test_UDPMessageForwarder: public ::testing::Test{
+        protected:
+            std::shared_ptr<ODEForwardPlugin::UDPMessageForwarder>  _udpMessageForwarder = std::make_shared<UDPMessageForwarder>();
+    };
+
+    TEST_F(test_UDPMessageForwarder, test_sendMessage_BEFORE_ATTACH_UDP_CLIENT){
+        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::TIM, "test"), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::BSM, "test"), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::SPAT, "test"), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::MAP, "test"), TmxException);
+    }
+
+    TEST_F(test_UDPMessageForwarder, test_attachUdpClient){
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::TIM, std::make_shared<UdpClient>("127.0.0.1", 1232));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::BSM, std::make_shared<UdpClient>("127.0.0.1", 1233));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::MAP, std::make_shared<UdpClient>("127.0.0.1", 1234));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::SPAT, std::make_shared<UdpClient>("127.0.0.1", 1235));
+    }
+
+    TEST_F(test_UDPMessageForwarder, test_sendMessage_AFTER_ATTACH_UDP_CLIENT){
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::TIM, std::make_shared<UdpClient>("127.0.0.1", 1232));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::BSM, std::make_shared<UdpClient>("127.0.0.1", 1233));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::MAP, std::make_shared<UdpClient>("127.0.0.1", 1234));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::SPAT, std::make_shared<UdpClient>("127.0.0.1", 1235));
+        _udpMessageForwarder->sendMessage(UDPMessageType::TIM, "test");
+        _udpMessageForwarder->sendMessage(UDPMessageType::BSM, "test");
+        _udpMessageForwarder->sendMessage(UDPMessageType::SPAT, "test");
+        _udpMessageForwarder->sendMessage(UDPMessageType::MAP, "test");
+    }
+
+    TEST_F(test_UDPMessageForwarder, test_getAllUdpClientMessageTypes){
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::TIM, std::make_shared<UdpClient>("127.0.0.1", 1232));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::BSM, std::make_shared<UdpClient>("127.0.0.1", 1233));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::MAP, std::make_shared<UdpClient>("127.0.0.1", 1234));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::SPAT, std::make_shared<UdpClient>("127.0.0.1", 1235));
+        auto allUdpClientMessageTypes = _udpMessageForwarder->getAllUdpClientMessageTypes();
+        EXPECT_EQ(allUdpClientMessageTypes.size(), 4);
+        EXPECT_TRUE(std::find(allUdpClientMessageTypes.begin(), allUdpClientMessageTypes.end(), UDPMessageType::TIM) != allUdpClientMessageTypes.end());
+        EXPECT_TRUE(std::find(allUdpClientMessageTypes.begin(), allUdpClientMessageTypes.end(), UDPMessageType::BSM) != allUdpClientMessageTypes.end());
+        EXPECT_TRUE(std::find(allUdpClientMessageTypes.begin(), allUdpClientMessageTypes.end(), UDPMessageType::SPAT) != allUdpClientMessageTypes.end());
+        EXPECT_TRUE(std::find(allUdpClientMessageTypes.begin(), allUdpClientMessageTypes.end(), UDPMessageType::MAP) != allUdpClientMessageTypes.end());
+    }
+
+    TEST_F(test_UDPMessageForwarder, test_getUdpClient){
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::TIM, std::make_shared<UdpClient>("127.0.0.1", 1232));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::BSM, std::make_shared<UdpClient>("127.0.0.1", 1233));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::MAP, std::make_shared<UdpClient>("127.0.0.1", 1234));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::SPAT, std::make_shared<UdpClient>("127.0.0.1", 1235));
+        EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::TIM)->GetPort(), 1232);
+        EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::BSM)->GetPort(), 1233);
+        EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::MAP)->GetPort(), 1234);
+        EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::SPAT)->GetPort(), 1235);
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::TIM, std::make_shared<UdpClient>("127.0.0.1", 2232));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::BSM, std::make_shared<UdpClient>("127.0.0.1", 2233));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::MAP, std::make_shared<UdpClient>("127.0.0.1", 2234));
+        _udpMessageForwarder->attachUdpClient(UDPMessageType::SPAT, std::make_shared<UdpClient>("127.0.0.1", 2235));
+        EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::TIM)->GetPort(), 2232);
+        EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::BSM)->GetPort(), 2233);
+        EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::MAP)->GetPort(), 2234);
+        EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::SPAT)->GetPort(), 2235);
+    }
+}

--- a/src/v2i-hub/ODEForwardPlugin/test/test_UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/test/test_UDPMessageForwarder.cpp
@@ -45,7 +45,14 @@ namespace ODEForwardPlugin{
         EXPECT_TRUE(std::find(allUdpClientMessageTypes.begin(), allUdpClientMessageTypes.end(), UDPMessageType::MAP) != allUdpClientMessageTypes.end());
     }
 
-    TEST_F(test_UDPMessageForwarder, test_getUdpClient){
+    TEST_F(test_UDPMessageForwarder, test_getUdpClient_BEFORE_ATTACH_UDP_CLIENT){
+        EXPECT_THROW(_udpMessageForwarder->getUdpClient(UDPMessageType::TIM), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->getUdpClient(UDPMessageType::BSM), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->getUdpClient(UDPMessageType::SPAT), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->getUdpClient(UDPMessageType::MAP), TmxException);
+    }
+    
+    TEST_F(test_UDPMessageForwarder, test_getUdpClient_AFTER_ATTACH_UDP_CLIENT){
         _udpMessageForwarder->attachUdpClient(UDPMessageType::TIM, std::make_shared<UdpClient>("127.0.0.1", 1232));
         _udpMessageForwarder->attachUdpClient(UDPMessageType::BSM, std::make_shared<UdpClient>("127.0.0.1", 1233));
         _udpMessageForwarder->attachUdpClient(UDPMessageType::MAP, std::make_shared<UdpClient>("127.0.0.1", 1234));

--- a/src/v2i-hub/ODEForwardPlugin/test/test_UDPMessageForwarder.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/test/test_UDPMessageForwarder.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <strstream>
 #include "UDPMessageForwarder.h"
 
 namespace ODEForwardPlugin{
@@ -8,10 +9,10 @@ namespace ODEForwardPlugin{
     };
 
     TEST_F(test_UDPMessageForwarder, test_sendMessage_BEFORE_ATTACH_UDP_CLIENT){
-        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::TIM, "test"), TmxException);
-        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::BSM, "test"), TmxException);
-        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::SPAT, "test"), TmxException);
-        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::MAP, "test"), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::TIM, "fffe4386ba00078005a53373"), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::BSM, "fffe4386ba00078005a53373"), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::SPAT, "fffe4386ba00078005a53373"), TmxException);
+        EXPECT_THROW(_udpMessageForwarder->sendMessage(UDPMessageType::MAP, "fffe4386ba00078005a53373"), TmxException);
     }
 
     TEST_F(test_UDPMessageForwarder, test_attachUdpClient){
@@ -26,10 +27,10 @@ namespace ODEForwardPlugin{
         _udpMessageForwarder->attachUdpClient(UDPMessageType::BSM, std::make_shared<UdpClient>("127.0.0.1", 1233));
         _udpMessageForwarder->attachUdpClient(UDPMessageType::MAP, std::make_shared<UdpClient>("127.0.0.1", 1234));
         _udpMessageForwarder->attachUdpClient(UDPMessageType::SPAT, std::make_shared<UdpClient>("127.0.0.1", 1235));
-        _udpMessageForwarder->sendMessage(UDPMessageType::TIM, "test");
-        _udpMessageForwarder->sendMessage(UDPMessageType::BSM, "test");
-        _udpMessageForwarder->sendMessage(UDPMessageType::SPAT, "test");
-        _udpMessageForwarder->sendMessage(UDPMessageType::MAP, "test");
+        _udpMessageForwarder->sendMessage(UDPMessageType::TIM, "fffe4386ba00078005a53373");
+        _udpMessageForwarder->sendMessage(UDPMessageType::BSM, "fffe4386ba00078005a53373");
+        _udpMessageForwarder->sendMessage(UDPMessageType::SPAT, "fffe4386ba00078005a53373");
+        _udpMessageForwarder->sendMessage(UDPMessageType::MAP, "fffe4386ba00078005a53373");
     }
 
     TEST_F(test_UDPMessageForwarder, test_getAllUdpClientMessageTypes){
@@ -69,5 +70,17 @@ namespace ODEForwardPlugin{
         EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::BSM)->GetPort(), 2233);
         EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::MAP)->GetPort(), 2234);
         EXPECT_EQ(_udpMessageForwarder->getUdpClient(UDPMessageType::SPAT)->GetPort(), 2235);
+    }
+
+    TEST_F(test_UDPMessageForwarder, test_hexToBytes){
+        //TIM Hex to bytes
+        std::string timHex = "001f526011c35d000000000023667bac0407299b9ef9e7a9b9408230dfffe4386ba00078005a53373df3cf5372810461b90ffff53373df3cf53728104618129800010704a04c7d7976ca3501872e1bb66ad19b2620";
+        std::string expectedBytes="031829617195930000035102123172474115515824923116918564130482232552285610716001200908355612432078311412949718515255245511152236024555401670241815201741607612512111820253113546271821062091553832";
+        std::string bytesResult = _udpMessageForwarder->hexToBytes(timHex);
+        std::stringstream bytesToIntResult;
+        for(unsigned char byte: bytesResult){
+            bytesToIntResult << (int)byte;
+        }
+       EXPECT_EQ(bytesToIntResult.str(), expectedBytes);
     }
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update ODEForwardPlugin to send UDP packet to remote UDP server ([ODE code base](https://github.com/usdot-jpo-ode)) by updating the following:
- Add ODEForwardPlugin communication mode: KAFKA or UDP
- Add UDP Clients to support different types of J2735 message forwarding as ODE server accept different UDP port connection for different J2735 messages.
- Update ODEForwardPlugin to support MAP (UDP socket only), SPAT (Both UDP and KAFKA), TIM (UDP socket only), BSM (Both UDP and KAFKA) messages

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
5GAA demo and integration with ODE
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
