### PR TITLE
Exclude TmxApi/test from test coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -104,6 +104,7 @@ TmxTools.sonar.sources                    =src
 TmxUtils.sonar.sources                    =src
 TmxUtils.sonar.exclusions                 =test/**
 TmxApi.sonar.sources                      =tmx
+TmxApi.sonar.exclusions                   =test/**
 Messages.sonar.sources                    =include
 CswPlugin.sonar.sources                   =src
 PortDrayagePlugin.sonar.sources           =src


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
TmxApi/test directory seems to be included in test coverage analysis which is not intentional. This PR should remove that.
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
Fix sonar scan analysis
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
CI
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
