### PR TITLE
Fix MAP Plugin not broadcasting MAP in simulation

### DIFF
--- a/src/tmx/TmxUtils/src/PluginClientClockAware.cpp
+++ b/src/tmx/TmxUtils/src/PluginClientClockAware.cpp
@@ -14,7 +14,7 @@ namespace tmx::utils {
         clock = std::make_shared<CarmaClock>(_simulation_mode);
         if (_simulation_mode) {
             AddMessageFilter<tmx::messages::TimeSyncMessage>(this, &PluginClientClockAware::HandleTimeSyncMessage);
-            SubscribeToMessages();
+            PLOG(logDEBUG) << "Added Time Sync Message Filter";
         }
 
     }

--- a/src/tmx/TmxUtils/src/PluginClientClockAware.cpp
+++ b/src/tmx/TmxUtils/src/PluginClientClockAware.cpp
@@ -14,7 +14,7 @@ namespace tmx::utils {
         clock = std::make_shared<CarmaClock>(_simulation_mode);
         if (_simulation_mode) {
             AddMessageFilter<tmx::messages::TimeSyncMessage>(this, &PluginClientClockAware::HandleTimeSyncMessage);
-            PLOG(logDEBUG) << "Added Time Sync Message Filter";
+            PLOG(logDEBUG2) << "Added Time Sync Message Filter";
         }
 
     }

--- a/src/v2i-hub/CDASimAdapter/scripts/send_timestep_udp.py
+++ b/src/v2i-hub/CDASimAdapter/scripts/send_timestep_udp.py
@@ -11,11 +11,11 @@ import time
 #
 # TODO Move this script into a more permanent location
 count_num = 0
-
+sim_time =0
 def generate_time_sync():
     jsonResult = {
         "seq":count_num, 
-        "timestep":int(time.time()*1000)
+        "timestep":sim_time
     }
     jsonResult = json.dumps(jsonResult)
     return jsonResult
@@ -35,7 +35,8 @@ while True :
         count_num += 1
         sock.sendto(encoded_msg,host)
         print( encoded_msg.decode(encoding= 'UTF-8'), 'was sent to ', host)
-        time.sleep(5)
+        time.sleep(.1)
+        sim_time+= 100
     except socket.gaierror:
 
         print ('There an error resolving the host')

--- a/src/v2i-hub/CDASimAdapter/scripts/send_timestep_udp.py
+++ b/src/v2i-hub/CDASimAdapter/scripts/send_timestep_udp.py
@@ -9,9 +9,12 @@ import time
 # host and port. To Test the Time Sync functionality of the CDASimAdapter
 # set port to the value of the TIME_SYNC_PORT environment variable.
 #
-# TODO Move this script into a more permanent location
+# count_name used to populate the seq field in the time sync message
 count_num = 0
+# sim_time (ms) used to populate the timestep field in the time sync message
 sim_time =0
+# sleep_dur (s) used to control the rate at which time sync messages are sent
+sleep_dur = 0.1
 def generate_time_sync():
     jsonResult = {
         "seq":count_num, 
@@ -35,7 +38,7 @@ while True :
         count_num += 1
         sock.sendto(encoded_msg,host)
         print( encoded_msg.decode(encoding= 'UTF-8'), 'was sent to ', host)
-        time.sleep(.1)
+        time.sleep(sleep_dur)
         sim_time+= 100
     except socket.gaierror:
 

--- a/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDriverPlugin.cpp
+++ b/src/v2i-hub/MUSTSensorDriverPlugin/src/MUSTSensorDriverPlugin.cpp
@@ -22,6 +22,10 @@ namespace MUSTSensorDriverPlugin {
 	
 	MUSTSensorDriverPlugin::MUSTSensorDriverPlugin(const string &name): PluginClientClockAware(name)
 	{
+		if (isSimulationMode()) {
+			// Subscribe to the TimeSyncMessage
+			SubscribeToMessages();
+		}
 		mustSensorPacketReceiverThread = std::make_unique<tmx::utils::ThreadTimer>(std::chrono::milliseconds(5));
 	}
 

--- a/src/v2i-hub/MapPlugin/src/MapPlugin.cpp
+++ b/src/v2i-hub/MapPlugin/src/MapPlugin.cpp
@@ -8,6 +8,7 @@ namespace MapPlugin {
 		AddMessageFilter(IVPMSG_TYPE_SIGCONT, "ACT", IvpMsgFlags_None);
 		SubscribeToMessages();
 		errThrottle.set_Frequency(std::chrono::minutes(30));
+		
 	}
 
 	void MapPlugin::UpdateConfigSettings() {

--- a/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
@@ -23,6 +23,10 @@ using namespace tmx::utils;
 namespace SpatPlugin {
 
 	SpatPlugin::SpatPlugin(const std::string &name) :PluginClientClockAware(name) {
+		if (isSimulationMode()) {
+			// Subscribe to the TimeSyncMessage
+			SubscribeToMessages();
+		}
 		spatReceiverThread = std::make_unique<tmx::utils::ThreadTimer>(std::chrono::milliseconds(5));
 	}
 

--- a/src/v2i-hub/docs/Programming_Guide.md
+++ b/src/v2i-hub/docs/Programming_Guide.md
@@ -117,7 +117,7 @@ void HandleDataChangeMessage(DataChangeMessage &msg, routeable_message &routeabl
 SubscribeToMessage()
 ```
 
-The SubscribeToMessages function must be called after the filters are setup, otherwise the plugin will not receive the wanted messages. This function can be invoked more than once, if other filters are added. Currently, the only way to un-subscribe to a message is to restart the plugin.
+The `SubscribeToMessages` function must be called after the filters are setup, otherwise the plugin will not receive the wanted messages. This function can be invoked more than once, but multiple calls to `SubscribeToMessages` will overwrite previously subscribed message filters. 
 
 #### State Changes
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This Pull Request fixes a bug with the MAP plugin in which it only sends a single MAP messages in simulation mode. Through local integration testing in the Dev Container environment, it was discovered that which the programming manual claims that multiple calls to SubscribeMessages() should not overwrite message filters it does.

Since the PluginClockAwareClient calls attempts to subscribe to TimeSync messages in its constructor and the MapPlugin attempts to subscribe to ACT messages in it's constructor, the second call to Subscribe removes the first filter. This means the plugin no longer receives time sync messages and all calls to sleep on the carma clock will hang indefinitely. To address this we avoid calling subscribe in the base class and instead rely on the parent class to call subscribe. 

The bug behavior can also be caught by examining plugin state
![image](https://github.com/user-attachments/assets/979c756e-4361-48f4-a5ea-39f162b220c5)
If plugin state does not include **Simulation Time Step** when in simulation it can be concluded that the plugin message filter does not include the TimeSync message handling of the time sync message triggers updates to this status
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix time synchronization for MAP plugin and other impacted plugins
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
local integration testing and tested in CDASim deployment by @adev4a 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
