### PR TITLE
Update SpatPlugin.cpp

### DIFF
--- a/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
@@ -63,7 +63,7 @@ namespace SpatPlugin {
 				scConnection = std::make_unique<SignalControllerConnection>(ip_address, port, signal_group_mapping_json, signal_controller_ip, signal_controller_snmp_port,signal_controller_snmp_community, intersection_name, intersection_id);
 			}
 			// Only send SNMP Rquest to enable spat in simulation mode and binary spat. TFHRC TSCs do not expose this OID so calls to it will fail in hardware deployment
-			auto connected = scConnection->initializeSignalControllerConnection(PluginClientClockAware::isSimulationMode() && spatMode == "BINARY" );
+			auto connected = scConnection->initializeSignalControllerConnection(false);
 			if  ( connected ) {
 				SetStatus(keyConnectionStatus, "IDLE");
 				try {

--- a/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
@@ -62,7 +62,8 @@ namespace SpatPlugin {
 			else {
 				scConnection = std::make_unique<SignalControllerConnection>(ip_address, port, signal_group_mapping_json, signal_controller_ip, signal_controller_snmp_port,signal_controller_snmp_community, intersection_name, intersection_id);
 			}
-			// Only send SNMP Rquest to enable spat in simulation mode and binary spat. TFHRC TSCs do not expose this OID so calls to it will fail in hardware deployment
+			// TODO: SNMP OID set call is now only required for old physical controllers and varies by controller. Implement more permanent fix that allows user
+			// to define an OID and value to set or none at all
 			auto connected = scConnection->initializeSignalControllerConnection(false);
 			if  ( connected ) {
 				SetStatus(keyConnectionStatus, "IDLE");


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The new Virtual Signal Controllers no longer support or require using SNMP calls to enable SPAT. This has been replaces with signal controller configurations. Since this SNMP OID is no longer supported, calls to it fail and this prevents the SPAT plugin from believing it is correctly connected to the controller. Disabling calls to this OID fixes the issuue
<!--- Describe your changes in detail -->

## Related Issue
TT-168
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Bug Fix
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
CDASim
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
