### PR TITLE
Fix CI  Docker Multi-Architecture build for Tags

### DIFF
--- a/.github/workflows/build_v2xhub_docker_image.yml
+++ b/.github/workflows/build_v2xhub_docker_image.yml
@@ -32,6 +32,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: usdotfhwaops/v2xhub
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=tag
@@ -68,6 +70,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: usdotfhwaops/v2xhub
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=tag


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix CI process during tag events which fails since arm/amd builds generate multiple tags including latest and only add the arm/amd suffix to the latest tag. See the following failed workflow.
https://github.com/usdot-fhwa-OPS/V2X-Hub/actions/runs/15855342353/job/44700105989
<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix CI
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
NA
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
