### PR TITLE
Fix Puffin Deployment

### DIFF
--- a/configuration/docker-compose.yml
+++ b/configuration/docker-compose.yml
@@ -46,6 +46,10 @@ services:
     restart: always
     depends_on:
       - db
+    ulimits:
+      nofile:
+        soft: 2560
+        hard: 2560
     deploy:
       resources:
         limits:

--- a/src/v2i-hub/CommandPlugin/src/CommandPlugin.cpp
+++ b/src/v2i-hub/CommandPlugin/src/CommandPlugin.cpp
@@ -1277,8 +1277,7 @@ int CommandPlugin::Main()
 	info.gid = -1;
 	info.uid = -1;
 	info.timeout_secs_ah_idle = 3600;
-	// Avoid environment setting breaking libwebsockets (https://github.com/warmcat/libwebsockets/issues/2449 )
-	info.rlimit_nofile = 2560
+
 	string crtPath = "";
 	string keyPath = "";
 	int opts = 0;

--- a/src/v2i-hub/CommandPlugin/src/CommandPlugin.cpp
+++ b/src/v2i-hub/CommandPlugin/src/CommandPlugin.cpp
@@ -1277,7 +1277,8 @@ int CommandPlugin::Main()
 	info.gid = -1;
 	info.uid = -1;
 	info.timeout_secs_ah_idle = 3600;
-
+	// Avoid environment setting breaking libwebsockets (https://github.com/warmcat/libwebsockets/issues/2449 )
+	info.rlimit_nofile = 2560
 	string crtPath = "";
 	string keyPath = "";
 	int opts = 0;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR is intended to address the issue (https://github.com/usdot-fhwa-OPS/V2X-Hub/issues/739) that occurs when attempting to deploy V2X Hub on ubuntu puffin (25.04) in which the CommandPlugin continuously fails to start up with the following log messages
```
root@IntelNUC:/var/log/tmx# tmxctl --start CommandPlugin
[2025/07/22 10:45:23:8882] E: OOM allocating 1073741816 fds
[2025/07/22 10:45:23:8882] E: ZERO RANDOM FD
```
This occurs due to an issue in 4.0.2 version of libwebsockets (https://github.com/warmcat/libwebsockets/issues/2449) in which a very high setting for ulimit nofile will cause and OOM error in libwebsockets. This has been fixed in later versions of libwebsockets by first adding a `info.rlimit_nofile` configuration parameter in 4.1.0 to override the environment setting and in 4.2.0 defaulting to 2560 when nofile is > 10,000,000. 

This only occurs in ubuntu puffin since in Jammy the default nofile limit is ~1,000,000 but in puffin it is 1,073,741,816 . To fix this regardless of host nofile limit, we can set container limits using docker compose 
<!--- Describe your changes in detail -->

## Related Issue
#739 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Fix deployment issue with ubuntu Puffin
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested fix on ubuntu Puffin
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[V2XHUB Contributing Guide](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
