### PR TITLE
	modified:   src/v2i-hub/MapPlugin/src/MapPlugin.cpp

### DIFF
--- a/src/v2i-hub/MapPlugin/src/MapPlugin.cpp
+++ b/src/v2i-hub/MapPlugin/src/MapPlugin.cpp
@@ -219,12 +219,13 @@ namespace MapPlugin {
 		// Check for and remove MessageFrame
 		if (fileContent.size() >= 4 && fileContent.substr(0, 4) == map_messageID)
 		{
-			// Check if message is hex size > 255, remove appropriate header
+			// If message is hex size > 127 (string > 254), set and remove appropriate header
+			// Per IEEE 1609.2-2020 section 8.1.3
 			std::string tempFrame = fileContent;
 			std::string newFrame = fileContent;
 			tempFrame.erase(0, 6);
 			PLOG(logDEBUG4) << "Checking size of: " << tempFrame;
-			auto headerSize = (tempFrame.size() > 510) ? 8 : 6;
+			auto headerSize = (tempFrame.size() > 254) ? 8 : 6;
 			newFrame.erase(0, headerSize);
 			
 			PLOG(logDEBUG4) << "Payload without MessageFrame: " << newFrame;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This update fixes the MAP plugin message frame parser to correctly check the payload size and trim the appropriate number of bytes to get the MAP payload.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The message frame parser was incorrectly checking for payloads greater than 255, but the IEEE 1609.2-2020 standard states that the message frame size contains 8 bytes when the payload is greater than 127. 

## How Has This Been Tested?
Tested with three messages containing message frames and of size:
- 57
- 252
- 658

All messages were parsed correctly. These sizes check that the parser correctly cuts messages less than 127, less than the old parser of 256, and greater than both old and new size constraints of 127 and 256.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
