### PR TITLE
Fixed interval logic, changed type for converting message to json

### DIFF
--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -70,6 +70,7 @@ namespace IntersectionValidation
         {
             PLOG(tmx::utils::logWARNING) << messageType << " interval violation: " << e.what();
 
+            // Calculate interval if there is an exception thrown
             if (lastTimestampMs != 0)
             {
                 intervalMs = currentTimeMs - lastTimestampMs;

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -70,6 +70,11 @@ namespace IntersectionValidation
         {
             PLOG(tmx::utils::logWARNING) << messageType << " interval violation: " << e.what();
 
+            if (lastTimestampMs != 0)
+            {
+                intervalMs = currentTimeMs - lastTimestampMs;
+            }
+
             TmxEventLogMessage eventLogMsg;
             eventLogMsg.set_level(IvpLogLevel::IvpLogLevel_warn);
             eventLogMsg.set_description(messageType + EVENT_MAX_THRESHOLD +
@@ -183,8 +188,9 @@ namespace IntersectionValidation
 
         try
         {
+            // Convert SPAT to JSON
             auto spatData = msg.get_j2735_data();
-            auto spatJsonMsg = TmxJ2735Message<SPAT, tmx::JSON>(spatData);
+            auto spatJsonMsg = TmxJ2735Message<MessageFrame, tmx::JSON>(spatData);
             std::string spatJsonStr = spatJsonMsg.to_string();
 
             // Get intersection ID from message
@@ -222,8 +228,9 @@ namespace IntersectionValidation
 
         try
         {
+            // Convert MAP to JSON
             auto mapData = msg.get_j2735_data();
-            auto mapJsonMsg = TmxJ2735Message<MapData, tmx::JSON>(mapData);
+            auto mapJsonMsg = TmxJ2735Message<MessageFrame, tmx::JSON>(mapData);
             std::string mapJsonStr = mapJsonMsg.to_string();
  
             PLOG(logDEBUG) << "MAP JSON: " << mapJsonStr;


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Interval logic is updated so that if a tmxException is thrown, time stamp of last received message is still updated. Also the message types when converting the messages to JSON were updated from the specific message type to Message Frame.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[VH-1532](https://usdot-carma.atlassian.net/browse/VH-1532?atlOrigin=eyJpIjoiZWVlYmIzMTZkMjFmNGFiOThiN2M0ZjI5N2RjNzFkZGYiLCJwIjoiaiJ9)

## Motivation and Context

Bug fixes found from integration testing

## How Has This Been Tested?

Local deployment testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[VH-1532]: https://usdot-carma.atlassian.net/browse/VH-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ