### PR TITLE
OMDO-173 TIM Plugin Tests Backwards Compatibility

### DIFF
--- a/src/v2i-hub/TimPlugin/test/TestTimUtils.cpp
+++ b/src/v2i-hub/TimPlugin/test/TestTimUtils.cpp
@@ -260,7 +260,7 @@ namespace TimPlugin {
                         </roadSignID>
                     </msgId>
                     <startYear>2025</startYear>
-                    <startTime>5760</startTime>
+                    <startTime>181181</startTime>
                     <duratonTime>5760</duratonTime>
                     <priority>5</priority>
                     <sspLocationRights>0</sspLocationRights>

--- a/src/v2i-hub/TimPlugin/test/TestTimUtils.cpp
+++ b/src/v2i-hub/TimPlugin/test/TestTimUtils.cpp
@@ -27,7 +27,11 @@ namespace TimPlugin {
 #endif
         auto timPtr = tim->get_j2735_data();
         // Setting duration time to max value 32000 should indicate indefinite broadcast of TIM
+#if SAEJ2735_SPEC >= 2024
         timPtr->dataFrames.list.array[0]->durationTime = 32000;
+#else
+        timPtr->dataFrames.list.array[0]->duratonTime = 32000;
+#endif
         EXPECT_TRUE(isTimActive(tim));
         // Start time 2025 May 14 5:36 PM (UTC)
         // Duration is 32000 miutes -> indefinite
@@ -371,13 +375,17 @@ namespace TimPlugin {
                     </TravelerDataFrame>
                 </dataFrames>
             </TravelerInformation>
-        )"
+        )";
 #endif
         auto tim = readTimXml(timXml);
         auto timPtr = tim->get_j2735_data();
         EXPECT_EQ(2025, *(timPtr->dataFrames.list.array[0]->startYear));
         EXPECT_EQ(181181, timPtr->dataFrames.list.array[0]->startTime);
+#if SAEJ2735_SPEC >= 2024
         EXPECT_EQ(5760, timPtr->dataFrames.list.array[0]->durationTime);
+#else
+        EXPECT_EQ(5760, timPtr->dataFrames.list.array[0]->duratonTime);
+#endif
         EXPECT_EQ(5, timPtr->dataFrames.list.array[0]->priority);
 
 
@@ -392,7 +400,11 @@ namespace TimPlugin {
         auto timPtr = tim->get_j2735_data();
         EXPECT_EQ(2025, *(timPtr->dataFrames.list.array[0]->startYear));
         EXPECT_EQ(181181, timPtr->dataFrames.list.array[0]->startTime);
+#if SAEJ2735_SPEC >= 2024
         EXPECT_EQ(5760, timPtr->dataFrames.list.array[0]->durationTime);
+#else
+        EXPECT_EQ(5760, timPtr->dataFrames.list.array[0]->duratonTime);
+#endif
         EXPECT_EQ(5, timPtr->dataFrames.list.array[0]->priority);
         // Attempt to read from file that does not exist
         EXPECT_THROW(readTimFile("../../../v2i-hub/TimPlugin/test/test_files/non-existant-file.xml"), tmx::TmxException);

--- a/src/v2i-hub/TimPlugin/test/test_files/tim_2016.xml
+++ b/src/v2i-hub/TimPlugin/test/test_files/tim_2016.xml
@@ -21,7 +21,7 @@
         </roadSignID>
       </msgId>
       <startYear>2025</startYear>
-      <startTime>5760</startTime>
+      <startTime>181181</startTime>
       <duratonTime>5760</duratonTime>
       <priority>5</priority>
       <sspLocationRights>0</sspLocationRights>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The TIM plugin test code `src/v2i-hub/TimPlugin/test/TestTimUtils.cpp` introduced in https://github.com/usdot-fhwa-OPS/V2X-Hub/commit/7dcc1c901184b7eebc544a12afbd7d2385cadb39 is not backwards compatible with J2735 version 2016 and 2020 and fails to compile for pre-2024 specifications.

- There is a syntax error breaking code. A raw XML string literal in `TestTimUtils.cpp` is missing a terminating semicolon. This causes the subsequent `auto` statement to be parsed as part of the string, resulting in a compile error.
- There is J2735 version incompatibility pre-2024 specification. The test code references the field `durationTime`. In J2735 versions prior to 2024 (e.g., 2016, 2020), the ASN.1-generated struct uses the field name `duratonTime` (no “i”) per the specification. This mismatch causes compilation failures when building against older J2735 versions.
- Bad J2735 version 2016 test data, specifically `startTime` should be `181181` to match test case.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

https://usdot-carma.atlassian.net/browse/OMDO-173

## Motivation and Context
Makes TIM plugin test cases backwards compatibility with J2735 versions prior to 2024.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- [x] Code compiles successfully with J2735 v2024, v2020, v2016
- [x] Tests execute successfully with J2735 v2024, and v2016

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
