### PR TITLE
switched removePluginStatusItems function to use prepared statements

### DIFF
--- a/src/tmx/TmxCore/src/database/PluginContext.cpp
+++ b/src/tmx/TmxCore/src/database/PluginContext.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "PluginContext.h"
+#include "../logger.h"
 #include <assert.h>
 #include <sstream>
 
@@ -132,7 +133,7 @@ void PluginContext::setPluginStatusItems(unsigned int pluginId, std::vector<Plug
 	}
 }
 
-void PluginContext::removePluginStatusItems(unsigned int pluginId, std::vector<std::string> itemKeys)
+void PluginContext::removePluginStatusItems(unsigned int pluginId, const std::vector<std::string>& itemKeys)
 {
     std::unique_ptr<sql::PreparedStatement> stmt(
         this->getPreparedStatement(
@@ -140,7 +141,7 @@ void PluginContext::removePluginStatusItems(unsigned int pluginId, std::vector<s
         )
     );
 
-    for (const auto& key : itemKeys)
+	for (const auto& key : itemKeys)
     {
         stmt->setUInt(1, pluginId);
         stmt->setString(2, key);

--- a/src/tmx/TmxCore/src/database/PluginContext.cpp
+++ b/src/tmx/TmxCore/src/database/PluginContext.cpp
@@ -134,14 +134,18 @@ void PluginContext::setPluginStatusItems(unsigned int pluginId, std::vector<Plug
 
 void PluginContext::removePluginStatusItems(unsigned int pluginId, std::vector<std::string> itemKeys)
 {
-	std::unique_ptr<sql::Statement> stmt(this->getStatement());
+    std::unique_ptr<sql::PreparedStatement> stmt(
+        this->getPreparedStatement(
+            "DELETE FROM `pluginStatus` WHERE `pluginId` = ? AND `key` = ?;"
+        )
+    );
 
-	for(vector<string>::iterator itr = itemKeys.begin(); itr != itemKeys.end(); itr++)
-	{
-		stringstream query;
-		query << "DELETE FROM `pluginStatus` WHERE `pluginId` = '" << pluginId << "' AND `key` = '" << DbContext::formatStringValue(*itr) << "';";
-		stmt->execute(query.str());
-	}
+    for (const auto& key : itemKeys)
+    {
+        stmt->setUInt(1, pluginId);
+        stmt->setString(2, key);
+        stmt->executeUpdate();
+    }
 }
 
 void PluginContext::removeAllPluginStatusItems(unsigned int pluginId)

--- a/src/tmx/TmxCore/src/database/PluginContext.cpp
+++ b/src/tmx/TmxCore/src/database/PluginContext.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "PluginContext.h"
-#include "../logger.h"
 #include <assert.h>
 #include <sstream>
 

--- a/src/tmx/TmxCore/src/database/PluginContext.h
+++ b/src/tmx/TmxCore/src/database/PluginContext.h
@@ -60,7 +60,7 @@ public:
 	void setStatusForAllPlugins(std::string status);
 	void setPluginStatus(unsigned int pluginId, std::string status);
 	void setPluginStatusItems(unsigned int pluginId, std::vector<PluginStatusItem> statusItems);
-	void removePluginStatusItems(unsigned int pluginId, std::vector<std::string> itemKeys);
+	void removePluginStatusItems(unsigned int pluginId, const std::vector<std::string>& itemKeys);
 	void removeAllPluginStatusItems(unsigned int pluginId);
 	void removeAllPluginStatusItems();
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This fixes and completely remediates # 120 SQL Injection in `PluginContext::removePluginStatusItems`. It switches queries to prepared statements which require no manual escaping as database handles all sanitization of inputs. It's immune to: quote injection, encoding tricks, SQL parser edge cases. It uses `DbContext::getPreparedStatement` to switch to prepared statement. 

- Fixed SonarQube issue: pass `itemKeys` by const reference to avoid expensive copy.

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/OMDO-147
<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

This was **manually** tested by enabling and disabling plugins, specifically the Message Receiver plugin, and verifying the database table `IVP.pluginStatus` has expected configuration parameter records for plugin.

> I would not recommend investing in unit testing the persistence layer, tests are usually super brittle, expensive to write, and performance intensive. I have explored options but this would best be covered in integration tests, possibly with testcontainer.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
