### PR TITLE
Added statuses for passed/failed message validation counters

### DIFF
--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -107,6 +107,9 @@ namespace IntersectionValidation
                                                              int intersectionId,
                                                              uint64_t handlerBeginMs)
     {
+        uint32_t &passed = (messageType == "SPaT") ? spatValidationPassed : mapValidationPassed;
+        uint32_t &failed = (messageType == "SPaT") ? spatFieldValidationErrors : mapFieldValidationErrors;
+
         FieldValidation result = validateJsonAgainstSchemaFile(jsonStr, schemaPath);
         
         if (messageType == "SPaT")
@@ -143,6 +146,23 @@ namespace IntersectionValidation
             eventMsg.set_missingDataElements(elements);
 
             PluginClient::BroadcastMessage(eventMsg);
+
+            failed++;
+        }
+        else
+        {
+            passed++;
+        }
+
+        if (messageType == "SPaT")
+        {
+            PluginClient::SetStatus<u_int32_t>("SPaT Field Validation Passed", passed);
+            PluginClient::SetStatus<u_int32_t>("SPaT Field Validation Failed", failed);
+        }
+        else if (messageType == "MAP")
+        {
+            PluginClient::SetStatus<u_int32_t>("MAP Field Validation Passed", passed);
+            PluginClient::SetStatus<u_int32_t>("MAP Field Validation Failed", failed);
         }
     }
 

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -56,6 +56,10 @@ namespace IntersectionValidation
 
         std::string spatSchemaPath = "/var/www/plugins/IntersectionValidationPlugin/resources/spat.schema.json";
         std::string mapSchemaPath = "/var/www/plugins/IntersectionValidationPlugin/resources/map.schema.json";
+        uint spatFieldValidationErrors;
+        uint spatValidationPassed;
+        uint mapFieldValidationErrors;
+        uint mapValidationPassed;
         std::string rsuSource;
 
         /**


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Added statuses for SPaT and MAP message counters that passed/failed field validation.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[VH-1532](https://usdot-carma.atlassian.net/browse/VH-1532?atlOrigin=eyJpIjoiMDM0MmMzMmFhMGRiNDVhMzgxNGExYjJmMDQzNjRlNzciLCJwIjoiaiJ9)

## Motivation and Context

Added statuses that can be used for integration testing

## How Has This Been Tested?

Local deployment testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[VH-1532]: https://usdot-carma.atlassian.net/browse/VH-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ