### PR TITLE
Fix V2xHub Metadata Tags

### DIFF
--- a/.github/workflows/build_v2xhub_docker_image.yml
+++ b/.github/workflows/build_v2xhub_docker_image.yml
@@ -6,6 +6,7 @@ on:
       - develop
       - master
       - 'release/**'
+      - fix_v2xhub_tags
     tags:
       - '*'
 
@@ -35,7 +36,6 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build & push AMD64
         uses: docker/build-push-action@v5
@@ -72,7 +72,6 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build & push ARM64
         uses: docker/build-push-action@v5
@@ -105,12 +104,10 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Create final multi-arch
         run: |
-          FINAL_TAG=$(echo '${{ steps.meta.outputs.tags }}' | cut -d',' -f1)
+          FINAL_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1 | tr -d '\n')
           echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_ENV
 
           AMD64_TAG="${FINAL_TAG}-amd64"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR addresses an issue with Docker tags during the manifest step, which resulted in the following error: error parsing name for manifest list usdotfhwaops/v2xhub:developusdotfhwaops/v2xhub:latest: invalid reference format. The fix ensures correct formatting for Docker tags in the manifest list.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
