### PR TITLE
Add memory limits to docker compose deployment

### DIFF
--- a/configuration/docker-compose.yml
+++ b/configuration/docker-compose.yml
@@ -43,6 +43,12 @@ services:
     restart: always
     depends_on:
       - db
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+        reservations:
+          memory: 1g
     environment:
       - MYSQL_PASSWORD=/run/secrets/mysql_password
       - SIMULATION_MODE=${SIMULATION_MODE:-false}
@@ -66,6 +72,12 @@ services:
     image: usdotfhwaops/port-drayage-webservice:${V2XHUB_VERSION:-develop}
     container_name: port_drayage_webservice
     network_mode: host
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+        reservations:
+          memory: 128m
 secrets:
     mysql_password:
         file: ./secrets/mysql_password.txt

--- a/configuration/docker-compose.yml
+++ b/configuration/docker-compose.yml
@@ -75,9 +75,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256m
+          memory: 1g
         reservations:
-          memory: 128m
+          memory: 512m
 secrets:
     mysql_password:
         file: ./secrets/mysql_password.txt


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Add docker compose memory limits to V2X Hub and Port Drayage Web Service containers. This is to avoid memory leaks or bad performance in our images from impacting host machine.

Documentation on docker resource constraints (https://docs.docker.com/engine/containers/resource_constraints/)
<!--- Describe your changes in detail -->

## Related Issue
CDAD-155
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Prevent memory leaks or large memory usage from impacting host machine performance 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local Integration testing 
`docker stats` command can be used to live monitor container memory usage.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
