### PR TITLE
Update produce call to include poll() and add delete for new MOM

### DIFF
--- a/src/tmx/TmxUtils/src/kafka/kafka_producer_worker.h
+++ b/src/tmx/TmxUtils/src/kafka/kafka_producer_worker.h
@@ -85,7 +85,7 @@ namespace tmx::utils
              * @return true if successful.
              * @return false if unsuccessful.
              */
-            virtual bool init_topic();
+            virtual bool init_topic( const std::string &topic_name);
              /**
              * @brief Initialize kafka producer.
              * @return true if successful.
@@ -102,7 +102,7 @@ namespace tmx::utils
              * @param msg message to produce.
              * @param topic_name topic to send the message to.
              */
-            virtual void send(const std::string& message, const std::string& topic_name ) const;
+            virtual void send(const std::string& message, const std::string& topic_name );
             /**
              * @brief Is kafka_producer_worker still running?
              * 

--- a/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
+++ b/src/v2i-hub/CARMAStreetsPlugin/src/CARMAStreetsPlugin.cpp
@@ -834,6 +834,7 @@ bool CARMAStreetsPlugin::getEncodedtsm3( tsm3EncodedMessage *tsm3EncodedMsg,  Js
 		PLOG(logDEBUG) << *_tsm3Message;
 		tsm3EncodedMsg->initialize(*_tsm3Message);
 		free(mobilityOperation);
+		delete _tsm3Message;
 		return true;
 	}
 	catch(const std::runtime_error &e )


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Apparently librdkafka does not clear it's memory properly unless there are regular calls to poll. See issue (https://github.com/confluentinc/librdkafka/issues/4997). Updated our produce method calls to use previous topic based implementation but just update topic dynamically.
<!--- Describe your changes in detail -->

## Related Issue
CDAD-155
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Remove memory leak
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
With new memory status information provided by #728 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
