### PR TITLE
Updated CARMACloudPlugin to use HTTPS

### DIFF
--- a/configuration/NETWORK_SECURITY.md
+++ b/configuration/NETWORK_SECURITY.md
@@ -147,6 +147,47 @@ docker network inspect configuration_v2xhub_app_external
 docker network inspect configuration_v2xhub_data_internal
 ```
 
+## Using `host.docker.internal`
+
+When V2X-Hub is running inside a Docker container, some services may still execute on the host machine rather than inside the container network. In these cases, containers cannot access the host machine using `localhost` or `127.0.0.1`, because those addresses resolve to the container itself.
+
+Docker provides the special hostname: 
+```text
+host.docker.internal
+```
+
+This hostname resolves to the host machine from within the container and should be used whenever a V2X-Hub plugin must communicate with a service running on the host system.
+
+### Example Use Case
+
+The CARMA Cloud Plugin uses SSH forward and reverse tunnels that are typically established on the host machine. Since the plugin executes inside the V2X-Hub Docker container, the plugin must connect to the host machine tunnel endpoint using:
+
+```text
+https://host.docker.internal:8443
+```
+
+instead of:
+
+```text
+https://localhost:8443
+```
+
+### When to Use `host.docker.internal`
+
+Use `host.docker.internal` when all of the following are true:
+
+* V2X-Hub is running inside a Docker container
+* The target service or SSH tunnel is running on the host machine
+* The container must access the host machine network endpoint
+
+### When NOT to Use `host.docker.internal`
+
+Do not use `host.docker.internal` when:
+
+* Both services run inside the same Docker network
+* Communication occurs directly between containers using Docker Compose service names
+* V2X-Hub is running directly on the host machine instead of inside Docker
+
 ## Security Benefits Achieved
 
 ### ✅ **Defense in Depth**

--- a/src/v2i-hub/CARMACloudPlugin/CMakeLists.txt
+++ b/src/v2i-hub/CARMACloudPlugin/CMakeLists.txt
@@ -34,3 +34,7 @@ TARGET_LINK_LIBRARIES ( ${PROJECT_NAME} PUBLIC tmxutils ${XercesC_LIBRARY} ${NET
 
 
 link_directories(${CMAKE_PREFIX_PATH}/lib)
+
+target_compile_definitions(CARMACloudPlugin PRIVATE
+    $<$<CONFIG:Debug>:ALLOW_INSECURE_TLS=1>
+)

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -62,6 +62,8 @@ To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH forwa
    * Set `CARMACloudBaseUrl` to use HTTPS and port `8443`
    * Example: `https://host.docker.internal:8443`
 
+For additional information about when to use `host.docker.internal` with Docker containers, see the [Network Security documentation](../../../configuration/NETWORK_SECURITY.md#verify-network-connectivity).
+
 ## Design
 ![Alt text](docs/CARMACloudCommunicationArchitecture.png)
 The diagram above illustrates how the CARMA Cloud Plugin functions within V2X-Hub. The plugin maintains communication with CARMA Cloud to exchange traffic control information.

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -62,7 +62,7 @@ To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH forwa
    * Set `CARMACloudBaseUrl` to use HTTPS and port `8443`
    * Example: `https://host.docker.internal:8443`
 
-For additional information about when to use `host.docker.internal` with Docker containers, see the [Network Security documentation](../../../configuration/NETWORK_SECURITY.md#verify-network-connectivity).
+For additional information about when to use `host.docker.internal` with Docker containers, see the [Network Security documentation](../../../configuration/NETWORK_SECURITY.md#using-hostdockerinternal).
 
 ## Design
 ![Alt text](docs/CARMACloudCommunicationArchitecture.png)

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -18,7 +18,7 @@ Receives V2X communications from V2X actors, such as Connected and Automated Veh
 
 ### Emergency Response Vehicle (ERV) Cloud Forwarding
 
-For forwarding ERV communications from V2X actors to CARMA cloud.
+For forwarding ERV communications from V2X actors to CARMA Cloud.
 
 ## Configuration / Deployment
 
@@ -42,16 +42,16 @@ The CARMA Cloud Plugin supports the following configuration parameters.
 | Parameter                          | Description                                                                                        |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `fetchTime` | Number of days in the past for which TCMs are requested from CARMA Cloud.                                             |
-| `listTCM`   | Determines whether CARMA Cloud returns a list of TCMs (`true`) or individual seperate TCM messages (`false`). Default: `true`. |
+| `listTCM`   | Determines whether CARMA Cloud returns a list of TCMs (`true`) or individual separate TCM messages (`false`). Default: `true`. |
 | `TCMRepeatedlyBroadcastTimeOut`    | Duration in milliseconds that a received TCM will continue to be rebroadcast.                      |
 | `TCMRepeatedlyBroadcastSleep`      | Sleep interval in milliseconds between repeated TCM broadcasts.                                    |
 | `TCMRepeatedlyBroadCastTotalTimes` | Maximum number of repeated broadcasts for TCMs with the same request ID during the timeout period. |
 | `TCMNOAcknowledgementDescription`  | If no acknowledgement is received from a CMV within the configured timeout period for a matching TCM, the plugin generates a `NO ACK` message for display in the UI. |
 
 
-### TCP Tunnel
+### TCP Tunnels
 
-To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH forward and reverse tunnels must be configured. The forward tunnel forwards HTTPS traffic from V2X-Hub's host environment to the remote CARMA Cloud server.  The reverse tunnel forwards TCM reply traffic from the remote CARMA Cloud server to V2X-Hub's host environment. The steps to configure these tunnels are:
+To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH forward and reverse tunnels must be configured. The forward tunnel forwards HTTPS traffic from V2X-Hub's host environment to the remote CARMA Cloud server.  The reverse tunnel forwards TCM reply traffic from the remote CARMA Cloud server to V2X-Hub's host environment. The following steps configure these tunnels:
 
 1. Provision the required `.pem` key file for SSH authentication and place it in the `./scripts/` directory.
 
@@ -69,16 +69,17 @@ When Traffic Control Requests (TCRs) are received, the plugin forwards them to C
 
 ### Messages
 
-**TCR**: This message contains information from a requesting CAV about what traffic controls it wants to know about. This includes information about time and location for which it wants traffic controls. 
+**TCR**: This message contains information from a requesting CAV about which traffic controls it is requesting, including the time and geographic region for which the controls apply.
 
-**TCM**: This message contains information about traffic controls like speed limits or lane closures and geographic information about the locations they apply to.
+**TCM**: This message contains information about traffic controls such as speed limits or lane closures and geographic information about the locations they apply to.
+
 > [!NOTE]
-> **TCM** and **TCR** are CARMA ecosystem prototype messages that have been proposed to the SAE standard for inclusion in J2735 V2X Message set.
+> **TCM** and **TCR** are CARMA ecosystem prototype messages that have been proposed for inclusion in the SAE J2735 V2X message set.
 
 ## Technical Communication Flow
 
-### Request traffic
-The Message Receiver Plugin receives a TCR from an RSU and publishes it to the CARMA Cloud Plugin. The CARMA Cloud Plugin then sends a TCM request with the TCR message to CARMA Cloud using an HTTPS POST over the SSH forward tunnel. CARMA Cloud processes the request and prepares to return the appropriate HTTP TCM response initiated by CARMA Cloud server to V2X-Hub. 
+### Request Traffic
+The Message Receiver Plugin receives a TCR from an RSU and publishes it to the CARMA Cloud Plugin. The CARMA Cloud Plugin then sends a TCM request containing the TCR message to CARMA Cloud using an HTTPS POST over the SSH forward tunnel. CARMA Cloud processes the request and later initiates a separate HTTP TCM response back to V2X-Hub.
 
 > [!WARNING]
 > This does not follow the typical HTTP request/response pattern.  CARMA Cloud initiates a separate HTTP TCM response back to V2X-Hub after processing the TCM request.
@@ -96,14 +97,13 @@ CARMA Cloud: TcmReqServlet.doPost() / run() handles `/carmacloud/tcmreq`
 
 > [!IMPORTANT]
 > - HTTPS is used for communication between V2X-Hub and CARMA Cloud to improve transport security and support stronger TLS configurations.
-> - WARNING: The SSH forward tunnel is required still because CARMA Cloud's `TcmReqServlet.java` reads the caller’s IP address with `getRemoteAddr()` for the TCM response.
-> - WARNING: The SSH forward tunnel remains required because CARMA Cloud's `TcmReqServlet.java` reads the caller’s IP address from incoming request with `getRemoteAddr()` to determine the callback destination for TCM responses.
+> - WARNING: The SSH forward tunnel remains required because CARMA Cloud's `TcmReqServlet.java` uses `getRemoteAddr()` to determine the callback destination for TCM responses.
 > - The SSH forward tunnel is configured with the `-g` option so Docker containers can access the forwarded port through `host.docker.internal`.
 > - `host.docker.internal` should be used when the SSH tunnel is established on the host machine while V2X-Hub is running inside a Docker container.
 > - The default HTTPS forwarding port is `8443`, but this may vary depending on deployment configuration.
 
 ### Reply Traffic
-After processing the TCR request, CARMA Cloud sends the corresponding TCM response back to V2X-Hub using an HTTP POST over the SSH reverse tunnel. The response destination is determined using the source host from the original HTTPS TCR request together with the callback port defined in the TCR message.
+After processing the TCR request, CARMA Cloud sends the corresponding TCM response back to V2X-Hub using an HTTP POST over the SSH reverse tunnel. The response destination is determined using the source host from the original HTTPS TCR request together with the callback port specified in the TCR message.
 
 > [!WARNING]
 > This communication pattern does not follow the traditional HTTP request/response flow.

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -10,7 +10,8 @@ A list of plugins related to the CARMA Cloud Plugin.
 
 ### Immediate Forward Plugin
 
-Provides RSU Immediate Message Forwarding (IMF) functionality for broadcasting V2X messages, such as Traffic Control Messages (TCMs), from CARMA Cloud to V2X actors.
+Provides RSU Immediate Message Forwarding (IMF) functionality for broadcasting V2X messages, such as Traffic Control Messages (TCMs), from CARMA Cloud to V2X actors. 
+See the [Immediate Forward Plugin README](../ImmediateForwardPlugin/README.md).
 
 ### Message Receiver Plugin
 

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -32,9 +32,33 @@ The CARMA Cloud Plugin supports the following configuration parameters.
 | `WebServicePort`         | Port used by V2X-Hub to receive TCM messages from CARMA Cloud through the SSH tunnel.                                    |
 | `CARMACloudBaseUrl`      | Base HTTPS URL used to communicate with CARMA Cloud through the SSH tunnel. Example: `https://host.docker.internal:8443` |
 | `enforceTLSVerification` | Enables TLS certificate verification for CARMA Cloud connections. Default: `true`.                                       |
+| `carma_cloud_ca_cert_path` | Optional path to a PEM-encoded CA certificate bundle used to validate CARMA Cloud TLS certificates signed by a private/internal CA. |
 
 > [!WARNING]
-> `enforceTLSVerification=false` should **ONLY** be used for local development or debugging purposes. V2X-Hub must be compiled as a `Debug` build. Production deployments should always enable TLS verification.
+> - `enforceTLSVerification=false` should **ONLY** be used for local development or debugging purposes. V2X-Hub must be compiled as a `Debug` build. Production deployments should always enable TLS verification.
+> - Consider using a trusted CA bundle over disabling TLS verification with `enforceTLSVerification=false`.
+
+<details>
+<summary><strong>Optional: Using a private/internal Certificate Authority (CA)</strong></summary>
+
+<h4> Private CA Certificate Requirements</h4>
+
+When CARMA Cloud uses a self-signed certificate or certificates signed by a private/internal Certificate Authority (CA), configure `carma_cloud_ca_cert_path` to point to the trusted CA certificate bundle.
+
+Example:
+
+```ini
+carma_cloud_ca_cert_path=/var/www/plugins/ssl/carma-cloud-rootCA.pem
+```
+
+#### Certificate Requirements
+* The certificate file must be PEM encoded.
+* The certificate bundle should contain the root CA certificate and any required intermediate CA certificates.
+* The certificate file must be accessible from within the V2X-Hub runtime environment or container.
+* The CARMA Cloud TLS server certificate must include `host.docker.internal` in the Subject Alternative Name (SAN) extension when V2X-Hub connects using `https://host.docker.internal:8443`.
+  * Example: `DNS.2 = host.docker.internal`
+
+</details>
 
 ---
 

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -100,10 +100,29 @@ CARMA Cloud: TcmReqServlet.doPost() / run() handles `/carmacloud/tcmreq`
 > - `host.docker.internal` should be used when the SSH tunnel is established on the host machine while V2X-Hub is running inside a Docker container.
 > - The default HTTPS forwarding port is `8443`, but this may vary depending on deployment configuration.
 
-### Reply traffic
-CARMA Cloud sends TCM reply using host from TCR HTTPS request and port defined in TCR message via HTTP post over SSH reverse tunnel. V2X-Hub's CARMA Cloud Plugin process.
+### Reply Traffic
+After processing the TCR request, CARMA Cloud sends the corresponding TCM response back to V2X-Hub using an HTTP POST over the SSH reverse tunnel. The response destination is determined using the source host from the original HTTPS TCR request together with the callback port defined in the TCR message.
 
-CARMA Cloud’s TomcatTcmReqServlet.run() handles reply → POST to http://127.0.0.1:22222/tcmreply(or whatever the source IP was for carmacloud/tcmreq and port in TCM message)  → SSH reverse tunnel maps CARMA Cloud’s localhost:22222 back to plugin localhost:22222 → CARMACloudPlugin::CARMAResponseHandler handles /tcmreply
+> [!WARNING]
+> This communication pattern does not follow the traditional HTTP request/response flow.
+> CARMA Cloud initiates a separate outbound HTTP POST back to V2X-Hub after asynchronously processing the original TCR request.
+
+### Reply communication flow with code references:
+
+```
+CARMA Cloud: TcmReqServlet.run() processes TCR request sends HTTP POST to `http://127.0.0.1:22222/tcmreply` (or the source host from the original /carmacloud/tcmreq request and callback port defined in the TCR)
+    ↓
+SSH reverse tunnel which maps the remote CARMA Cloud server HTTP endpoint to V2X-Hub (e.g., CARMA Cloud’s localhost:22222 to V2X-Hub’s container localhost:22222)
+    ↓
+CARMACloudPlugin::CARMAResponseHandler handles /tcmreply
+```
+
+> [!IMPORTANT]
+> - CARMA Cloud determines the callback destination from:
+>    - the source IP/host of the original `/carmacloud/tcmreq` request
+>    - the callback port provided in the TCR message
+> - The SSH reverse tunnel allows CARMA Cloud to securely initiate communication back to V2X-Hub even when V2X-Hub is running behind NAT or inside a Docker container.
+> - The `/tcmreply` endpoint is hosted by the CARMA Cloud Plugin within V2X-Hub.
 
 ## Functionality Testing
 

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -18,7 +18,7 @@ Receives V2X communications from V2X actors, such as Connected and Automated Veh
 
 ### Emergency Response Vehicle (ERV) Cloud Forwarding
 
-For forwarding ERV communications from V2X actors to CARMA Cloud.
+Provides functionality for forwarding ERV communications from V2X actors to CARMA Cloud.
 
 ## Configuration / Deployment
 
@@ -33,7 +33,7 @@ The CARMA Cloud Plugin supports the following configuration parameters.
 | `enforceTLSVerification` | Enables TLS certificate verification for CARMA Cloud connections. Default: `true`.                                       |
 
 > [!WARNING]
-> `enforceTLSVerification=false` should **ONLY** be used for local development or debugging purposes. V2X-Hub must be compiled with `BUILD_TYPE` of `Debug`. Production deployments should always enable TLS verification.
+> `enforceTLSVerification=false` should **ONLY** be used for local development or debugging purposes. V2X-Hub must be compiled as a `Debug` build. Production deployments should always enable TLS verification.
 
 ---
 
@@ -49,9 +49,9 @@ The CARMA Cloud Plugin supports the following configuration parameters.
 | `TCMNOAcknowledgementDescription`  | If no acknowledgement is received from a CMV within the configured timeout period for a matching TCM, the plugin generates a `NO ACK` message for display in the UI. |
 
 
-### TCP Tunnels
+### SSH Tunnels
 
-To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH forward and reverse tunnels must be configured. The forward tunnel forwards HTTPS traffic from V2X-Hub's host environment to the remote CARMA Cloud server.  The reverse tunnel forwards TCM reply traffic from the remote CARMA Cloud server to V2X-Hub's host environment. The following steps configure these tunnels:
+To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH forward and reverse tunnels must be configured. The forward tunnel forwards HTTPS traffic from V2X-Hub's host machine to the remote CARMA Cloud server.  The reverse tunnel forwards TCM reply traffic from the remote CARMA Cloud server to V2X-Hub's host machine. The following steps configure these tunnels:
 
 1. Provision the required `.pem` key file for SSH authentication and place it in the `./scripts/` directory.
 
@@ -79,7 +79,7 @@ When Traffic Control Requests (TCRs) are received, the plugin forwards them to C
 ## Technical Communication Flow
 
 ### Request Traffic
-The Message Receiver Plugin receives a TCR from an RSU and publishes it to the CARMA Cloud Plugin. The CARMA Cloud Plugin then sends a TCM request containing the TCR message to CARMA Cloud using an HTTPS POST over the SSH forward tunnel. CARMA Cloud processes the request and later initiates a separate HTTP TCM response back to V2X-Hub.
+The Message Receiver Plugin receives a TCR from an RSU and publishes it to the CARMA Cloud Plugin. The CARMA Cloud Plugin then sends a TCM request containing the TCR message to CARMA Cloud using an HTTPS POST over the SSH forward tunnel. CARMA Cloud processes the request and later initiates a separate HTTP TCM response to V2X-Hub.
 
 > [!WARNING]
 > This does not follow the typical HTTP request/response pattern.  CARMA Cloud initiates a separate HTTP TCM response back to V2X-Hub after processing the TCM request.
@@ -88,7 +88,7 @@ The Message Receiver Plugin receives a TCR from an RSU and publishes it to the C
 ```
 Message Receiver Plugin
     ↓
-CARMA Cloud Plugin: CARMACloudPlugin::CloudSend() sends HTTPS POST to `https://host.docker.internal:8443/carmacloud/tcmreq` (or the configured CARMACloudBaseUrl/carmacloud/tcmreq)
+CARMA Cloud Plugin: CARMACloudPlugin::CloudSend() sends HTTPS POST to `https://host.docker.internal:8443/carmacloud/tcmreq` (or the configured CARMACloudBaseUrl plus /carmacloud/tcmreq)
     ↓
 SSH forward tunnel maps the host machine HTTPS endpoint to the remote CARMA Cloud HTTPS endpoint (e.g., V2X-Hub’s host machine localhost:33333 → CARMA Cloud localhost:8443)
     ↓
@@ -97,7 +97,7 @@ CARMA Cloud: TcmReqServlet.doPost() / run() handles `/carmacloud/tcmreq`
 
 > [!IMPORTANT]
 > - HTTPS is used for communication between V2X-Hub and CARMA Cloud to improve transport security and support stronger TLS configurations.
-> - WARNING: The SSH forward tunnel remains required because CARMA Cloud's `TcmReqServlet.java` uses `getRemoteAddr()` to determine the callback destination for TCM responses.
+> - The SSH forward tunnel remains **required** because CARMA Cloud's `TcmReqServlet.java` uses `getRemoteAddr()` to determine the callback destination for TCM responses.
 > - The SSH forward tunnel is configured with the `-g` option so Docker containers can access the forwarded port through `host.docker.internal`.
 > - `host.docker.internal` should be used when the SSH tunnel is established on the host machine while V2X-Hub is running inside a Docker container.
 > - The default HTTPS forwarding port is `8443`, but this may vary depending on deployment configuration.
@@ -136,3 +136,34 @@ To test functionality of CARMA Cloud Plugin without an active vehicle, we have p
 3. Enable both the CARMA Cloud Plugin and Message Receiver Plugin.
 4. Run `python3 tcr_script.py` to send a mock TCR to the Message Receiver Plugin.
 5. Confirm that TCM messages are received by the CARMA Cloud Plugin using the Messages tab in the V2X-Hub Admin UI.
+6. Verify CARMA Cloud HTTP access logs and application logs received TCR request.
+
+The following examples show expected CARMA Cloud HTTP access and application logs after a successful TCR request.
+<details>
+<summary><strong>Expected HTTP access logs results</strong></summary>
+  
+```shell
+ubuntu@carma-cloud-server:~$ sudo grep "carmacloud/tcmreq" carmacloudvol/logs/localhost_access_log.2026-05-07.txt
+127.0.0.1 - - [07/May/2026:11:40:58 +0000] "POST /carmacloud/tcmreq HTTP/1.1" 200 -
+```
+</details>
+
+<details>
+<summary><strong>Expected application log results with request and reply</strong></summary>
+  
+```xml
+ubuntu@carma-cloud-server:~$ sudo more carma-cloud/carmacloudvol/logs/carmacloud.log 
+
+[DEBUG 11:40:58.091 [TcmReqServlet] - 127.0.0.1<?xml version="1.0" encoding="UTF-8"?><TrafficControlRequest port="22222" list="true"><reqid>D0E0C6E650394C06</reqid><reqseq>0</reqseq><scale>-1</scale><bounds><oldest>29614300</oldest><reflon>-771512807</reflon><reflat>38954865
+4</reflat><offsets><deltax>3426</deltax><deltay>0</deltay></offsets><offsets><deltax>3426</deltax><deltay>2317</deltay></offsets><offsets><deltax>0</deltax><deltay>2317</deltay></offsets></bounds></TrafficControlRequest>
+
+[DEBUG 11:40:58.105 [TcmReqServlet] - <?xml version="1.0" encoding="UTF-8"?><TrafficControlMessageList><TrafficControlMessage><tcmV01><reqid>D0E0C6E650394C06</reqid><reqseq>0</reqseq><msgtot>1</msgtot><msgnum>1</msgnum><id>00cccaf0a3be3de3287ad6ccb7686934</id><updated>0</upd
+ated><package><label>workzone</label><tcids><Id128b>00cccaf0a3be3de3287ad6ccb7686934</Id128b></tcids></package><params><vclasses><motorcycle/><passenger-car/><light-truck-van/><bus/><two-axle-six-tire-single-unit-truck/><three-axle-single-unit-truck/><four-or-more-axle-singl
+e-unit-truck/><four-or-fewer-axle-single-trailer-truck/><five-axle-single-trailer-truck/><six-or-more-axle-single-trailer-truck/><five-or-fewer-axle-multi-trailer-truck/><six-axle-multi-trailer-truck/><seven-or-more-axle-multi-trailer-truck/></vclasses><schedule><start>29632
+054</start><end>153722867280912</end><dow>1111111</dow></schedule><regulatory><true/></regulatory><detail><latperm><none/><emergency-only/></latperm></detail></params><geometry><proj>epsg:3785</proj><datum>WGS84</datum><reftime>29632054</reftime><reflon>-771475726</reflon><r
+eflat>389550079</reflat><refelv>0</refelv><refwidth>411</refwidth><heading>3312</heading><nodes><PathNode><x>1</x><y>0</y><width>-1</width></PathNode><PathNode><x>-1468</x><y>-302</y><width>-8</width></PathNode><PathNode><x>-1469</x><y>-301</y><width>-14</width></PathNode><P
+athNode><x>-1470</x><y>-279</y><width>-13</width></PathNode><PathNode><x>-1480</x><y>-228</y><width>-5</width></PathNode><PathNode><x>-1487</x><y>-180</y><width>2</width></PathNode><PathNode><x>-1495</x><y>-106</y><width>0</width></PathNode><PathNode><x>-1498</x><y>-16</y><w
+idth>2</width></PathNode><PathNode><x>-1498</x><y>50</y><width>6</width></PathNode><PathNode><x>-1496</x><y>101</y><width>12</width></PathNode><PathNode><x>-1490</x><y>166</y><width>10</width></PathNode><PathNode><x>-1482</x><y>230</y><width>7</width></PathNode><PathNode><x>
+-562</x><y>97</y><width>1</width></PathNode></nodes></geometry></tcmV01></TrafficControlMessage></TrafficControlMessageList>
+```
+</details>

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -20,27 +20,36 @@ For receiving V2X communication from V2X actors like CAVs (Connected Autonomous 
 
 For forwarding ERV communications from V2X actors to CARMA cloud.
 
-## Configuration/Deployment
+## Configuration / Deployment
 
+The CARMA Cloud Plugin supports the following configuration parameters.
 This plugin has several configuration parameters. Below these are listed out as together with descriptions on how to set them.
 
-**WebServicePort**: Port for V2X-Hub to receive TCM messages from CARMA Cloud over SSH-tunnel.
 
-**CARMACloudBaseUrl**: Host or server IP address and port for SSH-tunnel to CARMA Cloud.
+### Connection Settings
 
-**fetchTime**: Time in days from which all TCMs will be requested from CARMA Cloud 
+| Parameter                | Description                                                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `WebServicePort`         | Port used by V2X-Hub to receive TCM messages from CARMA Cloud through the SSH tunnel.                                    |
+| `CARMACloudBaseUrl`      | Base HTTPS URL used to communicate with CARMA Cloud through the SSH tunnel. Example: `https://host.docker.internal:8443` |
+| `enforceTLSVerification` | Enables TLS certificate verification for CARMA Cloud connections. Default: `true`.                                       |
 
-**TCMRepeatedlyBroadcastTimeOut**: After it receives TCM from carma cloud, it repeatedly broadcasts TCM until TCMRepeatTimeOut milliseconds.
+> [!WARNING]
+> `enforceTLSVerification=false` should **ONLY** be used for local development or debugging purposes. V2X-Hub must be compiled with `BUILD_TYPE` of `Debug`. Production deployments should always enable TLS verification.
 
-**TCMRepeatedlyBroadcastSleep**: The repeatedly broadcast thread should sleep for number of milliseconds.
+---
 
-**TCMRepeatedlyBroadCastTotalTimes**: The number of times TCMs with the same request id should be repeatedly broadcast within the time out period.
+### TCM Settings
 
-**TCMNOAcknowledgementDescription**: If the plugin does not receives any aknowledgement from CMV within the configured seconds that match the original TCM, the plugin will create an NO ACK message and display it on UI.
+| Parameter                          | Description                                                                                        |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fetchTime` | Number of days in the past for which TCMs are requested from CARMA Cloud.                                             |
+| `listTCM`   | Determines whether CARMA Cloud returns a list of TCMs (`true`) or individual seperate TCM messages (`false`). Default: `true`. |
+| `TCMRepeatedlyBroadcastTimeOut`    | Duration in milliseconds that a received TCM will continue to be rebroadcast.                      |
+| `TCMRepeatedlyBroadcastSleep`      | Sleep interval in milliseconds between repeated TCM broadcasts.                                    |
+| `TCMRepeatedlyBroadCastTotalTimes` | Maximum number of repeated broadcasts for TCMs with the same request ID during the timeout period. |
+| `TCMNOAcknowledgementDescription`  | If no acknowledgement is received from a CMV within the configured timeout period for a matching TCM, the plugin generates a `NO ACK` message for display in the UI. |
 
-**listTCM**: Indicator to determine if v2xhub receives a list of TCMs from carma-cloud. Default to true, returning a list of TCM. If false, return one TCM at a time. Indicator value can only be either true or false.
-
-**enforceTLSVerification**: Indicator to determine if v2xhub should enforce TLS verification for CARMA-Cloud connnection. Default to true. False should **ONLY** be used for development and debugging purposes; further must be compiled as a Debug build.
 
 ### TCP Tunnel
 

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The CARMA Cloud Plugin is responsible for connecting V2X-Hub to [CARMA Cloud](https://github.com/usdot-fhwa-stol/carma-cloud), which is the STOL Cloud Cooperative Driving Automation (CAD) application supporting different use cases like work-zone.
+The CARMA Cloud Plugin is responsible for connecting V2X-Hub to [CARMA Cloud](https://github.com/usdot-fhwa-stol/carma-cloud), the STOL Cloud Cooperative Driving Automation (CDA) application supporting use cases such as work zones.
 
 ## Related Plugins
 
@@ -10,11 +10,11 @@ A list of plugins related to the CARMA Cloud Plugin.
 
 ### Immediate Forward Plugin
 
-For RSU Immediate Message Forwarding (IMF) functionality forward V2X Messages like Traffic Control Messages (TCMs) from CARMA Cloud to V2X actors.
+Provides RSU Immediate Message Forwarding (IMF) functionality for broadcasting V2X messages, such as Traffic Control Messages (TCMs), from CARMA Cloud to V2X actors.
 
 ### Message Receiver Plugin
 
-For receiving V2X communication from V2X actors like CAVs (Connected Autonomous Vehicles) sending Traffic Control Requests (TCRs)
+Receives V2X communications from V2X actors, such as Connected and Automated Vehicles (CAVs), including Traffic Control Requests (TCRs).
 
 ### Emergency Response Vehicle (ERV) Cloud Forwarding
 
@@ -23,8 +23,6 @@ For forwarding ERV communications from V2X actors to CARMA cloud.
 ## Configuration / Deployment
 
 The CARMA Cloud Plugin supports the following configuration parameters.
-This plugin has several configuration parameters. Below these are listed out as together with descriptions on how to set them.
-
 
 ### Connection Settings
 
@@ -53,7 +51,7 @@ This plugin has several configuration parameters. Below these are listed out as 
 
 ### TCP Tunnel
 
-To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH tunnels must be configured. The forward tunnel forwards HTTPS traffic from V2X-Hub's local host environment to the remote CARMA Cloud server.  The reverse tunnel forwards TCM reply traffic from the remote CARMA Cloud server to V2X-Hub's local host environment. The steps to configure these tunnels are:
+To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH forward and reverse tunnels must be configured. The forward tunnel forwards HTTPS traffic from V2X-Hub's host environment to the remote CARMA Cloud server.  The reverse tunnel forwards TCM reply traffic from the remote CARMA Cloud server to V2X-Hub's host environment. The steps to configure these tunnels are:
 
 1. Provision the required `.pem` key file for SSH authentication and place it in the `./scripts/` directory.
 
@@ -65,14 +63,17 @@ To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH tunne
 
 ## Design
 ![Alt text](docs/CARMACloudCommunicationArchitecture.png)
-The diagram above illustrates roughly how the CARMA Cloud Plugin functions. The CARMA Cloud Plugin maintains a connection to CARMA Cloud. When receiveing TCRs, it forwards these to CARMA Cloud, which will respond with relevant traffic controls via the TCM message. These TCMs will be broadcast to vehicles providing them updates to their local map like lane-closures or speed limits associated with dynamic work zones.
+The diagram above illustrates how the CARMA Cloud Plugin functions within V2X-Hub. The plugin maintains communication with CARMA Cloud to exchange traffic control information.
+
+When Traffic Control Requests (TCRs) are received, the plugin forwards them to CARMA Cloud. CARMA Cloud responds with Traffic Control Messages (TCMs), which are then broadcast to vehicles to provide updates to their local maps, such as lane closures, speed limits, and other dynamic work zone information.
+
 ### Messages
 
 **TCR**: This message contains information from a requesting CAV about what traffic controls it wants to know about. This includes information about time and location for which it wants traffic controls. 
 
 **TCM**: This message contains information about traffic controls like speed limits or lane closures and geographic information about the locations they apply to.
 > [!NOTE]
-> **TCM** and **TRC** are CARMA ecosystem protype messages that have been proposed to the SAE standard for inclusion in J2735 V2X Message set.
+> **TCM** and **TCR** are CARMA ecosystem prototype messages that have been proposed to the SAE standard for inclusion in J2735 V2X Message set.
 
 ## Technical Communication Flow
 
@@ -80,7 +81,7 @@ The diagram above illustrates roughly how the CARMA Cloud Plugin functions. The 
 The Message Receiver Plugin receives a TCR from an RSU and publishes it to the CARMA Cloud Plugin. The CARMA Cloud Plugin then sends a TCM request with the TCR message to CARMA Cloud using an HTTPS POST over the SSH forward tunnel. CARMA Cloud processes the request and prepares to return the appropriate HTTP TCM response initiated by CARMA Cloud server to V2X-Hub. 
 
 > [!WARNING]
-> This does not follow the typical HTTP request/response pattern.  CARMA Cloud initiates a seperate HTTP TCM response back to V2X-Hub after processing the TCM request.
+> This does not follow the typical HTTP request/response pattern.  CARMA Cloud initiates a separate HTTP TCM response back to V2X-Hub after processing the TCM request.
 
 ### Request communication flow with code references:
 ```
@@ -88,7 +89,7 @@ Message Receiver Plugin
     ↓
 CARMA Cloud Plugin: CARMACloudPlugin::CloudSend() sends HTTPS POST to `https://host.docker.internal:8443/carmacloud/tcmreq` (or the configured CARMACloudBaseUrl/carmacloud/tcmreq)
     ↓
-SSH forward tunnel which maps the local HTTPS endpoint to the remote CARMA Cloud server (e.g., V2X-Hub’s localhost:33333 not container localhost to CARMA Cloud’s localhost:8443)
+SSH forward tunnel maps the host machine HTTPS endpoint to the remote CARMA Cloud HTTPS endpoint (e.g., V2X-Hub’s host machine localhost:33333 → CARMA Cloud localhost:8443)
     ↓
 CARMA Cloud: TcmReqServlet.doPost() / run() handles `/carmacloud/tcmreq`
 ```
@@ -96,6 +97,7 @@ CARMA Cloud: TcmReqServlet.doPost() / run() handles `/carmacloud/tcmreq`
 > [!IMPORTANT]
 > - HTTPS is used for communication between V2X-Hub and CARMA Cloud to improve transport security and support stronger TLS configurations.
 > - WARNING: The SSH forward tunnel is required still because CARMA Cloud's `TcmReqServlet.java` reads the caller’s IP address with `getRemoteAddr()` for the TCM response.
+> - WARNING: The SSH forward tunnel remains required because CARMA Cloud's `TcmReqServlet.java` reads the caller’s IP address from incoming request with `getRemoteAddr()` to determine the callback destination for TCM responses.
 > - The SSH forward tunnel is configured with the `-g` option so Docker containers can access the forwarded port through `host.docker.internal`.
 > - `host.docker.internal` should be used when the SSH tunnel is established on the host machine while V2X-Hub is running inside a Docker container.
 > - The default HTTPS forwarding port is `8443`, but this may vary depending on deployment configuration.
@@ -122,13 +124,15 @@ CARMACloudPlugin::CARMAResponseHandler handles /tcmreply
 >    - the source IP/host of the original `/carmacloud/tcmreq` request
 >    - the callback port provided in the TCR message
 > - The SSH reverse tunnel allows CARMA Cloud to securely initiate communication back to V2X-Hub even when V2X-Hub is running behind NAT or inside a Docker container.
+> - The reverse tunnel traffic currently uses HTTP because the communication is protected by the SSH tunnel itself.
 > - The `/tcmreply` endpoint is hosted by the CARMA Cloud Plugin within V2X-Hub.
 
 ## Functionality Testing
 
-To test functionality of CARMA Cloud Plugin without an active vehicle, we have provided a script which can send mock TCRs to V2X Hub. These TCRs should be received by the CARMA Cloud Plugin, forwarded to CARMA Cloud, and if there are any relevant active traffic controls, should result in response TCMs being sent to the CARMA Cloud Plugin. Steps to conduct this test are outlined below:
-1) Deploy V2X Hub and CARMA Cloud
-2) Configure CARMA Cloud Plugin to connect the CARMA Cloud (including setup of any necessary TCP tunnels)
-3) Enable both CARMA Cloud Plugin and Message Receiver Plugin
-4) Run 'python3 tcr_script.py` to send a TCR to the Message Receiver Plugin
-5) Confirm that TCM messages are being received by CARMA Cloud Plugin via the Messages tab in the V2X Hub Admin UI web portal  
+To test functionality of CARMA Cloud Plugin without an active vehicle, we have provided a script which can send mock TCRs to V2X-Hub. These TCRs should be received by the CARMA Cloud Plugin, forwarded to CARMA Cloud, and if there are any relevant active traffic controls, should result in response TCMs being sent to the CARMA Cloud Plugin. Steps to conduct this test are outlined below:
+
+1. Deploy V2X-Hub and CARMA Cloud.
+2. Configure the CARMA Cloud Plugin, including the required SSH tunnels.
+3. Enable both the CARMA Cloud Plugin and Message Receiver Plugin.
+4. Run `python3 tcr_script.py` to send a mock TCR to the Message Receiver Plugin.
+5. Confirm that TCM messages are received by the CARMA Cloud Plugin using the Messages tab in the V2X-Hub Admin UI.

--- a/src/v2i-hub/CARMACloudPlugin/README.md
+++ b/src/v2i-hub/CARMACloudPlugin/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The CARMA Cloud Plugin is responsible for connecting V2X Hub to [CARMA Cloud](https://github.com/usdot-fhwa-stol/carma-cloud), which is the STOL Cloud Cooperative Driving Automation (CAD) application supporting different use cases like work-zone.
+The CARMA Cloud Plugin is responsible for connecting V2X-Hub to [CARMA Cloud](https://github.com/usdot-fhwa-stol/carma-cloud), which is the STOL Cloud Cooperative Driving Automation (CAD) application supporting different use cases like work-zone.
 
 ## Related Plugins
 
@@ -16,15 +16,17 @@ For RSU Immediate Message Forwarding (IMF) functionality forward V2X Messages li
 
 For receiving V2X communication from V2X actors like CAVs (Connected Autonomous Vehicles) sending Traffic Control Requests (TCRs)
 
+### Emergency Response Vehicle (ERV) Cloud Forwarding
+
+For forwarding ERV communications from V2X actors to CARMA cloud.
+
 ## Configuration/Deployment
 
 This plugin has several configuration parameters. Below these are listed out as together with descriptions on how to set them.
 
-**WebServiceIP**: REST Server IP where V2X Hub listens for incoming messages from CARMA Cloud.
+**WebServicePort**: Port for V2X-Hub to receive TCM messages from CARMA Cloud over SSH-tunnel.
 
-**CARMACloudIP**: REST Server IP where V2X Hub sends REST requests to CARMA Cloud.
-
-**CARMACloudPort**: REST Server port where V2X Hub sends REST request to CARMA Cloud.
+**CARMACloudBaseUrl**: Host or server IP address and port for SSH-tunnel to CARMA Cloud.
 
 **fetchTime**: Time in days from which all TCMs will be requested from CARMA Cloud 
 
@@ -38,18 +40,23 @@ This plugin has several configuration parameters. Below these are listed out as 
 
 **listTCM**: Indicator to determine if v2xhub receives a list of TCMs from carma-cloud. Default to true, returning a list of TCM. If false, return one TCM at a time. Indicator value can only be either true or false.
 
+**enforceTLSVerification**: Indicator to determine if v2xhub should enforce TLS verification for CARMA-Cloud connnection. Default to true. False should **ONLY** be used for development and debugging purposes; further must be compiled as a Debug build.
+
 ### TCP Tunnel
 
-Currently to connect securely to a remotely hosted CARMA Cloud instance, an additional step is required. The configuration of a TCP tunnel, which creates a secure connection to a carma-cloud instance. The steps to configure this tunnel are :
+To securely connect V2X-Hub to a remotely hosted CARMA Cloud instance, SSH tunnels must be configured. The forward tunnel forwards HTTPS traffic from V2X-Hub's local host environment to the remote CARMA Cloud server.  The reverse tunnel forwards TCM reply traffic from the remote CARMA Cloud server to V2X-Hub's local host environment. The steps to configure these tunnels are:
 
-1) Provision required `.pem` file for secure connection and move it to the `./scripts/` directory
-2) Run `./call.sh` in the `./scripts/` directory.
+1. Provision the required `.pem` key file for SSH authentication and place it in the `./scripts/` directory.
+
+2. Run `./call.sh` from the `./scripts/` directory to establish the SSH tunnel.
+
+3. Start V2X-Hub. Configure the `CARMACloudPlugin`:
+   * Set `CARMACloudBaseUrl` to use HTTPS and port `8443`
+   * Example: `https://host.docker.internal:8443`
 
 ## Design
-
 ![Alt text](docs/CARMACloudCommunicationArchitecture.png)
 The diagram above illustrates roughly how the CARMA Cloud Plugin functions. The CARMA Cloud Plugin maintains a connection to CARMA Cloud. When receiveing TCRs, it forwards these to CARMA Cloud, which will respond with relevant traffic controls via the TCM message. These TCMs will be broadcast to vehicles providing them updates to their local map like lane-closures or speed limits associated with dynamic work zones.
-
 ### Messages
 
 **TCR**: This message contains information from a requesting CAV about what traffic controls it wants to know about. This includes information about time and location for which it wants traffic controls. 
@@ -57,6 +64,37 @@ The diagram above illustrates roughly how the CARMA Cloud Plugin functions. The 
 **TCM**: This message contains information about traffic controls like speed limits or lane closures and geographic information about the locations they apply to.
 > [!NOTE]
 > **TCM** and **TRC** are CARMA ecosystem protype messages that have been proposed to the SAE standard for inclusion in J2735 V2X Message set.
+
+## Technical Communication Flow
+
+### Request traffic
+The Message Receiver Plugin receives a TCR from an RSU and publishes it to the CARMA Cloud Plugin. The CARMA Cloud Plugin then sends a TCM request with the TCR message to CARMA Cloud using an HTTPS POST over the SSH forward tunnel. CARMA Cloud processes the request and prepares to return the appropriate HTTP TCM response initiated by CARMA Cloud server to V2X-Hub. 
+
+> [!WARNING]
+> This does not follow the typical HTTP request/response pattern.  CARMA Cloud initiates a seperate HTTP TCM response back to V2X-Hub after processing the TCM request.
+
+### Request communication flow with code references:
+```
+Message Receiver Plugin
+    ↓
+CARMA Cloud Plugin: CARMACloudPlugin::CloudSend() sends HTTPS POST to `https://host.docker.internal:8443/carmacloud/tcmreq` (or the configured CARMACloudBaseUrl/carmacloud/tcmreq)
+    ↓
+SSH forward tunnel which maps the local HTTPS endpoint to the remote CARMA Cloud server (e.g., V2X-Hub’s localhost:33333 not container localhost to CARMA Cloud’s localhost:8443)
+    ↓
+CARMA Cloud: TcmReqServlet.doPost() / run() handles `/carmacloud/tcmreq`
+```
+
+> [!IMPORTANT]
+> - HTTPS is used for communication between V2X-Hub and CARMA Cloud to improve transport security and support stronger TLS configurations.
+> - WARNING: The SSH forward tunnel is required still because CARMA Cloud's `TcmReqServlet.java` reads the caller’s IP address with `getRemoteAddr()` for the TCM response.
+> - The SSH forward tunnel is configured with the `-g` option so Docker containers can access the forwarded port through `host.docker.internal`.
+> - `host.docker.internal` should be used when the SSH tunnel is established on the host machine while V2X-Hub is running inside a Docker container.
+> - The default HTTPS forwarding port is `8443`, but this may vary depending on deployment configuration.
+
+### Reply traffic
+CARMA Cloud sends TCM reply using host from TCR HTTPS request and port defined in TCR message via HTTP post over SSH reverse tunnel. V2X-Hub's CARMA Cloud Plugin process.
+
+CARMA Cloud’s TomcatTcmReqServlet.run() handles reply → POST to http://127.0.0.1:22222/tcmreply(or whatever the source IP was for carmacloud/tcmreq and port in TCM message)  → SSH reverse tunnel maps CARMA Cloud’s localhost:22222 back to plugin localhost:22222 → CARMACloudPlugin::CARMAResponseHandler handles /tcmreply
 
 ## Functionality Testing
 

--- a/src/v2i-hub/CARMACloudPlugin/manifest.json
+++ b/src/v2i-hub/CARMACloudPlugin/manifest.json
@@ -71,7 +71,7 @@
 		{
 			"key":"enforceTLSVerification",
 			"default":"true",
-			"description":"Indicator to determine if v2xhub should enforce TLS verification for CARMA-Cloud connnection. Default to true.  False should only be used for development and debugging purposes."
+			"description":"Indicator to determine if v2xhub should enforce TLS verification for CARMA-Cloud connnection. Default to true.  False should only be used for development and debugging purposes - must be a compiled Debug build."
 		}
 	]
 }

--- a/src/v2i-hub/CARMACloudPlugin/manifest.json
+++ b/src/v2i-hub/CARMACloudPlugin/manifest.json
@@ -72,6 +72,11 @@
 			"key":"enforceTLSVerification",
 			"default":"true",
 			"description":"Indicator to determine if v2xhub should enforce TLS verification for CARMA-Cloud connnection. Default to true.  False should only be used for development and debugging purposes - must be a compiled Debug build."
+		},
+		{
+			"key":"carma_cloud_ca_cert_path",
+			"default":"",
+			"description":"Optional CA bundle for TLS validation when CARMA-Cloud uses a private/internal CA. Deploy the PEM file to /var/www/plugins/ssl and reference the mounted container path in configuration."
 		}
 	]
 }

--- a/src/v2i-hub/CARMACloudPlugin/manifest.json
+++ b/src/v2i-hub/CARMACloudPlugin/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name":"CARMACloud",
-	"description":"CARMA cloud plugin for making websocket connection with CARMA cloud .",
+	"description":"CARMA cloud plugin for making websocket connection with CARMA cloud. Requires external SSH tunnel to be established.",
 	"version":"@PROJECT_VERSION@",
 	"exeLocation":"/bin/CARMACloudPlugin",
 	"coreIpAddr":"127.0.0.1",
@@ -16,17 +16,12 @@
 		{
 			"key":"WebServicePort",
 			"default":"22222",
-			"description":"Server Port for V2X hub to receive TCM messages"
+			"description":"Port for V2X hub to receive TCM messages from CARMA Cloud"
 		},
 		{
-			"key":"CARMACloudIP",
-			"default":"http://127.0.0.1",
-			"description":"Server IP address of carma-cloud"
-		},
-		{
-			"key":"CARMACloudPort",
-			"default":"33333",
-			"description":"Server Port for V2X hub to send TCR messages to carma-cloud"
+			"key":"CARMACloudBaseUrl",
+			"default":"https://host.docker.internal:33333",
+			"description":"Host or server IP address and port for SSH-tunnel to CARMA Cloud"
 		},
 		{
 			"key":"fetchTime",
@@ -72,6 +67,11 @@
 			"key":"listTCM",
 			"default":"true",
 			"description":"Indicator to determine if v2xhub receives a list of TCMs from carma-cloud. Default to true, returning a list of TCM. If false, return one TCM at a time. Indicator value can only be either true or false."
+		},
+		{
+			"key":"enforceTLSVerification",
+			"default":"true",
+			"description":"Indicator to determine if v2xhub should enforce TLS verification for CARMA-Cloud connnection. Default to true.  False should only be used for development and debugging purposes."
 		}
 	]
 }

--- a/src/v2i-hub/CARMACloudPlugin/scripts/open_tunnels.sh
+++ b/src/v2i-hub/CARMACloudPlugin/scripts/open_tunnels.sh
@@ -39,7 +39,7 @@ if [ -z "$TEMP_FILE" ]; then
 fi
 
 
-# open http tunnel, port-forwarding from HOST_PORT to port 8080 (8080: running on carma cloud)
+# open http tunnel, port-forwarding from HOST_PORT to port 8443 (8443: running on carma cloud)
 if  [ -z "$REMOTE_USER" ] || [ -z "$REMOTE_ADDR" ] || [ -z "$KEY_FILE" ]; then
     showUsage
 fi
@@ -51,10 +51,10 @@ if sudo lsof -t -i:$HOST_PORT >/dev/null; then
 fi
 
 
-# Open forward tunnel: This port (33333) is forwarded to remote host (carma-cloud) and port: 8080 
+# Open forward tunnel: This port (33333) is forwarded to remote host (carma-cloud) and port: 8443
 echo "Open forward tunnel..."
 
-CMD="/usr/bin/ssh -4 -f -i $KEY_FILE -L $HOST_PORT:localhost:8080 -N -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o UserKnownHostsFile=/dev/null -o LogLevel=quiet $REMOTE_USER@$REMOTE_ADDR" # -f runs ssh in background after it authenticates, -N creates a tunnel without running remote commands to save resources, -T disables pseudo-tty allocation 
+CMD="/usr/bin/ssh -4 -f -g -i $KEY_FILE -L $HOST_PORT:localhost:8443 -N -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o UserKnownHostsFile=/dev/null -o LogLevel=quiet $REMOTE_USER@$REMOTE_ADDR" # -f runs ssh in background after it authenticates, -N creates a tunnel without running remote commands to save resources, -T disables pseudo-tty allocation
 ps -x -o pid,cmd | grep "$CMD" > $TEMP_FILE # write the contents of the ps command to a file, it only prints the pid and the command line command used to create the entry
 while read -r line; do # read the lines of the file with ps command
     case "$line" in

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -2,6 +2,7 @@
 #include <WGS84Point.h>
 #include <math.h>
 #include <thread>
+#include <cstdlib>
 using namespace std;
 using namespace tmx::messages;
 using namespace tmx::utils;
@@ -485,8 +486,13 @@ void CARMACloudPlugin::UpdateConfigSettings() {
 	GetConfigValue<string>("listTCM",list_tcm);
 	GetConfigValue<string>("CARMACloudBaseUrl",carma_cloud_url);
 	GetConfigValue<bool>("enforceTLSVerification",enforceTLSVerification);
+	GetConfigValue<string>("carma_cloud_ca_cert_path",carma_cloud_ca_cert_path);
+
 	PLOG(logDEBUG) << "Setting CARMA Cloud Base URL to " << carma_cloud_url << std::endl;
 	PLOG(logDEBUG) << "Setting CARMA Cloud 'Enforce TLS Verification' mode to " << enforceTLSVerification << std::endl;
+    PLOG(logDEBUG) << "Setting CARMA Cloud CA cert path to "
+                   << (carma_cloud_ca_cert_path.empty() ? "<system default>" : carma_cloud_ca_cert_path)
+                   << std::endl;
 }
 
 void CARMACloudPlugin::OnConfigChanged(const char *key, const char *value) {
@@ -528,9 +534,14 @@ int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url
 	// Enforce certificate validation
 	curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 1L);
     curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 2L);
-    // curl_easy_setopt(req, CURLOPT_CAINFO, "/path/to/internal-ca.pem");
+    // Use configured CA bundle for TLS certificate validation when connecting
+	// to services secured with a private/internal Certificate Authority (CA).
+	if (!carma_cloud_ca_cert_path.empty()) {
+		curl_easy_setopt(req, CURLOPT_CAINFO, carma_cloud_ca_cert_path.c_str());
+	}
 
 #ifdef ALLOW_INSECURE_TLS
+	// VONLY included when compiled as a Debug build
     if (!enforceTLSVerification) {
         curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0L);
@@ -540,8 +551,7 @@ int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url
     }
 #else
     if (!enforceTLSVerification) {
-        PLOG(logERROR)
-            << "TLS verification can ONLY be disabled in Debug builds.";
+        PLOG(logERROR) << "TLS verification can ONLY be disabled in Debug builds.";
         curl_easy_cleanup(req);
         return 1;
     }
@@ -552,9 +562,9 @@ int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url
     curl_easy_setopt(req, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 
-    if (strcmp(local_method.c_str(), "POST") == 0) {
+    if (local_method == "POST") {
         curl_easy_setopt(req, CURLOPT_POSTFIELDS, local_msg.c_str());
-        curl_easy_setopt(req, CURLOPT_POSTFIELDSIZE, (long)local_msg.size());
+        curl_easy_setopt(req, CURLOPT_POSTFIELDSIZE, static_cast<long>(local_msg.size()));
     }
 
     CURLcode res = curl_easy_perform(req);

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -541,6 +541,9 @@ int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url
 	}
 
 #ifdef ALLOW_INSECURE_TLS
+	// By disabled in release builds. Only enabled in debug builds for testing and debugging purposes
+	// Can be ignored for sonar scanning since not in released images
+	// BEGIN-NOSCAN
 	// ONLY included when compiled as a Debug build
     if (!enforceTLSVerification) {
         curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 0L);
@@ -549,6 +552,7 @@ int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url
 			<< "CARMA-Cloud certificate and hostname validation are NOT being enforced. "
 			<< "This option should only be disabled in non-production / development environments for temporary troubleshooting.";
     }
+	// END-NOSCAN
 #else
     if (!enforceTLSVerification) {
         PLOG(logERROR) << "TLS verification can ONLY be disabled in Debug builds.";

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -526,17 +526,26 @@ int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url
     curl_easy_setopt(req, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
 
 	// Enforce certificate validation
-    if (enforceTLSVerification) {
-        curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 1L);
-        curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 2L);
-        // curl_easy_setopt(req, CURLOPT_CAINFO, "/path/to/internal-ca.pem");
-    } else {
+	curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 2L);
+    // curl_easy_setopt(req, CURLOPT_CAINFO, "/path/to/internal-ca.pem");
+
+#ifdef ALLOW_INSECURE_TLS
+    if (!enforceTLSVerification) {
         curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0L);
 		PLOG(logWARNING) << "TLS verification disabled by setting configuration 'enforceTLSVerification' to false. "
 			<< "CARMA-Cloud certificate and hostname validation are NOT being enforced. "
 			<< "This option should only be disabled in non-production / development environments for temporary troubleshooting.";
     }
+#else
+    if (!enforceTLSVerification) {
+        PLOG(logERROR)
+            << "TLS verification can ONLY be disabled in Debug builds.";
+        curl_easy_cleanup(req);
+        return 1;
+    }
+#endif
 
     curl_easy_setopt(req, CURLOPT_CONNECTTIMEOUT_MS, 500L);
     curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 1000L);

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -42,7 +42,7 @@ CARMACloudPlugin::CARMACloudPlugin(string name) : PluginClientClockAware(name)
 void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &routeableMsg)
 {
 	auto carmaRequest = msg.get_j2735_data();
-
+	asn_fprint(stdout, &asn_DEF_TestMessage04, carmaRequest.get());
 
 
 	// convert reqid bytes to hex string.
@@ -54,7 +54,6 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 	}
 
 	printf("%s\n",reqid);
-
 	long int reqseq = carmaRequest->body.choice.tcrV01.reqseq;
 	long int scale = carmaRequest->body.choice.tcrV01.scale;
 	
@@ -68,7 +67,6 @@ void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &r
 
 	while (cnt < totBounds)
 	{
-
 		long lat = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->reflat;
 		long longg = carmaRequest->body.choice.tcrV01.bounds.list.array[cnt]->reflon;
 
@@ -487,19 +485,17 @@ void CARMACloudPlugin::UpdateConfigSettings() {
 	GetConfigValue<int>("TCMRepeatedlyBroadCastTotalTimes", _TCMRepeatedlyBroadCastTotalTimes);
 	GetConfigValue<int>("TCMRepeatedlyBroadcastSleep", _TCMRepeatedlyBroadcastSleep);
 	GetConfigValue<string>("listTCM",list_tcm);
-	std::string carma_cloud_ip;
-	uint carma_cloud_port;
-	GetConfigValue<string>("CARMACloudIP",carma_cloud_ip);
-	GetConfigValue<uint>("CARMACloudPort",carma_cloud_port);
-	carma_cloud_url = carma_cloud_ip + ":" + std::to_string(carma_cloud_port);
-	PLOG(logDEBUG) << "Setting CARMA Cloud URL to " << carma_cloud_url << std::endl;
-	
+	GetConfigValue<string>("CARMACloudBaseUrl",carma_cloud_url);
+	GetConfigValue<bool>("enforceTLSVerification",enforceTLSVerification);
+	PLOG(logDEBUG) << "Setting CARMA Cloud Base URL to " << carma_cloud_url << std::endl;
+	PLOG(logDEBUG) << "Setting CARMA Cloud 'Enforce TLS Verification' mode to " << enforceTLSVerification << std::endl;
 }
 
 void CARMACloudPlugin::OnConfigChanged(const char *key, const char *value) {
 	PluginClient::OnConfigChanged(key, value);
 	UpdateConfigSettings();
 }
+	void OnStateChange(IvpPluginState state);
 
 void CARMACloudPlugin::OnStateChange(IvpPluginState state) {
 	PluginClient::OnStateChange(state);
@@ -511,36 +507,58 @@ void CARMACloudPlugin::OnStateChange(IvpPluginState state) {
 
 void CARMACloudPlugin::CloudSendAsync(const string& local_msg,const string& local_url, const string& local_base, const string& local_method)
 {
-	std::thread t([this, &local_msg, &local_url, &local_base, &local_method](){	
-		CloudSend(local_msg, local_url, local_base, local_method);	
+	std::thread t([this, local_msg, local_url, local_base, local_method]() {
+		CloudSend(local_msg, local_url, local_base, local_method);
 	});
 	t.detach();
 }
 
 int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url, const string& local_base, const string& local_method)
 { 	
-	CURL *req;
-	CURLcode res;
-	string urlfull = local_url+local_base;	
-	req = curl_easy_init();
-	if(req) {
-		curl_easy_setopt(req, CURLOPT_URL, urlfull.c_str());
+    CURL* req = curl_easy_init();
+    if (!req) return 1;
 
-		if(strcmp(local_method.c_str(),"POST")==0)
-		{
-			curl_easy_setopt(req, CURLOPT_POSTFIELDS, local_msg.c_str());
-			curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 1000L); // Request operation complete within max millisecond timeout 
-			res = curl_easy_perform(req);
-			if(res != CURLE_OK)
-			{
-				fprintf(stderr, "curl send failed: %s\n",curl_easy_strerror(res));
-				return 1;
-			}	  
-		}
-		curl_easy_cleanup(req);
-	}	
-  	
-  return 0;
+    const std::string urlfull = local_url + local_base;
+
+    curl_easy_setopt(req, CURLOPT_URL, urlfull.c_str());
+    curl_easy_setopt(req, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+    curl_easy_setopt(req, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTPS);
+
+	// Enforce modern TLS
+    curl_easy_setopt(req, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+
+	// Enforce certificate validation
+    if (enforceTLSVerification) {
+        curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 1L);
+        curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 2L);
+        // curl_easy_setopt(req, CURLOPT_CAINFO, "/path/to/internal-ca.pem");
+    } else {
+        curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 0L);
+        curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0L);
+		PLOG(logWARNING) << "TLS verification disabled by setting configuration 'enforceTLSVerification' to false. "
+			<< "CARMA-Cloud certificate and hostname validation are NOT being enforced. "
+			<< "This option should only be disabled in non-production / development environments for temporary troubleshooting.";
+    }
+
+    curl_easy_setopt(req, CURLOPT_CONNECTTIMEOUT_MS, 500L);
+    curl_easy_setopt(req, CURLOPT_TIMEOUT_MS, 1000L);
+    curl_easy_setopt(req, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(req, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+
+    if (strcmp(local_method.c_str(), "POST") == 0) {
+        curl_easy_setopt(req, CURLOPT_POSTFIELDS, local_msg.c_str());
+        curl_easy_setopt(req, CURLOPT_POSTFIELDSIZE, (long)local_msg.size());
+    }
+
+    CURLcode res = curl_easy_perform(req);
+    curl_easy_cleanup(req);
+
+    if (res != CURLE_OK) {
+        PLOG(logERROR) << "curl send failed: " << curl_easy_strerror(res);
+        return 1;
+    }
+
+    return 0;
 }
 
 void CARMACloudPlugin::ConvertString2Vector(std::vector<string> &sub_str_v, const string &str) const{

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -541,7 +541,7 @@ int CARMACloudPlugin::CloudSend(const string &local_msg, const string& local_url
 	}
 
 #ifdef ALLOW_INSECURE_TLS
-	// VONLY included when compiled as a Debug build
+	// ONLY included when compiled as a Debug build
     if (!enforceTLSVerification) {
         curl_easy_setopt(req, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(req, CURLOPT_SSL_VERIFYHOST, 0L);

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.cpp
@@ -42,8 +42,6 @@ CARMACloudPlugin::CARMACloudPlugin(string name) : PluginClientClockAware(name)
 void CARMACloudPlugin::HandleCARMARequest(tsm4Message &msg, routeable_message &routeableMsg)
 {
 	auto carmaRequest = msg.get_j2735_data();
-	asn_fprint(stdout, &asn_DEF_TestMessage04, carmaRequest.get());
-
 
 	// convert reqid bytes to hex string.
 	size_t hexlen = 2; //size of each hex representation with a leading 0

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -106,7 +106,6 @@ protected:
 
 	// Virtual method overrides.
 	void OnConfigChanged(const char *key, const char *value);
-	//void OnMessageReceived(IvpMessage *msg);
 	void OnStateChange(IvpPluginState state);
 
 	int  StartWebService();
@@ -211,6 +210,8 @@ private:
 	std::string list_tcm = "true";
 	//API URL to accept TCM response
 	const QString TCM_REPLY = "tcmreply";
+	// Enforce TLS verification. Default is true.  False should only be used for development and debugging purposes.
+	bool enforceTLSVerification = false;
 };
 std::mutex _cfgLock;
 }

--- a/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
+++ b/src/v2i-hub/CARMACloudPlugin/src/CARMACloudPlugin.h
@@ -212,6 +212,10 @@ private:
 	const QString TCM_REPLY = "tcmreply";
 	// Enforce TLS verification. Default is true.  False should only be used for development and debugging purposes.
 	bool enforceTLSVerification = false;
+	// Optional CA bundle used by the CARMA-Cloud Plugin for TLS validation
+    // when CARMA-Cloud is secured with a private/internal Certificate Authority.
+    // set plugin configuration carma_cloud_ca_cert_path=/var/www/plugins/ssl/carma-cloud-internal-ca.pem
+	std::string carma_cloud_ca_cert_path;
 };
 std::mutex _cfgLock;
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

V2X-Hub and CARMA Cloud currently communicate over HTTP through SSH tunnels. This change updates CARMACloudPlugin to use HTTPS over the existing SSH tunnel infrastructure and addresses SonarQube findings related to deprecated SSL/TLS configurations.

### Specific Changes
* Updated `CloudSend` to use HTTPS communication
* Updated `CloudSendAsync` to capture variables by value
  * **Reason:** The detached thread previously captured `local_msg`, `local_url`, `local_base`, and `local_method` by reference. These references could become invalid after the function returned, potentially causing undefined behavior or stability issues.
* Simplified manifest configurations to use `CARMACloudBaseUrl` and set default to `https://host.docker.internal:33333` 
* Added `enforceTLSVerification`  and  `carma_cloud_ca_cert_path` configurations support to `CARMACloudPlugin` and exposed it through the manifest
* Updated SSH tunnel configuration to enable HTTPS traffic from V2X-Hub to CARMA-Cloud:
  * used the `-g` flag which permits non-local connections to the forwarded port, enabling Docker containers to access the tunnel endpoint established on host.
  * forwarded HTTPS traffic over port `8443` 
* Updated documentation to clarify plugin configuration options and explain when `host.docker.internal` should be used



## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
[ OMDO-158](https://usdot-carma.atlassian.net/browse/OMDO-158)

## Motivation and Context
 It addressed SonarQube finding to use stronger SSL and TLS versions.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This was tested manually.

### Test Steps
- Build and deploy V2X Hub
- Enable Message Receiver and CARMA Cloud Plugins
- Configure CARMA Cloud Plugin for CARMA Cloud connection
- Establish SSH tunneling from host
- Use [tcr_script.py](https://github.com/usdot-fhwa-OPS/V2X-Hub/blob/develop/src/v2i-hub/CARMACloudPlugin/scripts/tcr_script.py) to send a Traffic Control Request (TCR) to the Message Receiver which will forward to CARMA Cloud Plugin which sends it to CARMA Cloud.
- Verify V2X-Hub logs (with DEBUG enabled) show TCR message going from Message Receiver → CARMA Cloud Plugin → CARMA Cloud
- Verify CARMA Cloud logs received request.
- Verify in V2X-Hub logs that CARMA Cloud Plugin received a response Traffic Control Message (TCM) from CARMA Cloud.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
