### PR TITLE
Added parsing through oneOf options and empty strings during field validaiton

### DIFF
--- a/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.cpp
@@ -72,11 +72,36 @@ namespace IntersectionValidation
 
     static const rapidjson::Value *getPropertySchema(const rapidjson::Value &schema, const char *key)
     {
-        if (schema.IsObject() && schema.HasMember("properties") &&
+        if (!schema.IsObject())
+        {
+            return nullptr;
+        }
+
+        // Direct properties lookup
+        if (schema.HasMember("properties") &&
             schema["properties"].IsObject() && schema["properties"].HasMember(key))
         {
             return &schema["properties"][key];
         }
+
+        // Search inside oneOf / anyOf / allOf
+        for (const char *combiner : {"oneOf", "anyOf", "allOf"})
+        {
+            if (!schema.HasMember(combiner) || !schema[combiner].IsArray())
+            {
+                continue;
+            }
+
+            for (rapidjson::SizeType i = 0; i < schema[combiner].Size(); ++i)
+            {
+                const rapidjson::Value *found = getPropertySchema(schema[combiner][i], key);
+                if (found != nullptr)
+                {
+                    return found;
+                }
+            }
+        }
+
         return nullptr;
     }
 
@@ -112,7 +137,11 @@ namespace IntersectionValidation
                                rapidjson::Document::AllocatorType &allocator,
                                const rapidjson::Value &schema)
     {
-        if (value.IsObject())
+        if (value.IsString() && schemaHasType(schema, "integer"))
+        {
+            tryConvertToInt(value);
+        }
+        else if (value.IsObject())
         {
             for (auto it = value.MemberBegin(); it != value.MemberEnd(); ++it)
             {
@@ -145,6 +174,38 @@ namespace IntersectionValidation
         }
     }
 
+    static void removeEmptyStrings(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator)
+    {
+        if (!value.IsObject())
+        {
+            return;
+        }
+
+        if (value.IsArray())
+        {
+            for (rapidjson::SizeType i = 0; i < value.Size(); ++i)
+            {
+                removeEmptyStrings(value[i], allocator);
+            }
+        }
+
+        for (auto it = value.MemberBegin(); it != value.MemberEnd();)
+        {
+            if (it->value.IsString() && it->value.GetStringLength() == 0)
+            {
+                it = value.EraseMember(it);
+            }
+            else
+            {
+                if (it->value.IsObject() || it->value.IsArray())
+                {
+                    removeEmptyStrings(it->value, allocator);
+                }
+                ++it;
+            }
+        }
+    }
+
     FieldValidation validateJsonAgainstSchema(const std::string &jsonStr, const std::string &schemaStr)
     {
         FieldValidation result;
@@ -170,6 +231,9 @@ namespace IntersectionValidation
             result.errors.emplace_back("Failed to parse input JSON");
             return result;
         }
+
+        // Remove TMX empty string placeholders for optional object fields
+        removeEmptyStrings(doc, doc.GetAllocator());
 
         // Convert numeric strings to integers
         convertNumericStrings(doc, doc.GetAllocator(), schemaDoc);


### PR DESCRIPTION
…Of members, and dealing with empty strings

<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

When testing validating various MAP messages, fields of type oneOf, anyOf and allOf were throwing errors, as well as empty strings in arrays. The field validation logic is updated to deal with these types of values

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[VH-1532](https://usdot-carma.atlassian.net/browse/VH-1532?atlOrigin=eyJpIjoiMjEzOWRhOWY3MWJmNDgwZmEzNGUxZjg2MjhjMmRjN2EiLCJwIjoiaiJ9)

## Motivation and Context

Adds validation support for additional field types

## How Has This Been Tested?

Local deployment testing, integration testing 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[VH-1532]: https://usdot-carma.atlassian.net/browse/VH-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ