### PR TITLE
Created Intersection Validation Plugin Shell

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -94,6 +94,7 @@ TelematicBridgePlugin.sonar.projectBaseDir     =src/v2i-hub/TelematicBridgePlugi
 MUSTSensorDriverPlugin.sonar.projectBaseDir     =src/v2i-hub/MUSTSensorDriverPlugin
 FLIRCameraDriverPlugin.sonar.projectBaseDir     =src/v2i-hub/FLIRCameraDriverPlugin
 JSONMessageLoggerPlugin.sonar.projectBaseDir =src/v2i-hub/JSONMessageLoggerPlugin
+IntersectionValidationPlugin.sonar.projectBaseDir =src/v2i-hub/IntersectionValidationPlugin
 
 # C++ Package differences
 # Sources
@@ -136,6 +137,8 @@ MUSTSensorDriverPlugin.sonar.sources  =src
 FLIRCameraDriverPlugin.sonar.sources  =src
 FLIRCameraDriverPlugin.sonar.exclusions =test/**
 JSONMessageLoggerPlugin.sonar.sources =src
+IntersectionValidationPlugin.sonar.sources =src
+IntersectionValidationPlugin.sonar.exclusions =test/**
 
 # Tests
 # Note: For C++ setting this field does not cause test analysis to occur. It only allows the test source code to be evaluated.
@@ -168,3 +171,5 @@ RSUHealthMonitorPlugin.sonar.tests=test
 TelematicBridgePlugin.sonar.tests=test
 MUSTSensorDriverPlugin.sonar.tests=test
 FLIRCameraDriverPlugin.sonar.tests=test
+#IntersectionValidationPlugin.sonar.tests=test
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -171,5 +171,5 @@ RSUHealthMonitorPlugin.sonar.tests=test
 TelematicBridgePlugin.sonar.tests=test
 MUSTSensorDriverPlugin.sonar.tests=test
 FLIRCameraDriverPlugin.sonar.tests=test
-#IntersectionValidationPlugin.sonar.tests=test
+IntersectionValidationPlugin.sonar.tests=test
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -61,7 +61,8 @@ sonar.modules=    TmxCore, \
   TelematicBridgePlugin, \
   MUSTSensorDriverPlugin, \
   FLIRCameraDriverPlugin, \
-  JSONMessageLoggerPlugin
+  JSONMessageLoggerPlugin, \
+  IntersectionValidationPlugin,
  
 
 TmxCore.sonar.projectBaseDir                    =src/tmx/TmxCore

--- a/src/v2i-hub/IntersectionValidationPlugin/CMakeLists.txt
+++ b/src/v2i-hub/IntersectionValidationPlugin/CMakeLists.txt
@@ -8,3 +8,13 @@ BuildTmxPlugin ()
 
 TARGET_INCLUDE_DIRECTORIES ( ${PROJECT_NAME} PUBLIC  )
 TARGET_LINK_LIBRARIES ( ${PROJECT_NAME} tmxutils ::carma-clock )
+
+#############
+## Testing ##
+#############
+enable_testing()
+set(BINARY ${PROJECT_NAME}_test)
+file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false test/*.cpp)
+add_executable(${BINARY} ${TEST_SOURCES})
+add_test(NAME ${BINARY} COMMAND ${BINARY})
+target_link_libraries(${BINARY} PUBLIC tmxutils gtest gmock gtest_main)

--- a/src/v2i-hub/IntersectionValidationPlugin/CMakeLists.txt
+++ b/src/v2i-hub/IntersectionValidationPlugin/CMakeLists.txt
@@ -1,0 +1,10 @@
+PROJECT ( IntersectionValidationPlugin VERSION 7.11.1 LANGUAGES CXX )
+
+SET (TMX_PLUGIN_NAME "Intersection Validation")
+
+FIND_PACKAGE (carma-clock)
+
+BuildTmxPlugin ()
+
+TARGET_INCLUDE_DIRECTORIES ( ${PROJECT_NAME} PUBLIC  )
+TARGET_LINK_LIBRARIES ( ${PROJECT_NAME} tmxutils ::carma-clock )

--- a/src/v2i-hub/IntersectionValidationPlugin/README.md
+++ b/src/v2i-hub/IntersectionValidationPlugin/README.md
@@ -6,7 +6,7 @@ The Intersection Validation Plugin is responsible for validating MAP, SPaT and T
 
 ## Related Plugins
 
-A list of plugins related to the SPaT Plugin.
+A list of plugins related to the Intersection Validation Plugin.
 
 ## Configuration/Deployment
 

--- a/src/v2i-hub/IntersectionValidationPlugin/README.md
+++ b/src/v2i-hub/IntersectionValidationPlugin/README.md
@@ -1,0 +1,17 @@
+# Intersection Validation Documentation
+
+## Introduction
+
+The Intersection Validation Plugin is responsible for validating MAP, SPaT and TIM messages received from RSUs prior to sending these messages to Connected Intersections Message Monitoring Systems (CIMMS).
+
+## Related Plugins
+
+A list of plugins related to the SPaT Plugin.
+
+## Configuration/Deployment
+
+## Design
+
+### Messages
+
+## Functionality Testing

--- a/src/v2i-hub/IntersectionValidationPlugin/README.md
+++ b/src/v2i-hub/IntersectionValidationPlugin/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The Intersection Validation Plugin is responsible for validating MAP, SPaT and TIM messages received from RSUs prior to sending these messages to Connected Intersections Message Monitoring Systems (CIMMS).
+The Intersection Validation Plugin is responsible for validating MAP, SPaT and TIM messages received from RSUs against the CTI 4501 standard.
 
 ## Related Plugins
 

--- a/src/v2i-hub/IntersectionValidationPlugin/manifest.json
+++ b/src/v2i-hub/IntersectionValidationPlugin/manifest.json
@@ -1,0 +1,32 @@
+{
+  "name": "IntersectionValidationPlugin",
+  "description": "Intersection Validation plugin for validating the intersection data received from the MAP SPAT TIM messages.",
+  "version": "@PROJECT_VERSION@",
+  "exeLocation": "/bin/IntersectionValidationPlugin",
+  "coreIpAddr": "127.0.0.1",
+  "corePort": 24601,
+  "messageTypes": [
+    {
+      "type": "J2735",
+      "subtype": "SPAT-P",
+      "description": "Decoded SPaT messages"
+    },
+    {
+      "type": "J2735",
+      "subtype": "MAP-P",
+      "description": "Decoded MAP messages"
+    },
+    {
+      "type": "J2735",
+      "subtype": "TIM",
+      "description": "Traveler Information Messages"
+    }
+  ],
+  "configuration": [
+    {
+      "key": "Instance",
+      "default": "0",
+      "description": "The instance of this plugin."
+    }
+  ]
+}

--- a/src/v2i-hub/IntersectionValidationPlugin/manifest.json
+++ b/src/v2i-hub/IntersectionValidationPlugin/manifest.json
@@ -9,24 +9,29 @@
     {
       "type": "J2735",
       "subtype": "SPAT-P",
-      "description": "Decoded SPaT messages"
+      "description": "Signal Phase and Timing (SPAT) status for the signalized intersection."
     },
     {
       "type": "J2735",
       "subtype": "MAP-P",
-      "description": "Decoded MAP messages"
+      "description": "Full geometric layout of the intersection."
     },
     {
       "type": "J2735",
       "subtype": "TIM",
-      "description": "Traveler Information Messages"
+      "description": "Travelor Information Message indicating the active Work Zone information."
     }
   ],
-  "configuration": [
-    {
-      "key": "Instance",
-      "default": "0",
-      "description": "The instance of this plugin."
-    }
+  "configuration":[
+		{
+			"key":"LogLevel",
+			"default":"INFO",
+			"description": "Map Plugin Log Level controls which log statements are printed to the terminal."
+		},
+		{
+			"key": "LogOutput",
+			"default": "-",
+			"description": "Name of the log file for this plugin. If a relative path is provided, this file will create a directory under /var/log/<PluginName> and add the file here. Not including this parameter or setting to (-) will direct log output to stdout which is the default behavior. NOTE: File logging for plugins should only be used for temporary data collection. Current file logging does not have mechanisms to purge data after a certain time or size."
+		}
   ]
 }

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -21,28 +21,47 @@ using namespace tmx::messages;
  
 namespace IntersectionValidation
 {
-    IntersectionValidationPlugin::IntersectionValidationPlugin(const std::string &name)
-        : PluginClient(name)
+    IntersectionValidationPlugin::IntersectionValidationPlugin(const std::string &name): PluginClientClockAware(name)
     {
  
-        AddMessageFilter<SpatMessage>(this, &IntersectionValidationPlugin::ValidateSpatMessage);
-        AddMessageFilter<MapDataMessage>(this, &IntersectionValidationPlugin::ValidateMapDataMessage);
-        AddMessageFilter<TimMessage>(this, &IntersectionValidationPlugin::ValidateTimMessage);
+        AddMessageFilter<SpatMessage>(this, &IntersectionValidationPlugin::HandleSpatMessage);
+        AddMessageFilter<MapDataMessage>(this, &IntersectionValidationPlugin::HandleMapDataMessage);
+        AddMessageFilter<TimMessage>(this, &IntersectionValidationPlugin::HandleTimMessage);
  
         SubscribeToMessages();
     }
+
+    void IntersectionValidationPlugin::UpdateConfigSettings()
+    {
+        // TODO: Implement configuration setting update logic
+    }
+
+	void IntersectionValidationPlugin::OnConfigChanged(const char *key, const char *value)
+	{
+		// TODO: Implement configuration change handling
+	}
+
+	void IntersectionValidationPlugin::OnMessageReceived(IvpMessage *msg)
+	{
+		// TODO: Implement message receiving handling
+	}
+
+	void IntersectionValidationPlugin::OnStateChange(IvpPluginState state)
+	{
+		// TODO: Implement state change handling
+	}
  
-    void IntersectionValidationPlugin::ValidateSpatMessage(SpatMessage &msg, routeable_message &routeableMsg)
+    void IntersectionValidationPlugin::HandleSpatMessage(SpatMessage &msg, routeable_message &routeableMsg)
     {
         // TODO: Perform SPAT required fields validation
     }
  
-    void IntersectionValidationPlugin::ValidateMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg)
+    void IntersectionValidationPlugin::HandleMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg)
     {
         // TODO: Perform MAP required fields validation
     }
  
-    void IntersectionValidationPlugin::ValidateTimMessage(TimMessage &msg, routeable_message &routeableMsg)
+    void IntersectionValidationPlugin::HandleTimMessage(TimMessage &msg, routeable_message &routeableMsg)
     {
         // TODO: Perform TIM required fields validation
     }

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+ 
+#include "IntersectionValidationPlugin.h"
+using namespace tmx;
+using namespace tmx::utils;
+using namespace tmx::messages;
+ 
+namespace IntersectionValidation
+{
+    IntersectionValidationPlugin::IntersectionValidationPlugin(const std::string &name)
+        : PluginClient(name)
+    {
+ 
+        AddMessageFilter<SpatMessage>(this, &IntersectionValidationPlugin::ValidateSpatMessage);
+        AddMessageFilter<MapDataMessage>(this, &IntersectionValidationPlugin::ValidateMapDataMessage);
+        AddMessageFilter<TimMessage>(this, &IntersectionValidationPlugin::ValidateTimMessage);
+ 
+        SubscribeToMessages();
+    }
+ 
+    void IntersectionValidationPlugin::ValidateSpatMessage(SpatMessage &msg, routeable_message &routeableMsg)
+    {
+        // TODO: Perform SPAT required fields validation
+    }
+ 
+    void IntersectionValidationPlugin::ValidateMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg)
+    {
+        // TODO: Perform MAP required fields validation
+    }
+ 
+    void IntersectionValidationPlugin::ValidateTimMessage(TimMessage &msg, routeable_message &routeableMsg)
+    {
+        // TODO: Perform TIM required fields validation
+    }
+ 
+}
+ 
+int main(int argc, char *argv[])
+{
+    return run_plugin<IntersectionValidation::IntersectionValidationPlugin>("IntersectionValidationPlugin", argc, argv);
+}

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#pragma once
+#include <iostream>
+#include <sstream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <thread>
+#include <PluginClient.h>
+ 
+#include <tmx/j2735_messages/MapDataMessage.hpp>
+#include <tmx/j2735_messages/SpatMessage.hpp>
+#include <tmx/j2735_messages/TravelerInformationMessage.hpp>
+ 
+using namespace tmx;
+using namespace tmx::utils;
+using namespace tmx::messages;
+ 
+namespace IntersectionValidation
+{
+ 
+    class IntersectionValidationPlugin : public tmx::utils::PluginClient
+    {
+    public:
+        IntersectionValidationPlugin(const std::string &name);
+        ~IntersectionValidationPlugin() override = default;
+ 
+        // Message handlers
+        void ValidateSpatMessage(SpatMessage &msg, routeable_message &routeableMsg);
+        void ValidateMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg);
+        void ValidateTimMessage(TimMessage &msg, routeable_message &routeableMsg);
+    };
+ 
+}

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -25,10 +25,7 @@
 #include <tmx/j2735_messages/MapDataMessage.hpp>
 #include <tmx/j2735_messages/SpatMessage.hpp>
 #include <tmx/j2735_messages/TravelerInformationMessage.hpp>
- 
-using namespace tmx;
-using namespace tmx::utils;
-using namespace tmx::messages;
+
  
 namespace IntersectionValidation
 {
@@ -36,15 +33,15 @@ namespace IntersectionValidation
     class IntersectionValidationPlugin : public tmx::utils::PluginClientClockAware
     {
     public:
-        IntersectionValidationPlugin(const std::string &name);
+        explicit IntersectionValidationPlugin(const std::string &name);
         ~IntersectionValidationPlugin() override = default;
 
         void UpdateConfigSettings();
  
         // Message handlers
-        void HandleSpatMessage(SpatMessage &msg, routeable_message &routeableMsg);
-        void HandleMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg);
-        void HandleTimMessage(TimMessage &msg, routeable_message &routeableMsg);
+        void HandleSpatMessage(tmx::messages::SpatMessage &msg, tmx::routeable_message &routeableMsg);
+        void HandleMapDataMessage(tmx::messages::MapDataMessage &msg, tmx::routeable_message &routeableMsg);
+        void HandleTimMessage(tmx::messages::TimMessage &msg, tmx::routeable_message &routeableMsg);
 
     protected:
         // Virtual method overrides.

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <string>
 #include <thread>
-#include <PluginClient.h>
+#include <PluginClientClockAware.h>
  
 #include <tmx/j2735_messages/MapDataMessage.hpp>
 #include <tmx/j2735_messages/SpatMessage.hpp>
@@ -33,16 +33,23 @@ using namespace tmx::messages;
 namespace IntersectionValidation
 {
  
-    class IntersectionValidationPlugin : public tmx::utils::PluginClient
+    class IntersectionValidationPlugin : public tmx::utils::PluginClientClockAware
     {
     public:
         IntersectionValidationPlugin(const std::string &name);
         ~IntersectionValidationPlugin() override = default;
+
+        void UpdateConfigSettings();
  
         // Message handlers
-        void ValidateSpatMessage(SpatMessage &msg, routeable_message &routeableMsg);
-        void ValidateMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg);
-        void ValidateTimMessage(TimMessage &msg, routeable_message &routeableMsg);
+        void HandleSpatMessage(SpatMessage &msg, routeable_message &routeableMsg);
+        void HandleMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg);
+        void HandleTimMessage(TimMessage &msg, routeable_message &routeableMsg);
+
+    protected:
+        // Virtual method overrides.
+        void OnConfigChanged(const char *key, const char *value) override;
+        void OnMessageReceived(IvpMessage *msg) override;
+        void OnStateChange(IvpPluginState state) override;
     };
- 
 }

--- a/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <tmx/j2735_messages/SpatMessage.hpp>
+#include <tmx/j2735_messages/MapDataMessage.hpp>
+#include <tmx/j2735_messages/TravelerInformationMessage.hpp>
+ 
+using namespace tmx::messages;
+ 
+namespace {
+ 
+TEST(MessageTypeTest, SpatMessageCanBeInstantiated) {
+    SpatMessage msg;
+    SUCCEED();
+}
+ 
+TEST(MessageTypeTest, MapDataMessageCanBeInstantiated) {
+    MapDataMessage msg;
+    SUCCEED();
+}
+ 
+TEST(MessageTypeTest, TimMessageCanBeInstantiated) {
+    TimMessage msg;
+    SUCCEED();
+}
+  
+TEST(SpatValidationTest, DISABLED_ValidSpatPassesValidation) {
+    // TODO: Construct a SPaT with all required fields and verify validation passes
+}
+ 
+TEST(MapValidationTest, DISABLED_ValidMapPassesValidation) {
+    // TODO: Construct a MAP with all required fields and verify validation passes
+}
+  
+TEST(TimValidationTest, DISABLED_ValidTimPassesValidation) {
+    // TODO: Construct a TIM with all required fields and verify validation passes
+}
+  
+TEST(FrequencyValidationTest, DISABLED_SpatFrequencyWithinExpectedFrequency) {
+    // TODO: Simulate SPaT messages arriving at expected frequency
+}
+ 
+TEST(FrequencyValidationTest, DISABLED_MapFrequencyWithinExpectedFrequency) {
+    // TODO: Simulate MAP messages arriving at expected frequency
+}
+
+TEST(FrequencyValidationTest, DISABLED_TimFrequencyWithinExpectedFrequency) {
+    // TODO: Simulate TIM messages arriving at expected frequency
+}
+ 
+} // namespace


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Created the shell for the Intersection Validation Plugin, including .h, .c files, CMakeLists, manifest.json and READme.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[VH-1534](https://usdot-carma.atlassian.net/browse/VH-1534?atlOrigin=eyJpIjoiNGYwZjliMjM0NTQzNGZkNzg3NjU0YzlkZjRlZjFhY2QiLCJwIjoiaiJ9)

## Motivation and Context

New plugin for CTI 4501 message validation on the edge.

## How Has This Been Tested?

Local deployment testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[VH-1534]: https://usdot-carma.atlassian.net/browse/VH-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ