### PR TITLE
Temporary fix for SPAT Plugin memory leak.

### DIFF
--- a/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.cpp
@@ -37,7 +37,7 @@ namespace SpatPlugin {
         return status;
     };
 
-    void SignalControllerConnection::receiveBinarySPAT(const std::shared_ptr<SPAT> &spat, uint64_t timeMs ) const {
+    void SignalControllerConnection::receiveBinarySPAT(SPAT *spat, uint64_t timeMs ) const {
         FILE_LOG(tmx::utils::logDEBUG) << "Receiving binary SPAT ..." << std::endl;
         char buf[SPAT_BINARY_BUFFER_SIZE];
         auto numBytes = spatPacketReceiver->TimedReceive(buf, SPAT_BINARY_BUFFER_SIZE, UDP_SERVER_TIMEOUT_MS);
@@ -47,10 +47,10 @@ namespace SpatPlugin {
             Ntcip1202 ntcip1202;
             ntcip1202.setSignalGroupMappingList(this->signalGroupMapping);
             ntcip1202.copyBytesIntoNtcip1202(buf, numBytes);
-            ntcip1202.ToJ2735SPAT(spat.get(),timeMs, intersectionName, intersectionId);
+            ntcip1202.ToJ2735SPAT(spat,timeMs, intersectionName, intersectionId);
             if (tmx::utils::FILELog::ReportingLevel() >= tmx::utils::logDEBUG)
             {
-                xer_fprint(stdout, &asn_DEF_SPAT, spat.get());
+                xer_fprint(stdout, &asn_DEF_SPAT, spat);
             }
         }
         else {

--- a/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.cpp
@@ -37,7 +37,7 @@ namespace SpatPlugin {
         return status;
     };
 
-    void SignalControllerConnection::receiveBinarySPAT(SPAT *spat, uint64_t timeMs ) const {
+    void SignalControllerConnection::receiveBinarySPAT(SPAT * const spat, uint64_t timeMs ) const {
         FILE_LOG(tmx::utils::logDEBUG) << "Receiving binary SPAT ..." << std::endl;
         char buf[SPAT_BINARY_BUFFER_SIZE];
         auto numBytes = spatPacketReceiver->TimedReceive(buf, SPAT_BINARY_BUFFER_SIZE, UDP_SERVER_TIMEOUT_MS);

--- a/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.h
+++ b/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.h
@@ -94,7 +94,7 @@ namespace SpatPlugin {
              * @param spat an empty SPaT pointer to which the SPAT data will be written.
              * @param timeMs current time in ms from epoch to use for message timestamp.
              */
-            void receiveBinarySPAT( SPAT *spat, uint64_t timeMs) const;
+            void receiveBinarySPAT( SPAT * const spat, uint64_t timeMs) const;
             /**
              * @brief Method to receive SPaT data in UPER Hex format from TSC.
              * @param spatEncoded_ptr Empty SpatEncodedMessage to which the UPER encoded SPaT data will be written.

--- a/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.h
+++ b/src/v2i-hub/SpatPlugin/src/SignalControllerConnection.h
@@ -94,7 +94,7 @@ namespace SpatPlugin {
              * @param spat an empty SPaT pointer to which the SPAT data will be written.
              * @param timeMs current time in ms from epoch to use for message timestamp.
              */
-            void receiveBinarySPAT(const std::shared_ptr<SPAT> &spat, uint64_t timeMs) const;
+            void receiveBinarySPAT( SPAT *spat, uint64_t timeMs) const;
             /**
              * @brief Method to receive SPaT data in UPER Hex format from TSC.
              * @param spatEncoded_ptr Empty SpatEncodedMessage to which the UPER encoded SPaT data will be written.

--- a/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
+++ b/src/v2i-hub/SpatPlugin/src/SpatPlugin.cpp
@@ -126,11 +126,11 @@ namespace SpatPlugin {
 					spatEncoded_ptr->set_data(TmxJ2735EncodedMessage<SPAT>::encode_j2735_message<codec::uper<MessageFrameMessage>>(frame));
 					spatEncoded_ptr->addDsrcMetadata(tmx::messages::api::msgPSID::signalPhaseAndTimingMessage_PSID);
 					auto rMsg = dynamic_cast<routeable_message*>(spatEncoded_ptr.get());
-					BroadcastMessage(_spatMessage);
+					BroadcastMessage(*rMsg);
 					// Recursively free SPAT struct 
 					ASN_STRUCT_FREE(asn_DEF_SPAT, spat_ptr);
 					// TODO fix MessageFrameMessage destructor to properly free internal SPAT pointer
-					free(frame.get_j2735_data().get());
+					free(frame.get_j2735_data().get()); 
 
 				
 				}

--- a/src/v2i-hub/SpatPlugin/test/TestSignalControllerConnection.cpp
+++ b/src/v2i-hub/SpatPlugin/test/TestSignalControllerConnection.cpp
@@ -102,7 +102,7 @@ namespace SpatPlugin {
     TEST_F(TestSignalControllerConnection, receiveBinarySPAT) {
         auto spat_binary_buf = read_binary_file("../../SpatPlugin/test/test_spat_binaries/spat_1721238398773.bin");
         EXPECT_CALL(*mockUdpServer, TimedReceive(_, 1000, 1000)).WillOnce(testing::DoAll(SetArrayArgument<0>(spat_binary_buf.begin(), spat_binary_buf.end()), Return(spat_binary_buf.size())));
-        auto spat = std::make_shared<SPAT>();
+        auto spat = (SPAT*)calloc(1, sizeof(SPAT));
 		signalControllerConnection->receiveBinarySPAT(spat, 1721238398773);
         /**
          * <SPAT>
@@ -335,11 +335,15 @@ namespace SpatPlugin {
         EXPECT_EQ(12, spat->intersections.list.array[0]->states.list.array[11]->signalGroup);
         EXPECT_EQ(3, spat->intersections.list.array[0]->states.list.array[11]->state_time_speed.list.array[0]->eventState);
         EXPECT_EQ(28027, spat->intersections.list.array[0]->states.list.array[11]->state_time_speed.list.array[0]->timing->minEndTime);
+        // Free the allocated memory for the SPAT structure
+        ASN_STRUCT_FREE(asn_DEF_SPAT, spat);
     }
     TEST_F(TestSignalControllerConnection, receiveBinarySPATException) {
         EXPECT_CALL(*mockUdpServer, TimedReceive(_, 1000, 1000)).WillOnce(testing::DoAll( Return(0)));
-        auto spat = std::make_shared<SPAT>();
+        auto spat = (SPAT*)calloc(1, sizeof(SPAT));
 		EXPECT_THROW(signalControllerConnection->receiveBinarySPAT(spat, 1721238398773), tmx::utils::UdpServerRuntimeError);
+        // Free the allocated memory for the SPAT structure
+        ASN_STRUCT_FREE(asn_DEF_SPAT, spat);
     }
 
     TEST_F(TestSignalControllerConnection, receiveUPERSPAT) {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This is a temporary fix for a large memory leak in the SPAT Plugin. This is largely due to the complexity of memory management with the V2X provided wrapper classes for J2735 ASN1 Compiler generate C structs TmxJ2735Message and TmxJ2735EncodeMessage and the ASN1 Compiler generated structs incompatibility with smart pointers.

The V2X provided wrapper classes for J2735 ASN1 Compiler generated C Structs `TmxJ2735Message` and `TmxJ2735EncodedMessage` both store a shared pointer to the underlying C struct. Depending on how they are created they will clean up none or part of this object. For instance :
**From V2X Hub Plugin programing guide**
`TmxJ2735Message(DataType &msg)`
A constructor from an existing J2735 message reference.  In this case, it is assumed that memory management is done outside this class, so destroying the object has no impact on the underlying structure.
`TmxJ2735Message(DataType *data = 0)`
This constructor builds a J2735 message from the given pointer to an already created structure.  This form assumes control over the management of the pointer, i.e. it will be freed when the object is destructed.  If the pointer is null, which is the default case, the message is considered empty.
`TmxJ2735Message(const TmxJ2735Message <DataType> & msg)`
A basic copy constructor that directly uses the same underlying J2735 structure pointer, effectively increasing the reference count by one.  Therefore, the pointer will only be freed when the last reference to it was destroyed.  Therefore, the original object can go out of scope without destroying the underlying structure used in this copy. Because the pointers are shared, changes to data inside will affect all references.  

With these varying constructors it is easy to create these wrapper types without correctly freeing their underlying C Structs

Additionally using smart pointers with the ASN1 Compiler generated C structs causes difficult with memory management. This is because they do not have destructors and instead rely on provide macros `ASN_STRUCT_FREE` to recursively step throw members and free all allocated memory. Using smart pointers will cause segmentation faults when the smart pointer destructor is called if the underlying pointer was already freed the provided macros and will leak memory if the macros is not called since the member of the C struct are not all recursively freed.


<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
VH-1449
<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This 
[Screencast from 10-01-2025 03:11:52 PM.webm](https://github.com/user-attachments/assets/8a6bbdf1-a7f7-4c9c-9252-4315ac77c4a0)
Been Tested?
Local Integration Testing with Econolite Virtual Signal Controller. Video Included below.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
