### PR TITLE
Switched addEventLogEntry to use prepared statements OMDO-145

### DIFF
--- a/src/tmx/TmxCore/src/database/LogContext.cpp
+++ b/src/tmx/TmxCore/src/database/LogContext.cpp
@@ -37,18 +37,18 @@ void LogContext::addEventLogEntry(std::string source, std::string description, L
 	}
 
 	try {
-		std::unique_ptr<sql::Statement> stmt(this->getStatement());
+	    std::unique_ptr<sql::PreparedStatement> stmt(
+			this->getPreparedStatement(
+				"INSERT INTO `eventLog` (`source`,`description`,`logLevel`) VALUES (?, ?, ?)"
+			)
+		);
 
-		stringstream query;
-		query << "INSERT INTO `eventLog` (`source`,`description`,`logLevel`) VALUES (";
-		query << "'" << source << "'";
-		query << ", ";
-		query << "'" << DbContext::formatStringValue(description) << "'";
-		query << ", ";
-		query << "'" << levelString << "'";
-		query << ");";
+		stmt->setString(1, source);
+		stmt->setString(2, description);
+		stmt->setString(3, levelString);
 
-		stmt->execute(query.str());
+		stmt->execute();
+
 	} catch (DbException &e) {
 		LOG_WARN("MySQL: Unable to add event log entry [" << e.what() << "]");
 	}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This fix and completely remediate # 115 - SQL Injection via Plugin Registration Name in `LogContext::addEventLogEntry`. It switches queries to prepared statements which require no manual escaping as database handles all sanitization of inputs. It's immune to: quote injection, encoding tricks, SQL parser edge cases. It uses `DbContext::getPreparedStatement` to switch to prepared statement.

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/OMDO-145

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

This was **manually** tested by enabling plugins, enabling plugins via the UI, verifying the database table `IVP.eventLog`, and verifying event logs in UI which has expected log records for plugins.

> I would not recommend investing in unit testing the persistence layer, tests are usually super brittle, expensive to write, and performance intensive. I have explored options but this would best be covered in integration tests, possibly with testcontainer.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
