### PR TITLE
Switched to prepared statements and modernized SQL syntax OMDO-148

### DIFF
--- a/src/tmx/TmxCore/src/database/MessageContext.cpp
+++ b/src/tmx/TmxCore/src/database/MessageContext.cpp
@@ -55,33 +55,46 @@ void MessageContext::insertOrUpdateMessageActivity(MessageActivityEntry &entry)
 
 void MessageContext::insertMessageType(MessageTypeEntry &entry, bool updateDescriptionOnDuplicate)
 {
-	std::unique_ptr<sql::Statement> stmt(this->getStatement());
+	// INSERT / UPSERT Message Type
+    std::string query =
+        "INSERT INTO `messageType` (`type`, `subtype`, `description`) "
+        "VALUES (?, ?, ?) AS new ";
 
-	stringstream query;
-	query << "INSERT INTO messageType (type, subtype, description)";
-	query << " VALUES ('" << entry.type << "','" << entry.subtype << "','" << entry.description << "')";
-	if (updateDescriptionOnDuplicate)
-		query << " ON DUPLICATE KEY UPDATE description=VALUES(description)";
-	else
-		query << " ON DUPLICATE KEY UPDATE `description`=IF(LENGTH(`description`)=0, '" << entry.description << "', `description`)";
+    if (updateDescriptionOnDuplicate)
+    {
+		// Always update description
+        query += "ON DUPLICATE KEY UPDATE `description` = new.description";
+    }
+    else
+    {
+		// Only update description, if current description is empty
+        query += "ON DUPLICATE KEY UPDATE `description` = IF(LENGTH(`description`) = 0, new.description, `description`)";
+    }
 
-	query << ";";
+    std::unique_ptr<sql::PreparedStatement> pstmt(this->getPreparedStatement(query));
+    pstmt->setString(1, entry.type);
+    pstmt->setString(2, entry.subtype);
+    pstmt->setString(3, entry.description);
+    pstmt->execute();
 
-	stmt->execute(query.str());
+    // Query for id of row that was just inserted/updated.
+    std::unique_ptr<sql::PreparedStatement> qstmt(
+        this->getPreparedStatement(
+            "SELECT `id`, `description` FROM `messageType` "
+            "WHERE `type` = ? AND `subtype` = ?"
+        )
+    );
 
-	// Query for id of row that was just inserted/updated.
+    qstmt->setString(1, entry.type);
+    qstmt->setString(2, entry.subtype);
 
-	query.clear();
-	query.str("");
-	query << "SELECT * FROM `messageType`";
-	query << " WHERE `messageType`.`type` = '" << entry.type << "' AND `messageType`.`subtype` = '" << entry.subtype << "'";
-
-	std::unique_ptr<sql::ResultSet> rset(stmt->executeQuery(query.str()));
-	if (rset->next())
-	{
-		entry.id = rset->getUInt("id");
-		entry.description = rset->getUInt("description");
-	}
+    std::unique_ptr<sql::ResultSet> rset(qstmt->executeQuery());
+    if (rset->next())
+    {
+		// Retrieve current id and description for use outside of function
+        entry.id = rset->getUInt("id");
+        entry.description = rset->getString("description");
+    }
 }
 
 void MessageContext::mapPluginToMessageType(unsigned int pluginId, unsigned int messageTypeId)

--- a/src/tmx/TmxCore/src/database/MessageContext.cpp
+++ b/src/tmx/TmxCore/src/database/MessageContext.cpp
@@ -68,7 +68,7 @@ void MessageContext::insertMessageType(MessageTypeEntry &entry, bool updateDescr
     else
     {
 		// Only update description, if current description is empty
-        query += "ON DUPLICATE KEY UPDATE `description` = IF(LENGTH(`description`) = 0, new.description, `description`)";
+        query += "ON DUPLICATE KEY UPDATE `description` = IF(LENGTH(`messageType`.`description`) = 0, new.description, `messageType`.`description`)";
     }
 
     std::unique_ptr<sql::PreparedStatement> pstmt(this->getPreparedStatement(query));


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This fixes and completely remediates # 122 SQL Injection in `MessageContext::insertMessageType`. It switches queries to prepared statements which require no manual escaping as database handles all sanitization of inputs. It's immune to: quote injection, encoding tricks, SQL parser edge cases. It uses `DbContext::getPreparedStatement` to switch to prepared statement. 

- Switched to modern MySQL syntax, and MySQL deprecated `VALUES()` in favor of row/column aliases. See documentation
https://dev.mysql.com/doc/refman/9.6/en/insert-on-duplicate.html

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
https://usdot-carma.atlassian.net/browse/OMDO-148
<!-- e.g. CAR-123 -->

## Motivation and Context
To address DARPA security findings.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This was **manually** tested.
### Test Steps
1. Clear database volume
2. Prior to start of V2-Hub 
3. Verify database state
   - Log into database from v2xhub container `mysql -u IVP -p IVP`
   - `SELECT * FROM IVP.messageType;`
   - Expected result
```
mysql> SELECT * FROM IVP.messageType;
Empty set (0.01 sec)
```
5. Start V2-Hub 
6. Verifying the database table `IVP.messageType` has expected records.  Note, record for `| System | KeepAlive |` exercise conditional "Only update description, if current description is empty". Other records will trigger Insert/Always Update description logic and Select statement.
```
mysql> SELECT * FROM IVP.messageType;
+----+--------+-----------+-----------------------------------+
| id | type   | subtype   | description                       |
+----+--------+-----------+-----------------------------------+
| 16 | J2735  | IC        | DSRC Intersection Collision       |
| 17 | J2735  | MAP       | DSRC Map Data                     |
| 18 | J2735  | SPAT      | DSRC SPAT Message                 |
| 19 | J2735  | BSM       | DSRC Basic Safety Message         |
| 20 | J2735  | CSR       | DSRC Common Safety Request        |
| 21 | J2735  | EVA       | DSRC Emergency Vehicle Alert      |
| 22 | J2735  | NMEA      | DSRC NMEA Corrections             |
| 23 | J2735  | PDM       | DSRC Probe Data Management        |
| 24 | J2735  | PVD       | DSRC Probe Vehicle Data           |
| 25 | J2735  | RSA       | DSRC Road Side Alert              |
| 26 | J2735  | RTCM      | DSRC RTCM Corrections             |
| 27 | J2735  | SRM       | DSRC Signal Request Message       |
| 28 | J2735  | SSM       | DSRC Signal Status Message        |
| 29 | J2735  | TIM       | DSRC Traveler Information Message |
| 30 | System | KeepAlive |                                   |
+----+--------+-----------+-----------------------------------+
15 rows in set (0.00 sec)
```
> I would not recommend investing in unit testing the persistence layer, tests are usually super brittle, expensive to write, and performance intensive. I have explored options but this would best be covered in integration tests, possibly with testcontainer.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
