### PR TITLE
Use docker compose profile for Port Drayage functionality

### DIFF
--- a/configuration/docker-compose.yml
+++ b/configuration/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   db:
     image: mysql:8.0
     container_name: mysql
-    restart: always
     environment:
       - MYSQL_DATABASE=IVP
       - MYSQL_USER=IVP
@@ -66,6 +65,7 @@ services:
     image: usdotfhwaops/port-drayage-webservice:${V2XHUB_VERSION:-develop}
     container_name: port_drayage_webservice
     network_mode: host
+    profiles: ["port_drayage"]
 secrets:
     mysql_password:
         file: ./secrets/mysql_password.txt

--- a/configuration/initialization.sh
+++ b/configuration/initialization.sh
@@ -8,6 +8,7 @@ V2XHUB_IP_DEFAULT="127.0.0.1"
 SIMULATION_MODE_DEFAULT="FALSE"
 SIMULATION_IP_DEFAULT="127.0.0.1"
 SENSOR_JSON_FILE_PATH_DEFAULT="/var/www/plugins/MAP/sensors.json"
+COMPOSE_PROFILES=""
 
 echo "Setting up the environment..."
 
@@ -38,7 +39,10 @@ V2XHUB_VERSION=${chosen_version:-$latest_version}
 # Enable Port Drayage functionality
 read -r -p "Enable Port Drayage functionality (TRUE/FALSE, or press Enter to use default as $PORT_DRAYAGE_ENABLED_DEFAULT): " PORT_DRAYAGE_ENABLED
 PORT_DRAYAGE_ENABLED=${PORT_DRAYAGE_ENABLED:-$PORT_DRAYAGE_ENABLED_DEFAULT}
-
+if [[ $PORT_DRAYAGE_ENABLED == "TRUE" ]]; then
+    echo "Activating port_drayage profile."
+    COMPOSE_PROFILES="port_drayage"
+fi
 # Infrastructure id
 read -r -p "Enter Infrastructure id (or press Enter to use default as $INFRASTRUCTURE_ID_DEFAULT): " INFRASTRUCTURE_ID
 INFRASTRUCTURE_ID=${INFRASTRUCTURE_ID:-$INFRASTRUCTURE_ID_DEFAULT}
@@ -76,6 +80,7 @@ INFRASTRUCTURE_ID=$INFRASTRUCTURE_ID
 INFRASTRUCTURE_NAME=$INFRASTRUCTURE_NAME
 V2XHUB_IP=$V2XHUB_IP
 SIMULATION_MODE=$SIMULATION_MODE
+COMPOSE_PROFILES=$COMPOSE_PROFILES
 EOF
 
     # Adding Simulation IP and Sensor Path if Simulation Mode is TRUE
@@ -90,10 +95,9 @@ fi
 directory=$(pwd)
 mysqlDir="$directory/mysql"
 
-# Update and upgrade commands to update linux OS
-sudo apt update -y && sudo apt upgrade -y
 
 # Install necessary and useful apps
+sudo apt update -y 
 sudo apt-get install chromium-browser -y
 
 # Make passwords for mysql
@@ -138,15 +142,8 @@ echo \
 sudo apt-get update
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-# Check if Port Drayage functionality is enabled
-if [[ $PORT_DRAYAGE_ENABLED == "TRUE" ]]; then
-    sudo docker compose up -d
-elif [[ $PORT_DRAYAGE_ENABLED == "FALSE" ]]; then
-    sudo docker compose up php -d
-else
-    echo "Invalid value for PORT_DRAYAGE_ENABLED. Please provide either TRUE or FALSE."
-    exit 1
-fi
+sudo docker compose up -d
+
 
 # Update permissions for tmx logs created by plugins
 sudo chmod -R 777 ./logs


### PR DESCRIPTION


<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update initialization.sh script to use docker compose profiles to launch portdrayage container
<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Use existing docker compose functionality for maintainability
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local testing of initialization script by running script with Port Drayage Functionality selected as enabled and as disabled and confirming the Port Drayage Web Service only gets launched on enable
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
