### PR TITLE
Set absolute path to avoid relative path issues with callers

### DIFF
--- a/container/generate_certificates.sh
+++ b/container/generate_certificates.sh
@@ -8,6 +8,6 @@ if [ -f /var/www/plugins/ssl/cert.pem ] && [ -f /var/www/plugins/ssl/cert-key.pe
     exit 0
 else
     echo "Generating new self-signed certificates for V2X Hub IP $LOCAL_IP"
-    openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /var/www/plugins/ssl/cert-key.pem -out /var/www/plugins/ssl/cert.pem -config san.cnf -days 365 -extensions v3_req
+    openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /var/www/plugins/ssl/cert-key.pem -out /var/www/plugins/ssl/cert.pem -config /home/V2X-Hub/container/san.cnf -days 365 -extensions v3_req
     chown -R plugin:www-data /var/www/plugins/ssl
 fi


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Container script to generate certificates if none are present would fail since it uses a relative path for conf file passed to openssl. This change corrects this to be an absolute path
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
VH-1431
<!-- e.g. CAR-123 -->

## Motivation and Context
Fix bug
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Run `configuration/` docker compose up without ssl certificates to ensure that the V2X Hub docker container can generate them
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
