### PR TITLE
Fix dev container syntax and set default mode to simulation=false

### DIFF
--- a/.devcontainer/docker-compose-vscode.yml
+++ b/.devcontainer/docker-compose-vscode.yml
@@ -12,19 +12,20 @@ services:
     # Overrides default command so things don't shut down after the process ends.
     command: /bin/sh -c "while sleep 1000; do :; done"  
     environment:
-      - MYSQL_PASSWORD=/run/secrets/mysql_password
-      - SIMULATION_MODE=true
-      - SIMULATION_IP=127.0.0.1
-      - SIMULATION_REGISTRATION_PORT=6767
-      - LOCAL_IP=127.0.0.1
-      - TIME_SYNC_TOPIC=time_sync
-      - TIME_SYNC_PORT=7575
-      - SIM_V2X_PORT=5757
-      - SIM_INTERACTION_PORT=7576
-      - V2X_PORT=8686
-      - INFRASTRUCTURE_ID=rsu_<J2735 MAP MESSAGE INTERSECTION ID>
-      - INFRASTRUCTURE_NAME=<RSU_NAME>
-      - SENSOR_JSON_FILE_PATH=/var/www/plugins/MAP/sensors.json
+      MYSQL_PASSWORD: /run/secrets/mysql_password
+      SIMULATION_MODE: false
+      # Environment variables only requires in simulation 
+      # SIMULATION_IP: 127.0.0.1
+      # SIMULATION_REGISTRATION_PORT: 6767
+      # TIME_SYNC_TOPIC: time_sync
+      # TIME_SYNC_PORT: 7575
+      # SIM_V2X_PORT: 5757
+      # SIM_INTERACTION_PORT: 7576
+      # V2X_PORT: 8686
+      LOCAL_IP: 127.0.0.1
+      INFRASTRUCTURE_ID: rsu_1234
+      INFRASTRUCTURE_NAME: East
+      SENSOR_JSON_FILE_PATH: /var/www/plugins/MAP/sensors.json
     secrets:
       - mysql_password
 
@@ -33,10 +34,10 @@ services:
     container_name: mysql
     restart: always
     environment:
-      - MYSQL_DATABASE=IVP
-      - MYSQL_USER=IVP
-      - MYSQL_PASSWORD_FILE=/run/secrets/mysql_password
-      - MYSQL_ROOT_PASSWORD_FILE=/run/secrets/mysql_root_password
+      MYSQL_DATABASE: IVP
+      MYSQL_USER: IVP
+      MYSQL_PASSWORD_FILE: /run/secrets/mysql_password
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/mysql_root_password
     network_mode: host
     secrets:
       - mysql_password


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Updates Dev Container docker compose file to avoid by default deploying V2X Hub in simulation mode. Making this update after Will had issues running SPaT plugin but did not realize V2X Hub was in simulation mode. Our default dev container probably should not be in simulation mode
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Improve usability of Dev Container setup
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally with dev container setup
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
