### PR TITLE
5gaa demo fix spat ms minute

### DIFF
--- a/src/v2i-hub/SpatPlugin/src/NTCIP1202.cpp
+++ b/src/v2i-hub/SpatPlugin/src/NTCIP1202.cpp
@@ -198,8 +198,9 @@ void Ntcip1202::printDebug()
 	}
 }
 
-void Ntcip1202::ToJ2735SPAT(SPAT* spat, unsigned long msEpoch , const std::string &intersectionName, IntersectionID_t intersectionId)
+void Ntcip1202::ToJ2735SPAT(SPAT* spat, std::shared_ptr<fwha_stol::lib::time::CarmaClock> carmaClock , const std::string &intersectionName, IntersectionID_t intersectionId)
 {
+	unsigned long msEpoch = carmaClock->nowInMilliseconds();
 	time_t epochSec = msEpoch/1000;
 	struct tm utctime;
 	gmtime_r( &epochSec, &utctime );

--- a/src/v2i-hub/SpatPlugin/src/NTCIP1202.h
+++ b/src/v2i-hub/SpatPlugin/src/NTCIP1202.h
@@ -31,6 +31,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/algorithm/string.hpp>
 
+#include "carma-clock/carma_clock.h"
 using namespace std;
 
 struct Ntcip1202Ext_PhaseTime
@@ -119,7 +120,7 @@ class Ntcip1202
 		bool isFlashingStatus();
 		bool isPhaseFlashing();
 
-		void ToJ2735SPAT(SPAT* spat, unsigned long msEpoch , const std::string &intersectionName, IntersectionID_t intersectionId);
+		void ToJ2735SPAT(SPAT* spat,std::shared_ptr<fwha_stol::lib::time::CarmaClock> carmaClock , const std::string &intersectionName, IntersectionID_t intersectionId);
 
 		void printDebug();
 	private:

--- a/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.cpp
@@ -37,7 +37,7 @@ namespace SpatPlugin {
         return status;
     };
 
-    void SignalControllerConnection::receiveBinarySPAT(const std::shared_ptr<SPAT> &spat, uint64_t timeMs ) const {
+    void SignalControllerConnection::receiveBinarySPAT(const std::shared_ptr<SPAT> &spat, std::shared_ptr<fwha_stol::lib::time::CarmaClock> carmaClock) const {
         FILE_LOG(tmx::utils::logDEBUG) << "Receiving binary SPAT ..." << std::endl;
         char buf[SPAT_BINARY_BUFFER_SIZE];
         auto numBytes = spatPacketReceiver->TimedReceive(buf, SPAT_BINARY_BUFFER_SIZE, UDP_SERVER_TIMEOUT_MS);
@@ -47,7 +47,7 @@ namespace SpatPlugin {
             Ntcip1202 ntcip1202;
             ntcip1202.setSignalGroupMappingList(this->signalGroupMapping);
             ntcip1202.copyBytesIntoNtcip1202(buf, numBytes);
-            ntcip1202.ToJ2735SPAT(spat.get(),timeMs, intersectionName, intersectionId);
+            ntcip1202.ToJ2735SPAT(spat.get(),carmaClock, intersectionName, intersectionId);
             if (tmx::utils::FILELog::ReportingLevel() >= tmx::utils::logDEBUG)
             {
                 xer_fprint(stdout, &asn_DEF_SPAT, spat.get());

--- a/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.h
+++ b/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.h
@@ -94,7 +94,7 @@ namespace SpatPlugin {
              * @param spat an empty SPaT pointer to which the SPAT data will be written.
              * @param timeMs current time in ms from epoch to use for message timestamp.
              */
-            void receiveBinarySPAT(const std::shared_ptr<SPAT> &spat, uint64_t timeMs) const;
+            void receiveBinarySPAT(const std::shared_ptr<SPAT> &spat, std::shared_ptr<fwha_stol::lib::time::CarmaClock> carmaClock) const;
             /**
              * @brief Method to receive SPaT data in UPER Hex format from TSC.
              * @param spatEncoded_ptr Empty SpatEncodedMessage to which the UPER encoded SPaT data will be written.

--- a/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
@@ -117,8 +117,10 @@ namespace SpatPlugin {
 					auto spatEncoded_ptr = std::make_shared<tmx::messages::SpatEncodedMessage>();
 					spatEncoded_ptr->initialize(_spatMessage,"", 0U, IvpMsgFlags_RouteDSRC);
 					spatEncoded_ptr->addDsrcMetadata(tmx::messages::api::msgPSID::signalPhaseAndTimingMessage_PSID);
+					PLOG(logDEBUG1) << "Generated SPaT " << spatEncoded_ptr->get_payload_str();
 					auto rMsg = dynamic_cast<routeable_message*>(spatEncoded_ptr.get());
 					BroadcastMessage(*rMsg);
+					PLOG(logDEBUG) << "Broadcast SPaT " << spatEncoded_ptr->get_payload_str();
 				}
 			}
 			catch (const UdpServerRuntimeError &e) {

--- a/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
@@ -112,7 +112,7 @@ namespace SpatPlugin {
 					}
 					auto spat_ptr = std::make_shared<SPAT>();
 					PLOG(logDEBUG) << "Starting SPaT Receiver ...";
-					scConnection->receiveBinarySPAT(spat_ptr, PluginClientClockAware::getClock()->nowInMilliseconds());
+					scConnection->receiveBinarySPAT(spat_ptr, PluginClientClockAware::getClock());
 					tmx::messages::SpatMessage _spatMessage(spat_ptr);
 					auto spatEncoded_ptr = std::make_shared<tmx::messages::SpatEncodedMessage>();
 					spatEncoded_ptr->initialize(_spatMessage,"", 0U, IvpMsgFlags_RouteDSRC);

--- a/src/v2i-hub/SpatPlugin/test/TestNTCIP1202.cpp
+++ b/src/v2i-hub/SpatPlugin/test/TestNTCIP1202.cpp
@@ -37,7 +37,8 @@ TEST(NTCIP1202Test, copyBytesIntoNtcip1202)
     ntcip1202_p->copyBytesIntoNtcip1202(buf, numBytes);
 
     SPAT *spat_ptr = (SPAT *)calloc(1, sizeof(SPAT));
-    ntcip1202_p->ToJ2735SPAT(spat_ptr,tsMsec, "test intersection name", 9012);
+    auto clock = std::make_shared<fwha_stol::lib::time::CarmaClock>(false);
+    ntcip1202_p->ToJ2735SPAT(spat_ptr,clock, "test intersection name", 9012);
 
     ASSERT_EQ(3,  spat_ptr->intersections.list.array[0]->states.list.array[0]->state_time_speed.list.array[0]->eventState);
 
@@ -50,7 +51,8 @@ TEST(NTCIP1202Test, ToJ2735SPAT)
 
     auto ntcip1202_p = std::make_shared<Ntcip1202>();
     SPAT *spat_ptr = (SPAT *)calloc(1, sizeof(SPAT));
-    ntcip1202_p->ToJ2735SPAT(spat_ptr, tsMsec, "test intersection name", 9012);
+    auto clock = std::make_shared<fwha_stol::lib::time::CarmaClock>(false);
+    ntcip1202_p->ToJ2735SPAT(spat_ptr, clock, "test intersection name", 9012);
     auto _spatMessage = std::make_shared<tmx::messages::SpatMessage>(spat_ptr);
     auto spat = _spatMessage->get_j2735_data();
 }

--- a/src/v2i-hub/SpatPlugin/test/TestSignalControllerConnection.cpp
+++ b/src/v2i-hub/SpatPlugin/test/TestSignalControllerConnection.cpp
@@ -20,6 +20,7 @@
 #include <MockUdpServer.h>
 #include <tmx/messages/J2735Exception.hpp>
 #include <NTCIP1202OIDs.h>
+#include "carma-clock/carma_clock.h"
 
 using testing::_;
 using testing::Action;
@@ -103,7 +104,8 @@ namespace SpatPlugin {
         auto spat_binary_buf = read_binary_file("../../SpatPlugin/test/test_spat_binaries/spat_1721238398773.bin");
         EXPECT_CALL(*mockUdpServer, TimedReceive(_, 1000, 1000)).WillOnce(testing::DoAll(SetArrayArgument<0>(spat_binary_buf.begin(), spat_binary_buf.end()), Return(spat_binary_buf.size())));
         auto spat = std::make_shared<SPAT>();
-		signalControllerConnection->receiveBinarySPAT(spat, 1721238398773);
+        auto clock = std::make_shared<fwha_stol::lib::time::CarmaClock>(false);
+		signalControllerConnection->receiveBinarySPAT(spat, clock);
         /**
          * <SPAT>
                 <intersections>
@@ -339,7 +341,8 @@ namespace SpatPlugin {
     TEST_F(TestSignalControllerConnection, receiveBinarySPATException) {
         EXPECT_CALL(*mockUdpServer, TimedReceive(_, 1000, 1000)).WillOnce(testing::DoAll( Return(0)));
         auto spat = std::make_shared<SPAT>();
-		EXPECT_THROW(signalControllerConnection->receiveBinarySPAT(spat, 1721238398773), tmx::utils::UdpServerRuntimeError);
+        auto clock = std::make_shared<fwha_stol::lib::time::CarmaClock>(false);
+		EXPECT_THROW(signalControllerConnection->receiveBinarySPAT(spat, clock), tmx::utils::UdpServerRuntimeError);
     }
 
     TEST_F(TestSignalControllerConnection, receiveUPERSPAT) {

--- a/src/v2i-hub/SpatPlugin/test/TestSignalControllerConnection.cpp
+++ b/src/v2i-hub/SpatPlugin/test/TestSignalControllerConnection.cpp
@@ -104,7 +104,8 @@ namespace SpatPlugin {
         auto spat_binary_buf = read_binary_file("../../SpatPlugin/test/test_spat_binaries/spat_1721238398773.bin");
         EXPECT_CALL(*mockUdpServer, TimedReceive(_, 1000, 1000)).WillOnce(testing::DoAll(SetArrayArgument<0>(spat_binary_buf.begin(), spat_binary_buf.end()), Return(spat_binary_buf.size())));
         auto spat = std::make_shared<SPAT>();
-        auto clock = std::make_shared<fwha_stol::lib::time::CarmaClock>(false);
+        auto clock = std::make_shared<fwha_stol::lib::time::CarmaClock>(true);
+        clock->update(1721238398773);
 		signalControllerConnection->receiveBinarySPAT(spat, clock);
         /**
          * <SPAT>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
SPATPlugin UDPsocket receiver listen to incoming SPAT data and wait for 1s before timeout. Since the receiver is in block mode and the SPAT data receiving rate is 10HZ, this means the receiver wait for around 100ms for a SPAT data. SPATPlugin uses this SPAT data and a timestamp now to compose J2735 SPAT message. However, this timestamp now is created before receiving SPAT data from UDPSocket and is likely around 100ms old. To better represent when the SPAT data and J2735 SPAT is generated, this PR is to update the now after receiving SPAT data.
<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
NA
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
