### PR TITLE
Cdad 150 add status for live pedestrian count

### DIFF
--- a/src/v2i-hub/FLIRCameraDriverPlugin/README.md
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/README.md
@@ -51,6 +51,7 @@ This plugin includes some custom status information to allow for real-time monit
 > We only modify incoming detections that have incomplete/invalid heading/speed information. After testing we have found that occassionally, when a detected object stops, the FLIR Camera will continue to broadcast detections that **do not** include angle or heading but **do** include speed. This seems to be a bug that only occurs for stationary objects intermittently. To address this, when no angle is provided, we assume speed is 0. For tracebility we have added this status as well as a flag in each SensorDetectedObjectMessage which indicates whether we have modified the detection data from the source sensor at all.
 **Unique Pedestrian Detections**: A complete count of all pedestrian detections from all FLIR Camera connections that are unique. We evaluate this by comparing the incoming detection ids to the previously received ids. This is meant to be a rough estimate of all pedestrians detected by the FLIR Cameras connected.
 **Total Pedestrian Detections**: A complete count of all pedestrian detections from all FLIR Camera connections. This includes any detections that where dropped or modified.
+**Live number of currently detected pedestrians**: A current/live count of unique pedestrian detections from all FLIR Camera connections.
 
 ![alt text](docs/FLIRCameraDriverStatus.png)
 

--- a/src/v2i-hub/FLIRCameraDriverPlugin/scripts/mockFLIRCamera.py
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/scripts/mockFLIRCamera.py
@@ -108,10 +108,11 @@ class FLIRPedestrianPresenceTracking:
 
 async def sendMessage(websocket):
     """Send the JSON message to the client periodically."""
+    tracks= FLIRPedestrianPresenceTracking()
+
     while True:
-        tracks= FLIRPedestrianPresenceTracking()
         # Ramdom chance to add a new track
-        if len(tracks.track) < 5 and random.random() > 0.2:
+        if len(tracks.track) < 5 and random.random() < 0.4:
             new_detection = FLIRDetection(
                 x=random.uniform(-5, 5),
                 y=random.uniform(-5, 5),
@@ -124,7 +125,7 @@ async def sendMessage(websocket):
             )
             tracks.track.append(new_detection)
         # Randomly remove a track
-        if len(tracks.track) > 0 and random.random() < 0.1:
+        if len(tracks.track) > 0 and random.random() < 0.3:
             if len(tracks.track) > 1:
                 tracks.track.pop(random.randint(0, len(tracks.track) - 1))
             else:
@@ -135,7 +136,7 @@ async def sendMessage(websocket):
             print("No tracks to send, skipping message")
         else:
             await websocket.send(json.dumps(tracks.to_json()))
-            print(f"Sending: {tracks.to_json()}")
+            print(f"Sending: {len(tracks.track)}")
             await asyncio.sleep(0.1)  # interval to send the message
 
 async def handleClient(websocket, path):

--- a/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRCameraDriverPlugin.cpp
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRCameraDriverPlugin.cpp
@@ -85,9 +85,14 @@ namespace FLIRCameraDriverPlugin
 			if (flirSessions.empty())
 			{
 				PLOG(logDEBUG) << "FLIR session not yet initialized: ";
+				SetStatus<uint>(Key_LivePedestrianCount, 0);
+
 			}
 			else
 			{	
+
+				auto livePedCount = 0;
+
 				//Loop through all FLIR sessions to check each session for any messages in the queue and broadcast them.
 				for(const auto &flirSession: flirSessions)
 				{
@@ -105,6 +110,10 @@ namespace FLIRCameraDriverPlugin
 					std::queue<tmx::messages::SensorDetectedObject> currentMsgQueue = flirSession->getMsgQueue();
 					// Update total pedestrian detection count.
 					totalPedCount += currentMsgQueue.size();
+					auto currentTime = getClock()->nowInMilliseconds();
+					if (currentTime - flirSession->getLastDetectionTime() < 1100) {
+						livePedCount += flirSession->getNumLastDetections();
+					}
 					while(!currentMsgQueue.empty())
 					{		
 						auto message = currentMsgQueue.front();
@@ -137,8 +146,9 @@ namespace FLIRCameraDriverPlugin
 				SetStatus<uint>(Key_ModifiedPedestrianCount, modifiedPedCount);
 				SetStatus<uint>(Key_UniquePedestrianCount, uniquePedCount);
 				SetStatus<uint>(Key_TotalPedestrianCount, totalPedCount);
-			
+				SetStatus<uint>(Key_LivePedestrianCount, livePedCount);
 			}
+			// Update the live pedestrian count status
 			// Sleep for 10 milliseconds
 			std::this_thread::sleep_for(std::chrono::milliseconds(10));
 		}

--- a/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRCameraDriverPlugin.cpp
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRCameraDriverPlugin.cpp
@@ -110,8 +110,11 @@ namespace FLIRCameraDriverPlugin
 					std::queue<tmx::messages::SensorDetectedObject> currentMsgQueue = flirSession->getMsgQueue();
 					// Update total pedestrian detection count.
 					totalPedCount += currentMsgQueue.size();
+					// Check Num Last Detections for each FLIR
+					// If Last detection time greater than FLIR detection reporting interval (100ms) +/- 1 polling interval (10ms see line 155)
+					// detection is no longer "live" and should not be considered.
 					auto currentTime = getClock()->nowInMilliseconds();
-					if (currentTime - flirSession->getLastDetectionTime() < 1100) {
+					if (currentTime - flirSession->getLastDetectionTime() < 110) {
 						livePedCount += flirSession->getNumLastDetections();
 					}
 					while(!currentMsgQueue.empty())

--- a/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRCameraDriverPlugin.hpp
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRCameraDriverPlugin.hpp
@@ -86,6 +86,8 @@ namespace FLIRCameraDriverPlugin
 			const char* Key_TotalPedestrianCount = "Total Pedestrian Detections";
 			// Total number of pedestrian detections
 			unsigned int totalPedCount = 0;
+			// Live number of currently detected pedestrians
+			const char* Key_LivePedestrianCount = "Live number of currently detected pedestrians";
 
 
 

--- a/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRWebsockAsyncClnSession.cpp
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRWebsockAsyncClnSession.cpp
@@ -199,6 +199,10 @@ namespace FLIRCameraDriverPlugin
             }
             
         }
+        // Set the number of last detections
+        numLastDetections_.store(msgQueue.size());
+        // Set the last detection time
+        lastDetectionTime_.store(timestamp);
         return msgQueue;
     }
 
@@ -263,5 +267,13 @@ namespace FLIRCameraDriverPlugin
 
     std::string FLIRWebsockAsyncClnSession::getSensorId() const {
         return sensorId;
+    }
+
+    long long FLIRWebsockAsyncClnSession::getLastDetectionTime() const {
+        return lastDetectionTime_.load();
+    }   
+
+    unsigned int FLIRWebsockAsyncClnSession::getNumLastDetections() const {
+        return numLastDetections_.load();
     }
 }

--- a/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRWebsockAsyncClnSession.cpp
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRWebsockAsyncClnSession.cpp
@@ -200,7 +200,7 @@ namespace FLIRCameraDriverPlugin
             
         }
         // Set the number of last detections
-        numLastDetections_.store(msgQueue.size());
+        numLastDetections_.store(std::static_cast<unsigned int>(msgQueue.size()));
         // Set the last detection time
         lastDetectionTime_.store(timestamp);
         return msgQueue;

--- a/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRWebsockAsyncClnSession.cpp
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRWebsockAsyncClnSession.cpp
@@ -200,7 +200,7 @@ namespace FLIRCameraDriverPlugin
             
         }
         // Set the number of last detections
-        numLastDetections_.store(std::static_cast<unsigned int>(msgQueue.size()));
+        numLastDetections_.store(static_cast<unsigned int>(msgQueue.size()));
         // Set the last detection time
         lastDetectionTime_.store(timestamp);
         return msgQueue;

--- a/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRWebsockAsyncClnSession.hpp
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/src/FLIRWebsockAsyncClnSession.hpp
@@ -81,6 +81,8 @@ namespace FLIRCameraDriverPlugin
             std::queue<tmx::messages::SensorDetectedObject> msgQueue;
 
             std::mutex _msgLock;
+            std::atomic<unsigned int> numLastDetections_{0};
+            std::atomic<long long> lastDetectionTime_{0};
 
             // Health status of the FLIR camera
             std::atomic<bool> isHealthy_;
@@ -198,6 +200,18 @@ namespace FLIRCameraDriverPlugin
              * @brief Clear the dropped pedestrian count
              */
             void clearDroppedPedCount();
+
+            /**
+             * @brief Get the last detection time
+             * @return The last detection time in milliseconds since epoch.
+             * 
+             */
+            long long getLastDetectionTime() const;
+            /**
+             * @brief Get the number of last detections
+             * @return The number of last detections.
+             */
+            unsigned int getNumLastDetections() const;
 
             std::string getSensorId() const;
     };

--- a/src/v2i-hub/FLIRCameraDriverPlugin/test/FLIRWebsockAsyncClnSessionTest.cpp
+++ b/src/v2i-hub/FLIRCameraDriverPlugin/test/FLIRWebsockAsyncClnSessionTest.cpp
@@ -75,6 +75,8 @@ TEST(FLIRWebsockAsyncClnSessionTest, testHandleDataMessage) {
 
     flirSession->handleDataMessage(pr);
     EXPECT_EQ(flirSession->getMsgQueue().size(), 2);
+    EXPECT_EQ(flirSession->getNumLastDetections(), 2);
+    EXPECT_EQ(flirSession->getLastDetectionTime(), 1747763255092);
     flirSession->clearMsgQueue();
     EXPECT_EQ(flirSession->getMsgQueue().size(), 0);
 } 
@@ -194,7 +196,8 @@ TEST(FLIRWebsockAsyncClnSessionTest, processPedestrianPresenceTrackingObjects)
 
     EXPECT_EQ(msgQueue.size(), 2);
     tmx::messages::SensorDetectedObject obj = msgQueue.front();
- 
+    EXPECT_EQ(flirSession->getNumLastDetections(), 2);
+    EXPECT_EQ(flirSession->getLastDetectionTime(), 1747763255092);
     EXPECT_NEAR(obj.get_timestamp(), 1747763255092, 1);
     std::string proj_string = "+proj=tmerc +lat_0=38.9549921700 +lon_0=-77.1492095300 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs +axis=enu";
     EXPECT_EQ( obj.get_projString(), proj_string);
@@ -245,7 +248,8 @@ TEST(FLIRPedestrianPresenceTrackingProcessorTest, processPedestrianPresenceTrack
 
     EXPECT_EQ(msgQueue.size(), 1);
     tmx::messages::SensorDetectedObject obj = msgQueue.front();
- 
+    EXPECT_EQ(flirSession->getNumLastDetections(), 1);
+    EXPECT_EQ(flirSession->getLastDetectionTime(), 1747785403461);
     EXPECT_NEAR(obj.get_timestamp(), 1747785403461, 1);
     std::string proj_string = "+proj=tmerc +lat_0=38.9549921700 +lon_0=-77.1492095300 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +geoidgrids=egm96_15.gtx +vunits=m +no_defs +axis=enu";
     EXPECT_EQ( obj.get_projString(), proj_string);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR adds a status for displaying a count of live pedestrians currently detected. Also fixed some bugs in the `mockFLIRCamera.py` script
<!--- Describe your changes in detail -->

## Related Issue
CDAD-150
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Improve status information
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing with `mockFLIRCamera.py` script 

[20250708-1944-21.7216703.webm](https://github.com/user-attachments/assets/dc475d96-c1ff-4e01-b720-d583822fc7f8)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
