### PR TITLE
Fix bugs introduced by simplified deployment

### DIFF
--- a/configuration/initialize_docker_environment.sh
+++ b/configuration/initialize_docker_environment.sh
@@ -73,18 +73,24 @@ if [[ $SIMULATION_MODE == "TRUE" ]]; then
 fi
 # MySQL (IVP) User Password
 read -r -s -p "MYSQL PASSWORD (password for configuration database): " MYSQL_PASSWORD
-MYSQL_PASSWORD=${MYSQL_PASSWORD}
+echo
 # V2X Hub Username
 read -r -p "V2X Hub Admin Username (or press Enter to use default as v2xadmin): " V2XHUB_USERNAME
 V2XHUB_USERNAME=${V2XHUB_USERNAME:-v2xadmin}
+echo "Password must be 8-12 charcters, and contain at least one of each of the following: uppercase letter, lowercase letter, number, and symbol."
+
 # V2X Hub Password
 read -r -s -p "V2X Hub Admin Password (input will be hidden): " V2XHUB_PASSWORD
-if [ $PASS_LENGTH -ge 8 ] && echo $V2XHUB_PASSWORD | grep -q [a-z] && echo $V2XHUB_PASSWORD | grep -q [A-Z] && echo $V2XHUB_PASSWORD | grep -q [0-9] && ( echo $V2XHUB_PASSWORD | grep -q [\$\!\.\+_\*@\#\^%\?~] || echo $V2XHUB_PASSWORD | grep -q [-] ); then
+# Get length of the password
+PASS_LENGTH=$(echo "$PASS" | wc -c)
+# Validate password complexity
+if [ $PASS_LENGTH -ge 8 ] && echo "$V2XHUB_PASSWORD" | grep -q "[a-z]" && echo "$V2XHUB_PASSWORD" | grep -q "[A-Z]" && echo "$V2XHUB_PASSWORD" | grep -q "[0-9]" && ( echo "$V2XHUB_PASSWORD" | grep -q "[\$\!\.\+_\*@\#\^%\?~]" || echo "$V2XHUB_PASSWORD" | grep -q "[-]" ); then
     echo
-    read -s -p "Confirm password: " CONF_PASS
-    while [ $CONF_PASS != $V2XHUB_PASSWORD ]; do
+    # Confirm password
+    read -r -s -p "Confirm password: " CONF_PASS
+    while [ "$CONF_PASS" != "$V2XHUB_PASSWORD" ]; do
         echo
-        read -s -p "Passwords do not match. Please re-enter password: " CONF_PASS
+        read -r -s -p "Passwords do not match. Please re-enter password: " CONF_PASS
     done
     echo "VALID PASSWORD"
 else

--- a/container/service.sh
+++ b/container/service.sh
@@ -7,9 +7,8 @@ for plugin in /usr/local/plugins/*.zip; do
     echo "Installing plugin $plugin"
     tmxctl --plugin-install "$plugin"
 done
-cd /home/V2X-Hub/container/
 # Generate self-signed certificates if they do not already exist
-./generate_certificates.sh
+/home/V2X-Hub/container/generate_certificates.sh
 # command plugin must always be enabled
 tmxctl --plugin CommandPlugin --enable
 # If in simulation mode, enable SimulationAdapter

--- a/container/service.sh
+++ b/container/service.sh
@@ -7,7 +7,7 @@ for plugin in /usr/local/plugins/*.zip; do
     echo "Installing plugin $plugin"
     tmxctl --plugin-install "$plugin"
 done
-cd container/
+cd /home/V2X-Hub/container/
 # Generate self-signed certificates if they do not already exist
 ./generate_certificates.sh
 # command plugin must always be enabled


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix bugs introduced by  #774 

Bugs include the following result when running the initialization.sh script
```
14:24:09 will@will-vm ~/workspace/V2X-Hub/configuration (develop) $ ./initialization.sh 
Initializing Docker Environment for V2X Hub...
Available Release Candidates (Only intended for use during release-testing):
  release-miura
  release-neon
  release-omega
  release-stingray
  release-tempest
  release-test_run
  release-timtsp
  release-vip-demo
  release-workzone-cp
Note: V2X-Hub multi architecture deployments only work for the versions 7.0 and above.
Available Release versions:
  7.0
  7.1
  7.2
  7.2.1
  7.2.2
  7.2.3
  7.3.0
  7.3.1
  7.4.0
  7.5.0
  7.5.1
  7.6.0
  7.7.0
  7.8.0
  7.8.1
  7.9.0
  7.10.0
  release-workzone-cp
Enter V2X-Hub Version (choose from the above, or press Enter to use the latest version 7.10.0): 7.10.0
Enable Port Drayage functionality (TRUE/FALSE, or press Enter to use default as FALSE): 
Enter Infrastructure id (or press Enter to use default as rsu_1234): 
Enter Infrastructure name (or press Enter to use default as East Intersection): 
Enter V2XHub IP (or press Enter to use default as 127.0.0.1): 
Simulation Mode (TRUE/FALSE, or press Enter to use default as FALSE): 
MYSQL PASSWORD (password for configuration database): V2X Hub Admin Username (or press Enter to use default as v2xadmin): 
V2X Hub Admin Password (input will be hidden): ./initialize_docker_environment.sh: line 82: [: -ge: unary operator expected
INVALID PASSWORD
Password must be 8-12 charcters, and contain at least one of each of the following: uppercase letter, lowercase letter, number, and symbol
```

and the following docker container output when generating ssl certificates
```
v2xhub  | /usr/local/bin/service.sh: line 10: cd: container/: No such file or directory
v2xhub  | /usr/local/bin/service.sh: line 12: ./generate_certificates.sh: No such file or directory
v2xhub  | Creating V2X Hub Admin User: v2xadmin
```
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
VH-1431
<!-- e.g. CAR-123 -->

## Motivation and Context
Fix deployment issues
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
