### PR TITLE
	modified:   configuration/run_v2xhub.sh

### DIFF
--- a/configuration/run_v2xhub.sh
+++ b/configuration/run_v2xhub.sh
@@ -3,10 +3,19 @@ set -e
 echo "Running V2X Hub..."
 
 if ! command -v chromium-browser &>/dev/null; then
-  echo "chromium-browser not found, install chromium-browser"
-  sudo apt update
-  sudo apt install chromium-browser -y
+  echo "chromium-browser not found, checking for chromium..."
+
+  if ! command -v chromium &>/dev/null; then
+    echo "chromium not found, installing chromium..."
+    sudo apt update
+    sudo apt install chromium-browser -y || sudo apt install chromium -y
+  else
+    echo "chromium is already installed."
+  fi
+else
+  echo "chromium-browser is already installed."
 fi
+
 # Start V2X Hub
 sudo docker compose up -d
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Update to run_v2xhub.sh script to handle package name difference between operating systems.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

chromium-browser has a different package name across operating systems. Some have a shorter name, just "chromium."
This change checks for which name to use, so the script doesn't fail.

## How Has This Been Tested?

Tested on ubuntu 24.04.4 (aarch64), debian 12, and debian 13. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
