### PR TITLE
Switched to prepared statements and modernized SQL syntax OMDO-149 & OMDO-150

### DIFF
--- a/src/tmx/TmxCore/src/database/PluginContext.cpp
+++ b/src/tmx/TmxCore/src/database/PluginContext.cpp
@@ -8,7 +8,6 @@
 #include "PluginContext.h"
 #include <assert.h>
 #include <sstream>
-
 using namespace std;
 
 PluginContext::PluginContext()
@@ -97,14 +96,6 @@ void PluginContext::removeAllNotInstalled()
 	stmt->execute(query.str());
 }
 
-/*void PluginContext::clearPluginStatuses()
-{
-	std::unique_ptr<sql::Statement> stmt(this->getStatement());
-
-	string query = "DELETE FROM `pluginStatus`";
-	stmt->execute(query);
-}*/
-
 void PluginContext::setStatusForAllPlugins(std::string status)
 {
 	std::unique_ptr<sql::Statement> stmt(this->getStatement());
@@ -124,28 +115,39 @@ void PluginContext::setPluginStatus(unsigned int pluginId, std::string status)
 	stmt->execute(query.str());
 }
 
-void PluginContext::setPluginStatusItems(unsigned int pluginId, std::vector<PluginStatusItem> statusItems)
+void PluginContext::setPluginStatusItems(unsigned int pluginId, const std::vector<PluginStatusItem>& statusItems)
 {
-	std::unique_ptr<sql::Statement> stmt(this->getStatement());
+	// No Status Changes
+    if (statusItems.empty()){
+        return;
+	}
 
-	if (statusItems.size() > 0)
-	{
-		stringstream query;
-		query << "INSERT INTO `pluginStatus` (`pluginId`,`key`,`value`) VALUES ";
-
-		bool first = true;
-		for(vector<PluginStatusItem>::iterator itr = statusItems.begin(); itr != statusItems.end(); itr++)
-		{
-			if (!first)
-				query << ", ";
-			query << "('" << pluginId << "', '" << DbContext::formatStringValue(itr->key) << "', '" << DbContext::formatStringValue(itr->value) << "')";
-			first = false;
+	// Insert / Update Plugin Status
+    std::string query = "INSERT INTO `pluginStatus` (`pluginId`, `key`, `value`) VALUES ";
+    //NOSONAR Build multirow insert of tuples e.g., (?, ?, ?), (?, ?, ?), (?, ?, ?)
+    for (size_t i = 0; i < statusItems.size(); ++i)
+    {
+        if (i > 0){
+            query += ", ";
 		}
 
-		query << " ON DUPLICATE KEY UPDATE value = VALUES(value);";
+        query += "(?, ?, ?)";
+    }
 
-		stmt->execute(query.str());
-	}
+    query += "  as new ON DUPLICATE KEY UPDATE `value` = new.value";
+
+    std::unique_ptr<sql::PreparedStatement> stmt(this->getPreparedStatement(query));
+
+	// Assign multirow insert inputs
+    int paramIndex = 1;
+    for (const auto &item : statusItems)
+    {
+        stmt->setUInt(paramIndex++, pluginId);
+        stmt->setString(paramIndex++, item.key);
+        stmt->setString(paramIndex++, item.value);
+    }
+
+    stmt->execute();
 }
 
 void PluginContext::removePluginStatusItems(unsigned int pluginId, const std::vector<std::string>& itemKeys)

--- a/src/tmx/TmxCore/src/database/PluginContext.cpp
+++ b/src/tmx/TmxCore/src/database/PluginContext.cpp
@@ -139,12 +139,15 @@ void PluginContext::setPluginStatusItems(unsigned int pluginId, const std::vecto
     std::unique_ptr<sql::PreparedStatement> stmt(this->getPreparedStatement(query));
 
 	// Assign multirow insert inputs
-    int paramIndex = 1;
+    int paramIndex = 0;
     for (const auto &item : statusItems)
     {
-        stmt->setUInt(paramIndex++, pluginId);
-        stmt->setString(paramIndex++, item.key);
-        stmt->setString(paramIndex++, item.value);
+        stmt->setUInt(paramIndex + 1, pluginId);
+        stmt->setString(paramIndex + 2, item.key);
+        stmt->setString(paramIndex + 3, item.value);
+
+        // Increment for next row's tuple
+        paramIndex += 3;
     }
 
     stmt->execute();

--- a/src/tmx/TmxCore/src/database/PluginContext.cpp
+++ b/src/tmx/TmxCore/src/database/PluginContext.cpp
@@ -59,13 +59,29 @@ PluginEntry PluginContext::getPlugin(std::string pluginName)
 
 void PluginContext::insertOrUpdatePlugin(PluginEntry &entry)
 {
-	std::unique_ptr<sql::Statement> stmt(this->getStatement());
+	// Insert / Update Plugin
+	std::string query =
+		"INSERT INTO `plugin` (`name`, `description`, `version`) "
+		"VALUES (?, ?, ?) as new "
+		"ON DUPLICATE KEY UPDATE "
+		"`name` = new.name, "
+		"`description` = new.description, "
+		"`version` = new.version";
 
-	string query = "INSERT INTO plugin (name, description, version) VALUES ('" + DbContext::formatStringValue(entry.name) + "', '" + DbContext::formatStringValue(entry.description) + "', '" + DbContext::formatStringValue(entry.version) + "') ON DUPLICATE KEY UPDATE name = VALUES(name), description = VALUES(description), version = VALUES(version)";
-	stmt->execute(query);
+	std::unique_ptr<sql::PreparedStatement> insertStmt(this->getPreparedStatement(query));
+	insertStmt->setString(1, entry.name);
+	insertStmt->setString(2, entry.description);
+	insertStmt->setString(3, entry.version);
+	insertStmt->execute();
 
-	query = "SELECT `id` FROM `plugin` WHERE `plugin`.`name` = '" + entry.name + "';";
-	std::unique_ptr< sql::ResultSet > rset(stmt->executeQuery(query));
+	std::unique_ptr<sql::PreparedStatement> selectStmt(
+		this->getPreparedStatement("SELECT `id` FROM `plugin` WHERE `plugin`.`name` = ?")
+	);
+
+	selectStmt->setString(1, entry.name);
+
+	// Query for id of row that was just inserted/updated.
+	std::unique_ptr<sql::ResultSet> rset(selectStmt->executeQuery());
 	if (rset->next())
 	{
 		entry.id = rset->getUInt("id");

--- a/src/tmx/TmxCore/src/database/PluginContext.h
+++ b/src/tmx/TmxCore/src/database/PluginContext.h
@@ -59,7 +59,7 @@ public:
 
 	void setStatusForAllPlugins(std::string status);
 	void setPluginStatus(unsigned int pluginId, std::string status);
-	void setPluginStatusItems(unsigned int pluginId, std::vector<PluginStatusItem> statusItems);
+	void setPluginStatusItems(unsigned int pluginId, const std::vector<PluginStatusItem>& statusItems);
 	void removePluginStatusItems(unsigned int pluginId, const std::vector<std::string>& itemKeys);
 	void removeAllPluginStatusItems(unsigned int pluginId);
 	void removeAllPluginStatusItems();


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This fixes and completely remediates # 130 SQL Injection in `PluginContext::insertOrUpdatePlugin` and # 147 SQL Injection in `PluginContext::setPluginStatusItems`. It switches queries to prepared statements which require no manual escaping as database handles all sanitization of inputs. It's immune to: quote injection, encoding tricks, SQL parser edge cases. It uses `DbContext::getPreparedStatement` to switch to prepared statement. 

- Switched to modern MySQL syntax, and MySQL deprecated `VALUES()` in favor of row/column aliases. See documentation https://dev.mysql.com/doc/refman/9.6/en/insert-on-duplicate.html
- Deletes dead code
- simplifies control flow logic in `PluginContext::setPluginStatusItems`
- Updated `PluginContext::setPluginStatusItems` function signature to pass by const reference.

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
https://usdot-carma.atlassian.net/browse/OMDO-149

## Motivation and Context
To address DARPA security findings.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This was **manually** tested.
### Test Steps OMDO-149
1. Clear database volume
2. Prior to start of V2-Hub 
3. Verify database state
   - Log into database from v2xhub container `mysql -u IVP -p IVP`
   - `SELECT * FROM IVP.plugin;`
   - Expected result
```
mysql> SELECT * FROM IVP.plugin;
Empty set (0.01 sec)
```
5. Start V2-Hub 
6. Verifying the database table `IVP.plugin` has expected records.  
```
mysql> SELECT * FROM IVP.plugin;
+----+------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+
| id | name                         | description                                                                                                                                                           | version |
+----+------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+
|  0 | Plugin System                | The global configuration for all TMX plugins                                                                                                                          | 4.0     |
| 24 | CARMACloud                   | CARMA cloud plugin for making websocket connection with CARMA cloud .                                                                                                 | 7.11.1  |
| 25 | CARMAStreetsPlugin           | Plugin to communicate with CARMA Streets via Apache Kafka                                                                                                             | 7.11.1  |
| 26 | CDASimAdapter                | CDASim Adapter is the V2X-Hub plugin that facilitates the connection between the CDASim simulation environment and V2X-Hub and CARMA Streets.                         | 7.11.1  |
| 27 | CommandPlugin                | Listens for websocket connections from the TMX admin portal and processes commands                                                                                    | 7.11.1  |
| 28 | CSW                          | Provides Curve Speed Warning (CSW).                                                                                                                                   | 7.11.1  |
| 29 | DynamicMessageSign           | Provides communication to a dynamic message sign.                                                                                                                     | 7.11.1  |
| 30 | ERVCloudForwarding           | ERV (Emergency Response Vehicle) cloud plugin for making websocket connection with CARMA cloud, and forward ERV BSM to CARMA cloud.                                   | 7.11.1  |
| 31 | FLIRCameraDriverPlugin       | FLIRCameraDriverPlugin consumes FLIR camera pedestrian detection data and publishes it as Sensor Detected Objects used for Cooperative Perception Messages like SDSM. | 7.11.1  |
| 32 | ImmediateForward             | Plugin that listens for TMX messages and forwards them to the V2X Radio (i.e. the RSU).                                                                               | 7.11.1  |
| 33 | IntersectionValidationPlugin | Intersection Validation plugin for validating the intersection data received from the MAP SPAT TIM messages.                                                          | 7.11.1  |
| 34 | JSONMessageLoggerPlugin      | Plugin that logs J2735 messages in JSON format                                                                                                                        | 7.11.1  |
| 35 | Location                     | Plugin used to send out Location Messages using data from GPSD                                                                                                        | 7.11.1  |
| 36 | MUSTSensorDriver             | Plugin for processing MUST Sensor Data.                                                                                                                               | 7.11.1  |
| 37 | MAP                          | Plugin that reads intersection geometry from a configuration file and publishes a J2735 MAP message.                                                                  | 7.11.1  |
| 38 | MessageReceiver              | Plugin to receive messages from an external V2X radio or other source                                                                                                 | 7.11.1  |
| 39 | ODEForwardPlugin             | Listens for J2735 messages and realtime forwards them to ODE.                                                                                                         | 7.11.1  |
| 40 | Pedestrian                   | Pedestrian plugin for the IVP system.                                                                                                                                 | 7.11.1  |
| 41 | PortDrayagePlugin            | PortDrayagePlugin for sending freight trucks automated actions in a port.                                                                                             | 7.11.1  |
| 42 | Preemption                   | Preemption plugin for the IVP system.                                                                                                                                 | 7.11.1  |
| 43 | RSUHealthMonitor             | Monitor RSU health status                                                                                                                                             | 7.11.1  |
| 44 | RTCM                         | Plugin to listen for RTCM messages from an NTRIP caster and route those messages over a V2X radio                                                                     | 7.11.1  |
| 45 | SPAT                         | The SPaT plugin receives live Signal Phase and Timing data from the Traffic Signal Controller and publishes a J2735 SPAT message.                                     | 7.11.1  |
| 46 | TelematicBridge              | Plugin that listens for TMX messages and forward them to the Telematic cloud services.                                                                                | 7.11.1  |
| 47 | TIM                          | Provides Traveller Information Message (TIM).                                                                                                                         | 7.11.1  |
| 48 | ivpcore.PluginMonitor        | Core element that is responsible for starting/stopping installed plugins and monitoring the status of the plugins                                                     | 3.2.0   |
| 49 | ivpcore.MessageProfiler      | Core element that is responsible for profiling the statistics of received messages                                                                                    | 3.2.0   |
| 50 | ivpcore.HistoryManager       | Core element that is responsible for purging old log and history data                                                                                                 | 3.2.0   |
+----+------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------+
28 rows in set (0.03 sec)
```

### Test Steps OMDO-150
1. Start V2-Hub 
2. Enable Message Receiver Plugin 
3. Verify database state
   - Log into database from v2xhub container `mysql -u IVP -p IVP`
   - `SELECT * FROM IVP.plugin;`
   - Expected result
```
mysql> SELECT * FROM IVP.pluginStatus ps INNER JOIN IVP.plugin p on p.id = ps.pluginId;
+-----+----------+---------------------------------------------------------+-------------------------+----+-------------------------+-------------------------------------------------------------------------------------------------------------------+---------+
| id  | pluginId | key                                                     | value                   | id | name                    | description                                                                                                       | version |
+-----+----------+---------------------------------------------------------+-------------------------+----+-------------------------+-------------------------------------------------------------------------------------------------------------------+---------+
|  34 |       48 |                                                         | Running                 | 48 | ivpcore.PluginMonitor   | Core element that is responsible for starting/stopping installed plugins and monitoring the status of the plugins | 3.2.0   |
|  37 |       49 |                                                         | Running                 | 49 | ivpcore.MessageProfiler | Core element that is responsible for profiling the statistics of received messages                                | 3.2.0   |
|  38 |       50 |                                                         | Running                 | 50 | ivpcore.HistoryManager  | Core element that is responsible for purging old log and history data                                             | 3.2.0   |
|  40 |       27 |                                                         | Running                 | 27 | CommandPlugin           | Listens for websocket connections from the TMX admin portal and processes commands                                | 7.11.1  |
| 251 |       38 |                                                         | Running                 | 38 | MessageReceiver         | Plugin to receive messages from an external V2X radio or other source                                             | 7.11.1  |
| 286 |       48 | Number of Active Plugins                                | 2                       | 48 | ivpcore.PluginMonitor   | Core element that is responsible for starting/stopping installed plugins and monitoring the status of the plugins | 3.2.0   |
| 295 |       27 | Start Time                                              | 2026-04-16 18:00:46.304 | 27 | CommandPlugin           | Listens for websocket connections from the TMX admin portal and processes commands                                | 7.11.1  |
| 297 |       38 | Start Time                                              | 2026-04-16 18:00:46.422 | 38 | MessageReceiver         | Plugin to receive messages from an external V2X radio or other source                                             | 7.11.1  |
| 298 |       38 | Message Skipped (Signature Verification Error Response) | 0                       | 38 | MessageReceiver         | Plugin to receive messages from an external V2X radio or other source                                             | 7.11.1  |
+-----+----------+---------------------------------------------------------+-------------------------+----+-------------------------+-------------------------------------------------------------------------------------------------------------------+---------+
```
4. Disable Message Receiver Plugin 
5. Verify database state
```
mysql> SELECT * FROM IVP.pluginStatus ps INNER JOIN IVP.plugin p on p.id = ps.pluginId;
+-----+----------+--------------------------+-------------------------+----+-------------------------+-------------------------------------------------------------------------------------------------------------------+---------+
| id  | pluginId | key                      | value                   | id | name                    | description                                                                                                       | version |
+-----+----------+--------------------------+-------------------------+----+-------------------------+-------------------------------------------------------------------------------------------------------------------+---------+
|  34 |       48 |                          | Running                 | 48 | ivpcore.PluginMonitor   | Core element that is responsible for starting/stopping installed plugins and monitoring the status of the plugins | 3.2.0   |
|  37 |       49 |                          | Running                 | 49 | ivpcore.MessageProfiler | Core element that is responsible for profiling the statistics of received messages                                | 3.2.0   |
|  38 |       50 |                          | Running                 | 50 | ivpcore.HistoryManager  | Core element that is responsible for purging old log and history data                                             | 3.2.0   |
|  40 |       27 |                          | Running                 | 27 | CommandPlugin           | Listens for websocket connections from the TMX admin portal and processes commands                                | 7.11.1  |
| 251 |       38 |                          | Stopped / Disconnected  | 38 | MessageReceiver         | Plugin to receive messages from an external V2X radio or other source                                             | 7.11.1  |
| 286 |       48 | Number of Active Plugins | 1                       | 48 | ivpcore.PluginMonitor   | Core element that is responsible for starting/stopping installed plugins and monitoring the status of the plugins | 3.2.0   |
| 295 |       27 | Start Time               | 2026-04-16 18:00:46.304 | 27 | CommandPlugin           | Listens for websocket connections from the TMX admin portal and processes commands                                | 7.11.1  |
+-----+----------+--------------------------+-------------------------+----+-------------------------+-------------------------------------------------------------------------------------------------------------------+---------+
7 rows in set (0.00 sec)
```
> I would not recommend investing in unit testing the persistence layer, tests are usually super brittle, expensive to write, and performance intensive. I have explored options but this would best be covered in integration tests, possibly with testcontainer.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
