### PR TITLE
VH-1527 Frequency Throttling for MAP and SPAT

### DIFF
--- a/src/tmx/TmxApi/tmx/IvpMessage.h
+++ b/src/tmx/TmxApi/tmx/IvpMessage.h
@@ -18,6 +18,7 @@ extern "C"
 typedef unsigned int IvpMsgFlags;
 #define IvpMsgFlags_None 0x00
 #define IvpMsgFlags_RouteDSRC 0x01
+#define IvpMsgFlags_Validated 0x02
 
 typedef struct IvpDsrcMetadata {
 	int psid;

--- a/src/v2i-hub/IntersectionValidationPlugin/CMakeLists.txt
+++ b/src/v2i-hub/IntersectionValidationPlugin/CMakeLists.txt
@@ -8,7 +8,7 @@ BuildTmxPlugin ()
 
 TARGET_LINK_LIBRARIES ( ${PROJECT_NAME} tmxutils ::carma-clock )
 
-add_library(${PROJECT_NAME}_lib src/MessageIntervalValidator.cpp src/FieldValidation.cpp src/RevisionCounterValidator.cpp)
+add_library(${PROJECT_NAME}_lib src/MessageIntervalValidator.cpp src/FieldValidation.cpp src/RevisionCounterValidator.cpp src/ODEForwarding.cpp)
 target_link_libraries(${PROJECT_NAME}_lib PUBLIC tmxutils)
 target_include_directories(${PROJECT_NAME}_lib PUBLIC ${PROJECT_SOURCE_DIR}/src)
 

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -18,6 +18,7 @@
 #include "MessageIntervalValidator.h"
 #include "FieldValidation.h"
 #include "RevisionCounterValidator.h"
+#include "ODEForwarding.h"
 
 using namespace tmx;
 using namespace tmx::utils;
@@ -107,7 +108,7 @@ namespace IntersectionValidation
         lastTimestampMs = currentTimeMs;
     }
 
-    void IntersectionValidationPlugin::validateMessage(const std::string &jsonStr,
+    RevisionCounterResult IntersectionValidationPlugin::validateMessage(const std::string &jsonStr,
                                                        const std::string &schemaPath,
                                                        const std::string &fieldEventType,
                                                        const std::string &revisionEventType,
@@ -121,7 +122,7 @@ namespace IntersectionValidation
         if (doc.HasParseError())
         {
             PLOG(logERROR) << "Failed to parse " << messageType << " JSON";
-            return;
+            return {};
         }
 
         // Load and parse the schema
@@ -131,7 +132,7 @@ namespace IntersectionValidation
         if (schemaDoc.HasParseError())
         {
             PLOG(logERROR) << "Failed to parse " << messageType << " schema";
-            return;
+            return {};
         }
 
         // Preprocess, remove TMX empty strings, convert
@@ -141,7 +142,7 @@ namespace IntersectionValidation
 
         // Run both validations on the same preprocessed document
         validateMessageFields(doc, schemaDoc, fieldEventType, messageType, intersectionId, handlerBeginMs);
-        validateRevisionCounters(doc, revisionEventType, messageType, intersectionId, handlerBeginMs);
+        return validateRevisionCounters(doc, revisionEventType, messageType, intersectionId, handlerBeginMs);
     }
 
     void IntersectionValidationPlugin::validateMessageFields(const rapidjson::Document &doc,
@@ -220,7 +221,7 @@ namespace IntersectionValidation
         }
     }
 
-    void IntersectionValidationPlugin::validateRevisionCounters(const rapidjson::Document &doc,
+    RevisionCounterResult IntersectionValidationPlugin::validateRevisionCounters(const rapidjson::Document &doc,
                                                                 const std::string &eventType,
                                                                 const std::string &messageType,
                                                                 int intersectionId,
@@ -260,6 +261,17 @@ namespace IntersectionValidation
             PluginClient::BroadcastMessage(eventMsg);
 
             failed++;
+
+            if (messageType == "SPaT")
+            {
+                PluginClient::SetStatus("SPaT Revision Validation Passed", static_cast<int>(passed));
+                PluginClient::SetStatus("SPaT Revision Validation Failed", static_cast<int>(failed));
+            }
+            else if (messageType == "MAP")
+            {
+                PluginClient::SetStatus("MAP Revision Validation Passed", static_cast<int>(passed));
+                PluginClient::SetStatus("MAP Revision Validation Failed", static_cast<int>(failed));
+            }
         }
         else if (result.comparisonPerformed && messageType == "SPaT")
         {
@@ -273,14 +285,113 @@ namespace IntersectionValidation
             PluginClient::SetStatus("MAP Revision Validation Passed", static_cast<int>(passed));
             PluginClient::SetStatus("MAP Revision Validation Failed", static_cast<int>(failed));
         }
+
+        return result;
+    }
+
+    void IntersectionValidationPlugin::broadcastValidated(routeable_message &msg)
+    {
+        // set_flags AFTER any initialize() on the encoded message (verified ordering).
+        msg.set_flags(IvpMsgFlags_Validated);
+        PluginClient::BroadcastMessage(msg);
+    }
+
+    void IntersectionValidationPlugin::forwardValidatedSpat(SpatMessage &msg, routeable_message &routeableMsg,
+                                                            const std::shared_ptr<SPAT> &spatDataRef,
+                                                            const std::map<int, int> &corrections)
+    {
+        // No corrections — original UPER bytes are still valid, just flag and forward.
+        if (corrections.empty())
+        {
+            broadcastValidated(routeableMsg);
+            return;
+        }
+
+        // Apply each correction to the matching intersection in the ASN.1 frame.
+        for (int i = 0; i < spatDataRef->intersections.list.count; ++i)
+        {
+            int id = static_cast<int>(spatDataRef->intersections.list.array[i]->id.id);
+            if (auto it = corrections.find(id); it != corrections.end())
+            {
+                spatDataRef->intersections.list.array[i]->revision = it->second;
+                PLOG(logWARNING) << "Corrected SPaT revision for intersection " << id
+                                 << " to " << it->second;
+            }
+        }
+
+        // Re-encode from the mutated frame
+        SpatMessage corrected(spatDataRef);
+        SpatEncodedMessage encodedMsg;
+        encodedMsg.initialize(corrected);
+
+        if (auto *rMsg = dynamic_cast<routeable_message *>(&encodedMsg))
+            broadcastValidated(*rMsg);
+        else
+            PLOG(logERROR) << "Failed to cast SpatEncodedMessage to routeable_message";
+    }
+
+    void IntersectionValidationPlugin::forwardValidatedMap(MapDataMessage &msg, routeable_message &routeableMsg,
+                                                           const std::shared_ptr<MapData> &mapDataRef,
+                                                           const std::map<int, int> &corrections,
+                                                           int msgRevisionCorrection)
+    {
+        // No corrections of either kind — original UPER bytes are valid, just flag and forward.
+        if (corrections.empty() && msgRevisionCorrection < 0)
+        {
+            broadcastValidated(routeableMsg);
+            return;
+        }
+
+        // Message-level correction. msgIssueRevision is a mandatory MsgCount field.
+        if (msgRevisionCorrection >= 0)
+        {
+            mapDataRef->msgIssueRevision = msgRevisionCorrection;
+            PLOG(logWARNING) << "Corrected MAP msgIssueRevision to " << msgRevisionCorrection;
+        }
+
+        // Per-intersection corrections. MAP 'intersections' is an OPTIONAL pointer — null-check it.
+        if (!corrections.empty() && mapDataRef->intersections != nullptr)
+        {
+            for (int i = 0; i < mapDataRef->intersections->list.count; ++i)
+            {
+                auto *ig = mapDataRef->intersections->list.array[i];
+                int id = static_cast<int>(ig->id.id);
+                if (auto it = corrections.find(id); it != corrections.end())
+                {
+                    ig->revision = it->second;
+                    PLOG(logWARNING) << "Corrected MAP revision for intersection " << id
+                                     << " to " << it->second;
+                }
+            }
+        }
+
+        // Re-encode from the mutated frame.
+        // *** VERIFY in your tree before relying on this: ***
+        //   1. MapDataMessage has a ctor taking std::shared_ptr<MapData>
+        //   2. the encoded type is MapDataEncodedMessage (TMX_J2735_DECLARE(MapData,...) naming),
+        //      NOT MapEncodedMessage — grep to confirm
+        //   3. MAP re-encode has thrown "Unable to stream JSON contents in memory" on large
+        //      payloads before — test with a MINIMAL real MAP first
+        MapDataMessage corrected(mapDataRef);
+        MapDataEncodedMessage encodedMsg;
+        encodedMsg.initialize(corrected);
+
+        if (auto *rMsg = dynamic_cast<routeable_message *>(&encodedMsg))
+            broadcastValidated(*rMsg);
+        else
+            PLOG(logERROR) << "Failed to cast MapDataEncodedMessage to routeable_message";
     }
 
     void IntersectionValidationPlugin::HandleSpatMessage(SpatMessage &msg, routeable_message &routeableMsg)
     {
+        // Skip our own re-broadcasts
+        if (routeableMsg.get_flags() & IvpMsgFlags_Validated)
+            return;
+
         uint64_t handlerBeginMs = PluginClientClockAware::getClock()->nowInMilliseconds();
  
         measureMessageInterval(_lastSpatTimeMs, SPAT_INTERVAL_REQUIRED_MS, SPAT_INTERVAL_MAX_THRESHOLD_MS, "SPaT");
- 
+
         if (spatSchemaPath.empty())
         {
             PLOG(logWARNING) << "SpatSchemaPath not configured, skipping validation";
@@ -291,7 +402,8 @@ namespace IntersectionValidation
         try
         {
             auto spatData = msg.get_j2735_data();
- 
+            auto spatDataRef = spatData; // keep alive past JSON conversion
+
             // Extract intersection ID before JSON conversion
             int intersectionId = -1;
             if (spatData && spatData->intersections.list.count > 0 &&
@@ -303,12 +415,14 @@ namespace IntersectionValidation
             // Convert to full MessageFrame JSON
             auto spatJsonMsg = TmxJ2735Message<MessageFrame, tmx::JSON>(spatData);
             std::string spatJsonStr = spatJsonMsg.to_string();
- 
-            PLOG(logDEBUG) << "SPaT JSON: " << spatJsonStr;
- 
+
             // Parse, preprocess, validate
-            validateMessage(spatJsonStr, spatSchemaPath, "SpatMinimumData", "SpatRevisionCounter",
-                            "SPaT", intersectionId, handlerBeginMs);
+            RevisionCounterResult revResult = validateMessage(spatJsonStr, spatSchemaPath, "SpatMinimumData",
+                                                              "SpatRevisionCounter", "SPaT", intersectionId, handlerBeginMs);
+
+            ODEForwarding plan = planForwarding(revResult);
+            if (plan.shouldForward)
+                forwardValidatedSpat(msg, routeableMsg, spatDataRef, plan.corrections);
         }
         catch (const std::exception &e)
         {
@@ -318,6 +432,10 @@ namespace IntersectionValidation
 
     void IntersectionValidationPlugin::HandleMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg)
     {
+        // Skip our own re-broadcasts
+        if (routeableMsg.get_flags() & IvpMsgFlags_Validated)
+            return;
+
         uint64_t handlerBeginMs = PluginClientClockAware::getClock()->nowInMilliseconds();
  
         measureMessageInterval(_lastMapTimeMs, MAP_INTERVAL_REQUIRED_MS, MAP_INTERVAL_MAX_THRESHOLD_MS, "MAP");
@@ -332,7 +450,8 @@ namespace IntersectionValidation
         try
         {
             auto mapData = msg.get_j2735_data();
- 
+            auto mapDataRef = mapData; // keep alive past JSON conversion
+
             // Extract intersection ID before JSON conversion
             int intersectionId = -1;
             if (mapData && mapData->intersections != nullptr &&
@@ -345,11 +464,13 @@ namespace IntersectionValidation
             auto mapJsonMsg = TmxJ2735Message<MessageFrame, tmx::JSON>(mapData);
             std::string mapJsonStr = mapJsonMsg.to_string();
  
-            PLOG(logDEBUG) << "MAP JSON: " << mapJsonStr;
- 
             // Parse, preprocess, validate
-            validateMessage(mapJsonStr, mapSchemaPath, "MapMinimumData", "MapRevisionCounter",
-                            "MAP", intersectionId, handlerBeginMs);
+            RevisionCounterResult revResult = validateMessage(mapJsonStr, mapSchemaPath, "MapMinimumData",
+                                                              "MapRevisionCounter", "MAP", intersectionId, handlerBeginMs);
+
+            ODEForwarding plan = planForwarding(revResult);
+            if (plan.shouldForward)
+                forwardValidatedMap(msg, routeableMsg, mapDataRef, plan.corrections, plan.msgRevisionCorrection);
         }
         catch (const std::exception &e)
         {
@@ -357,7 +478,6 @@ namespace IntersectionValidation
         }
     }
 }
- 
 int main(int argc, char *argv[])
 {
     return run_plugin<IntersectionValidation::IntersectionValidationPlugin>("IntersectionValidationPlugin", argc, argv);

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -307,6 +307,8 @@ namespace IntersectionValidation
             return;
         }
 
+        uint &correctedCount = spatRevisionCorrectionsApplied;
+
         // Apply each correction to the matching intersection in message
         for (int i = 0; i < spatDataRef->intersections.list.count; ++i)
         {
@@ -316,6 +318,8 @@ namespace IntersectionValidation
                 spatDataRef->intersections.list.array[i]->revision = it->second;
                 PLOG(logWARNING) << "Corrected SPaT revision for intersection " << id
                                  << " to " << it->second;
+                correctedCount++;
+                PluginClient::SetStatus("SPaT Revision Corrections Applied", correctedCount);
             }
         }
 
@@ -342,6 +346,8 @@ namespace IntersectionValidation
             return;
         }
 
+        uint &correctedCount = mapRevisionCorrectionsApplied;
+
         // Message-level correction
         if (msgRevisionCorrection >= 0)
         {
@@ -361,6 +367,8 @@ namespace IntersectionValidation
                     ig->revision = it->second;
                     PLOG(logWARNING) << "Corrected MAP revision for intersection " << id
                                      << " to " << it->second;
+                    correctedCount++;
+                    PluginClient::SetStatus("MAP Revision Corrections Applied", correctedCount);
                 }
             }
         }

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -310,7 +310,7 @@ namespace IntersectionValidation
         // Apply each correction to the matching intersection in message
         for (int i = 0; i < spatDataRef->intersections.list.count; ++i)
         {
-            int id = static_cast<int>(spatDataRef->intersections.list.array[i]->id.id);
+            auto id = static_cast<int>(spatDataRef->intersections.list.array[i]->id.id);
             if (auto it = corrections.find(id); it != corrections.end())
             {
                 spatDataRef->intersections.list.array[i]->revision = it->second;
@@ -355,7 +355,7 @@ namespace IntersectionValidation
             for (int i = 0; i < mapDataRef->intersections->list.count; ++i)
             {
                 auto *ig = mapDataRef->intersections->list.array[i];
-                int id = static_cast<int>(ig->id.id);
+                auto id = static_cast<int>(ig->id.id);
                 if (auto it = corrections.find(id); it != corrections.end())
                 {
                     ig->revision = it->second;

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -291,7 +291,7 @@ namespace IntersectionValidation
 
     void IntersectionValidationPlugin::broadcastValidated(routeable_message &msg)
     {
-        // set_flags AFTER any initialize() on the encoded message (verified ordering).
+        // set_flags on the encoded message
         msg.set_flags(IvpMsgFlags_Validated);
         PluginClient::BroadcastMessage(msg);
     }
@@ -300,14 +300,14 @@ namespace IntersectionValidation
                                                             const std::shared_ptr<SPAT> &spatDataRef,
                                                             const std::map<int, int> &corrections)
     {
-        // No corrections — original UPER bytes are still valid, just flag and forward.
+        // No corrections
         if (corrections.empty())
         {
             broadcastValidated(routeableMsg);
             return;
         }
 
-        // Apply each correction to the matching intersection in the ASN.1 frame.
+        // Apply each correction to the matching intersection in message
         for (int i = 0; i < spatDataRef->intersections.list.count; ++i)
         {
             int id = static_cast<int>(spatDataRef->intersections.list.array[i]->id.id);
@@ -319,7 +319,7 @@ namespace IntersectionValidation
             }
         }
 
-        // Re-encode from the mutated frame
+        // Re-encode
         SpatMessage corrected(spatDataRef);
         SpatEncodedMessage encodedMsg;
         encodedMsg.initialize(corrected);
@@ -335,21 +335,21 @@ namespace IntersectionValidation
                                                            const std::map<int, int> &corrections,
                                                            int msgRevisionCorrection)
     {
-        // No corrections of either kind — original UPER bytes are valid, just flag and forward.
+        // No corrections
         if (corrections.empty() && msgRevisionCorrection < 0)
         {
             broadcastValidated(routeableMsg);
             return;
         }
 
-        // Message-level correction. msgIssueRevision is a mandatory MsgCount field.
+        // Message-level correction
         if (msgRevisionCorrection >= 0)
         {
             mapDataRef->msgIssueRevision = msgRevisionCorrection;
             PLOG(logWARNING) << "Corrected MAP msgIssueRevision to " << msgRevisionCorrection;
         }
 
-        // Per-intersection corrections. MAP 'intersections' is an OPTIONAL pointer — null-check it.
+        // Per-intersection corrections
         if (!corrections.empty() && mapDataRef->intersections != nullptr)
         {
             for (int i = 0; i < mapDataRef->intersections->list.count; ++i)
@@ -365,13 +365,6 @@ namespace IntersectionValidation
             }
         }
 
-        // Re-encode from the mutated frame.
-        // *** VERIFY in your tree before relying on this: ***
-        //   1. MapDataMessage has a ctor taking std::shared_ptr<MapData>
-        //   2. the encoded type is MapDataEncodedMessage (TMX_J2735_DECLARE(MapData,...) naming),
-        //      NOT MapEncodedMessage — grep to confirm
-        //   3. MAP re-encode has thrown "Unable to stream JSON contents in memory" on large
-        //      payloads before — test with a MINIMAL real MAP first
         MapDataMessage corrected(mapDataRef);
         MapDataEncodedMessage encodedMsg;
         encodedMsg.initialize(corrected);
@@ -384,7 +377,7 @@ namespace IntersectionValidation
 
     void IntersectionValidationPlugin::HandleSpatMessage(SpatMessage &msg, routeable_message &routeableMsg)
     {
-        // Skip our own re-broadcasts
+        // Skip re-broadcasts
         if (routeableMsg.get_flags() & IvpMsgFlags_Validated)
             return;
 
@@ -432,7 +425,7 @@ namespace IntersectionValidation
 
     void IntersectionValidationPlugin::HandleMapDataMessage(MapDataMessage &msg, routeable_message &routeableMsg)
     {
-        // Skip our own re-broadcasts
+        // Skip re-broadcasts
         if (routeableMsg.get_flags() & IvpMsgFlags_Validated)
             return;
 
@@ -450,7 +443,7 @@ namespace IntersectionValidation
         try
         {
             auto mapData = msg.get_j2735_data();
-            auto mapDataRef = mapData; // keep alive past JSON conversion
+            auto mapDataRef = mapData;
 
             // Extract intersection ID before JSON conversion
             int intersectionId = -1;

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -296,93 +296,6 @@ namespace IntersectionValidation
         PluginClient::BroadcastMessage(msg);
     }
 
-    void IntersectionValidationPlugin::forwardValidatedSpat(SpatMessage &msg, routeable_message &routeableMsg,
-                                                            const std::shared_ptr<SPAT> &spatDataRef,
-                                                            const std::map<int, int> &corrections)
-    {
-        // No corrections
-        if (corrections.empty())
-        {
-            broadcastValidated(routeableMsg);
-            return;
-        }
-
-        uint &correctedCount = spatRevisionCorrectionsApplied;
-
-        // Apply each correction to the matching intersection in message
-        for (int i = 0; i < spatDataRef->intersections.list.count; ++i)
-        {
-            auto id = static_cast<int>(spatDataRef->intersections.list.array[i]->id.id);
-            if (auto it = corrections.find(id); it != corrections.end())
-            {
-                spatDataRef->intersections.list.array[i]->revision = it->second;
-                PLOG(logWARNING) << "Corrected SPaT revision for intersection " << id
-                                 << " to " << it->second;
-                correctedCount++;
-                PluginClient::SetStatus("SPaT Revision Corrections Applied", correctedCount);
-            }
-        }
-
-        // Re-encode
-        SpatMessage corrected(spatDataRef);
-        SpatEncodedMessage encodedMsg;
-        encodedMsg.initialize(corrected);
-
-        if (auto *rMsg = dynamic_cast<routeable_message *>(&encodedMsg))
-            broadcastValidated(*rMsg);
-        else
-            PLOG(logERROR) << "Failed to cast SpatEncodedMessage to routeable_message";
-    }
-
-    void IntersectionValidationPlugin::forwardValidatedMap(MapDataMessage &msg, routeable_message &routeableMsg,
-                                                           const std::shared_ptr<MapData> &mapDataRef,
-                                                           const std::map<int, int> &corrections,
-                                                           int msgRevisionCorrection)
-    {
-        // No corrections
-        if (corrections.empty() && msgRevisionCorrection < 0)
-        {
-            broadcastValidated(routeableMsg);
-            return;
-        }
-
-        uint &correctedCount = mapRevisionCorrectionsApplied;
-
-        // Message-level correction
-        if (msgRevisionCorrection >= 0)
-        {
-            mapDataRef->msgIssueRevision = msgRevisionCorrection;
-            PLOG(logWARNING) << "Corrected MAP msgIssueRevision to " << msgRevisionCorrection;
-        }
-
-        // Per-intersection corrections
-        if (!corrections.empty() && mapDataRef->intersections != nullptr)
-        {
-            for (int i = 0; i < mapDataRef->intersections->list.count; ++i)
-            {
-                auto *ig = mapDataRef->intersections->list.array[i];
-                auto id = static_cast<int>(ig->id.id);
-                if (auto it = corrections.find(id); it != corrections.end())
-                {
-                    ig->revision = it->second;
-                    PLOG(logWARNING) << "Corrected MAP revision for intersection " << id
-                                     << " to " << it->second;
-                    correctedCount++;
-                    PluginClient::SetStatus("MAP Revision Corrections Applied", correctedCount);
-                }
-            }
-        }
-
-        MapDataMessage corrected(mapDataRef);
-        MapDataEncodedMessage encodedMsg;
-        encodedMsg.initialize(corrected);
-
-        if (auto *rMsg = dynamic_cast<routeable_message *>(&encodedMsg))
-            broadcastValidated(*rMsg);
-        else
-            PLOG(logERROR) << "Failed to cast MapDataEncodedMessage to routeable_message";
-    }
-
     void IntersectionValidationPlugin::HandleSpatMessage(SpatMessage &msg, routeable_message &routeableMsg)
     {
         // Skip re-broadcasts
@@ -421,9 +334,8 @@ namespace IntersectionValidation
             RevisionCounterResult revResult = validateMessage(spatJsonStr, spatSchemaPath, "SpatMinimumData",
                                                               "SpatRevisionCounter", "SPaT", intersectionId, handlerBeginMs);
 
-            ODEForwarding plan = planForwarding(revResult);
-            if (plan.shouldForward)
-                forwardValidatedSpat(msg, routeableMsg, spatDataRef, plan.corrections);
+            if (planForwarding(revResult))
+                broadcastValidated(routeableMsg);
         }
         catch (const std::exception &e)
         {
@@ -469,9 +381,8 @@ namespace IntersectionValidation
             RevisionCounterResult revResult = validateMessage(mapJsonStr, mapSchemaPath, "MapMinimumData",
                                                               "MapRevisionCounter", "MAP", intersectionId, handlerBeginMs);
 
-            ODEForwarding plan = planForwarding(revResult);
-            if (plan.shouldForward)
-                forwardValidatedMap(msg, routeableMsg, mapDataRef, plan.corrections, plan.msgRevisionCorrection);
+            if (planForwarding(revResult))
+                broadcastValidated(routeableMsg);
         }
         catch (const std::exception &e)
         {

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -70,6 +70,9 @@ namespace IntersectionValidation
         uint spatRevisionFailed = 0;
         uint mapRevisionFailed = 0;
 
+        uint spatRevisionCorrectionsApplied = 0;
+        uint mapRevisionCorrectionsApplied = 0;
+
         /**
          * @brief Measure message interval and broadcast TmxEventLogMessage if threshold exceeded.
          * @param lastTimestampMs reference to stored timestamp for this message type (updated in place).

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <thread>
 #include <mutex>
+#include <map>
+#include <memory>
 #include <PluginClientClockAware.h>
 #include <jsoncpp/json/json.h>
 #include <CTI4501ValidationMessage.h>
@@ -88,8 +90,9 @@ namespace IntersectionValidation
          * @param messageType Display name ("SPaT" or "MAP").
          * @param intersectionId Intersection ID for event messages.
          * @param handlerBeginMs Timestamp when the handler started.
+         * @return Result from revision counter validation check (including intersection info for revision changes)
          */
-        void validateMessage(const std::string &jsonStr, const std::string &schemaPath,
+        RevisionCounterResult validateMessage(const std::string &jsonStr, const std::string &schemaPath,
                              const std::string &fieldEventType, const std::string &revisionEventType,
                              const std::string &messageType, int intersectionId,
                              uint64_t handlerBeginMs);
@@ -114,10 +117,35 @@ namespace IntersectionValidation
          * @param messageType The message type label for logging and status updates (e.g. "SPaT", "MAP").
          * @param intersectionId The intersection ID to include in the CTI4501ValidationMessage if validation fails.
          * @param handlerBeginMs Timestamp in milliseconds when message handling began
+         * @return Result from revision counter validation check
          */
-        void validateRevisionCounters(const rapidjson::Document &doc,
+        RevisionCounterResult validateRevisionCounters(const rapidjson::Document &doc,
                                        const std::string &eventType, const std::string &messageType,
                                        int intersectionId, uint64_t handlerBeginMs);
+
+        /**
+         * @brief Set IvpMsgFlags_Validated on a routeable message and broadcast it.
+         *        Single-sources the validated-flag spelling for both SPaT and MAP.
+         */
+        void broadcastValidated(tmx::routeable_message &msg);
+
+        /**
+         * @brief Apply per-intersection revision corrections to the SPaT message and
+         *        re-broadcast the validated SPaT with IvpMsgFlags_Validated set.
+         */
+        void forwardValidatedSpat(tmx::messages::SpatMessage &msg, tmx::routeable_message &routeableMsg,
+                                  const std::shared_ptr<SPAT> &spatDataRef,
+                                  const std::map<int, int> &corrections);
+
+        /**
+         * @brief Apply intersection and message revision corrections MAP ASN.1 message, then re-broadcast
+         *        the validated MAP with IvpMsgFlags_Validated set.
+         * @param msgRevisionCorrection corrected msgIssueRevision, or -1 for none.
+         */
+        void forwardValidatedMap(tmx::messages::MapDataMessage &msg, tmx::routeable_message &routeableMsg,
+                                 const std::shared_ptr<MapData> &mapDataRef,
+                                 const std::map<int, int> &corrections,
+                                 int msgRevisionCorrection);
 
         // Revision counter validator — stores previous message state and
         // compares against current to detect CTI 4501 revision violations

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -70,9 +70,6 @@ namespace IntersectionValidation
         uint spatRevisionFailed = 0;
         uint mapRevisionFailed = 0;
 
-        uint spatRevisionCorrectionsApplied = 0;
-        uint mapRevisionCorrectionsApplied = 0;
-
         /**
          * @brief Measure message interval and broadcast TmxEventLogMessage if threshold exceeded.
          * @param lastTimestampMs reference to stored timestamp for this message type (updated in place).
@@ -131,24 +128,6 @@ namespace IntersectionValidation
          *        Single-sources the validated-flag spelling for both SPaT and MAP.
          */
         void broadcastValidated(tmx::routeable_message &msg);
-
-        /**
-         * @brief Apply per-intersection revision corrections to the SPaT message and
-         *        re-broadcast the validated SPaT with IvpMsgFlags_Validated set.
-         */
-        void forwardValidatedSpat(tmx::messages::SpatMessage &msg, tmx::routeable_message &routeableMsg,
-                                  const std::shared_ptr<SPAT> &spatDataRef,
-                                  const std::map<int, int> &corrections);
-
-        /**
-         * @brief Apply intersection and message revision corrections MAP ASN.1 message, then re-broadcast
-         *        the validated MAP with IvpMsgFlags_Validated set.
-         * @param msgRevisionCorrection corrected msgIssueRevision, or -1 for none.
-         */
-        void forwardValidatedMap(tmx::messages::MapDataMessage &msg, tmx::routeable_message &routeableMsg,
-                                 const std::shared_ptr<MapData> &mapDataRef,
-                                 const std::map<int, int> &corrections,
-                                 int msgRevisionCorrection);
 
         // Revision counter validator — stores previous message state and
         // compares against current to detect CTI 4501 revision violations

--- a/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.cpp
@@ -18,56 +18,21 @@
 
 namespace IntersectionValidation
 {
-    ODEForwarding planForwarding(const RevisionCounterResult &result)
+    bool planForwarding(const RevisionCounterResult &result)
     {
-        ODEForwarding plan;
-
-        // First message
         if (!result.comparisonPerformed)
         {
-            plan.shouldForward = true;
-            return plan;
+            return true;
         }
 
-        bool anyContentChanged = false;
-
-        // Per-intersection revision
         for (const auto &change : result.intersectionChanges)
         {
-            if (change.contentChanged || change.revisionChanged)
-            {
-                plan.shouldForward = true;
-
-                // content changed but revision did not increment -> correct it
-                if (change.contentChanged && !change.revisionChanged)
-                {
-                    plan.corrections[change.id] = (change.currentRevision + 1) % 128;
-                }
-            }
             if (change.contentChanged)
             {
-                anyContentChanged = true;
+                return true;
             }
         }
-
-        // Message-level msgIssueRevision
-        if (result.hasMsgRevision)
-        {
-            if (anyContentChanged)
-            {
-                plan.shouldForward = true;
-                // msgIssueRevision must change if any fields change
-                if (!result.msgRevisionChanged)
-                {
-                    plan.msgRevisionCorrection = (result.currentMsgRevision + 1) % 128;
-                }
-            }
-            else if (result.msgRevisionChanged)
-            {
-                plan.shouldForward = true;
-            }
-        }
-
-        return plan;
+        
+        return false;
     }
 }

--- a/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "ODEForwarding.h"
+#include <algorithm>
 
 namespace IntersectionValidation
 {
@@ -25,14 +26,8 @@ namespace IntersectionValidation
             return true;
         }
 
-        for (const auto &change : result.intersectionChanges)
-        {
-            if (change.contentChanged)
-            {
-                return true;
-            }
-        }
-        
-        return false;
+        // Forward when any intersection's content changed.
+        return std::any_of(result.intersectionChanges.begin(), result.intersectionChanges.end(),
+                           [](const IntersectionChangeInfo &change) { return change.contentChanged; });
     }
 }

--- a/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "ODEForwarding.h"
+
+namespace IntersectionValidation
+{
+    ODEForwarding planForwarding(const RevisionCounterResult &result)
+    {
+        ODEForwarding plan;
+
+        // First message
+        if (!result.comparisonPerformed)
+        {
+            plan.shouldForward = true;
+            return plan;
+        }
+
+        bool anyContentChanged = false;
+
+        // Per-intersection revision
+        for (const auto &change : result.intersectionChanges)
+        {
+            if (change.contentChanged || change.revisionChanged)
+            {
+                plan.shouldForward = true;
+
+                // content changed but revision did not increment -> correct it
+                if (change.contentChanged && !change.revisionChanged)
+                {
+                    plan.corrections[change.id] = (change.currentRevision + 1) % 128;
+                }
+            }
+            if (change.contentChanged)
+            {
+                anyContentChanged = true;
+            }
+        }
+
+        // Message-level msgIssueRevision
+        if (result.hasMsgRevision)
+        {
+            if (anyContentChanged)
+            {
+                plan.shouldForward = true;
+                // msgIssueRevision must change if any fields change
+                if (!result.msgRevisionChanged)
+                {
+                    plan.msgRevisionCorrection = (result.currentMsgRevision + 1) % 128;
+                }
+            }
+            else if (result.msgRevisionChanged)
+            {
+                plan.shouldForward = true;
+            }
+        }
+
+        return plan;
+    }
+}

--- a/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.h
@@ -26,8 +26,8 @@ namespace IntersectionValidation
     struct ODEForwarding
     {
         bool shouldForward = false;
-        std::map<int, int> corrections; // intersectionId -> corrected per-intersection revision
-        int msgRevisionCorrection = -1;  // -1 = none; MAP msgIssueRevision corrected value (MAP only)
+        std::map<int, int> corrections; // Intersection level revision correction
+        int msgRevisionCorrection = -1;  // msgRevisionCount correction (MAP)
     };
 
     /**

--- a/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.h
@@ -20,21 +20,9 @@
 namespace IntersectionValidation
 {
     /**
-     * @brief What to do with a validated message: whether to re-broadcast it,
-     *        and any revision corrections to apply before doing so.
+     * @brief Decide whether a validated message should be forwarded.
+     * 
+     *    Forward any message that has its content changed
      */
-    struct ODEForwarding
-    {
-        bool shouldForward = false;
-        std::map<int, int> corrections; // Intersection level revision correction
-        int msgRevisionCorrection = -1;  // msgRevisionCount correction (MAP)
-    };
-
-    /**
-     * @brief Decide whether a validated message should be forwarded and what
-     *        revision corrections to apply. Used for BOTH SPaT and MAP:
-     *        the message-level (msgIssueRevision) branch only fires when
-     *        result.hasMsgRevision is true, which is MAP-only.
-     */
-    ODEForwarding planForwarding(const RevisionCounterResult &result);
+    bool planForwarding(const RevisionCounterResult &result);
 }

--- a/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/ODEForwarding.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#pragma once
+#include <map>
+#include "RevisionCounterValidator.h"
+
+namespace IntersectionValidation
+{
+    /**
+     * @brief What to do with a validated message: whether to re-broadcast it,
+     *        and any revision corrections to apply before doing so.
+     */
+    struct ODEForwarding
+    {
+        bool shouldForward = false;
+        std::map<int, int> corrections; // intersectionId -> corrected per-intersection revision
+        int msgRevisionCorrection = -1;  // -1 = none; MAP msgIssueRevision corrected value (MAP only)
+    };
+
+    /**
+     * @brief Decide whether a validated message should be forwarded and what
+     *        revision corrections to apply. Used for BOTH SPaT and MAP:
+     *        the message-level (msgIssueRevision) branch only fires when
+     *        result.hasMsgRevision is true, which is MAP-only.
+     */
+    ODEForwarding planForwarding(const RevisionCounterResult &result);
+}

--- a/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.cpp
@@ -120,6 +120,55 @@ namespace IntersectionValidation
         return buffer.GetString();
     }
 
+    void RevisionCounterValidator::processIntersectionArray(const rapidjson::Value &intersections,
+                                                            std::unordered_map<int, IntersectionState> &prevStates,
+                                                            const std::string &messageType,
+                                                            RevisionCounterResult &result,
+                                                            bool &anyChanged)
+    {
+        for (rapidjson::SizeType i = 0; i < intersections.Size(); ++i)
+        {
+            const auto &intersection = intersections[i];
+
+            if (!intersection.HasMember("id") || !intersection["id"].HasMember("id"))
+            {
+                continue;
+            }
+
+            // Values are already integers after convertNumericStrings
+            int intersectionId = intersection["id"]["id"].GetInt();
+            int currentRevision = intersection.HasMember("revision")
+                                      ? intersection["revision"].GetInt()
+                                      : -1;
+
+            std::string contentHash = createContentHash(intersection);
+
+            IntersectionChangeInfo change;
+            change.id = intersectionId;
+            change.currentRevision = currentRevision;
+
+            if (auto prevIt = prevStates.find(intersectionId); prevIt != prevStates.end())
+            {
+                change.contentChanged = checkRevisionViolation(intersectionId, currentRevision, contentHash,
+                                                               prevIt->second, messageType, result);
+                change.revisionChanged = (currentRevision != prevIt->second.revision);
+                if (change.contentChanged)
+                {
+                    anyChanged = true;
+                }
+            }
+            else
+            {
+                // First time we've seen this intersection
+                change.contentChanged = true;
+                anyChanged = true;
+            }
+
+            result.intersectionChanges.push_back(change);
+            prevStates[intersectionId] = {currentRevision, contentHash};
+        }
+    }
+
     RevisionCounterResult RevisionCounterValidator::validateSpatRevision(const rapidjson::Document &doc)
     {
         RevisionCounterResult result;
@@ -139,33 +188,9 @@ namespace IntersectionValidation
             return result;
         }
 
-        const auto &intersections = doc["value"]["SPAT"]["intersections"];
-
-        for (rapidjson::SizeType i = 0; i < intersections.Size(); ++i)
-        {
-            const auto &intersection = intersections[i];
-
-            if (!intersection.HasMember("id") || !intersection["id"].HasMember("id"))
-            {
-                continue;
-            }
-
-            // Values are already integers after convertNumericStrings
-            int intersectionId = intersection["id"]["id"].GetInt();
-            int currentRevision = intersection.HasMember("revision")
-                                      ? intersection["revision"].GetInt()
-                                      : -1;
-
-            std::string contentHash = createContentHash(intersection);
-
-            if (auto prevIt = _prevSpatIntersections.find(intersectionId); prevIt != _prevSpatIntersections.end())
-            {
-                checkRevisionViolation(intersectionId, currentRevision, contentHash,
-                                       prevIt->second, "SPaT", result);
-            }
-
-            _prevSpatIntersections[intersectionId] = {currentRevision, contentHash};
-        }
+        bool anyChanged = false; 
+        processIntersectionArray(doc["value"]["SPAT"]["intersections"], _prevSpatIntersections,
+                                 "SPaT", result, anyChanged);
 
         return result;
     }
@@ -203,6 +228,14 @@ namespace IntersectionValidation
 
         validateMsgIssueRevision(currentMsgRevision, anyIntersectionChanged, result);
 
+        // Capture message-level revision state
+        result.currentMsgRevision = currentMsgRevision;
+        if (_hasMapPrevious)
+        {
+            result.hasMsgRevision     = true;
+            result.msgRevisionChanged = (currentMsgRevision != _prevMapMessage.msgIssueRevision);
+        }
+
         _prevMapMessage.msgIssueRevision = currentMsgRevision;
         _hasMapPrevious = true;
 
@@ -213,40 +246,7 @@ namespace IntersectionValidation
                                                             RevisionCounterResult &result)
     {
         bool anyChanged = false;
-
-        for (rapidjson::SizeType i = 0; i < intersections.Size(); ++i)
-        {
-            const auto &intersection = intersections[i];
-
-            if (!intersection.HasMember("id") || !intersection["id"].HasMember("id"))
-            {
-                continue;
-            }
-
-            int intersectionId = intersection["id"]["id"].GetInt();
-            int currentRevision = intersection.HasMember("revision")
-                                      ? intersection["revision"].GetInt()
-                                      : -1;
-
-            std::string contentHash = createContentHash(intersection);
-
-            if (auto prevIt = _prevMapIntersections.find(intersectionId); prevIt != _prevMapIntersections.end())
-            {
-                bool changed = checkRevisionViolation(intersectionId, currentRevision,
-                                                      contentHash, prevIt->second, "MAP", result);
-                if (changed)
-                {
-                    anyChanged = true;
-                }
-            }
-            else
-            {
-                anyChanged = true;
-            }
-
-            _prevMapIntersections[intersectionId] = {currentRevision, contentHash};
-        }
-
+        processIntersectionArray(intersections, _prevMapIntersections, "MAP", result, anyChanged);
         return anyChanged;
     }
 

--- a/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.cpp
@@ -120,7 +120,7 @@ namespace IntersectionValidation
         return buffer.GetString();
     }
 
-    const void RevisionCounterValidator::processIntersectionArray(const rapidjson::Value &intersections,
+    void RevisionCounterValidator::processIntersectionArray(const rapidjson::Value &intersections,
                                                             std::unordered_map<int, IntersectionState> &prevStates,
                                                             const std::string &messageType,
                                                             RevisionCounterResult &result,

--- a/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.cpp
@@ -120,7 +120,7 @@ namespace IntersectionValidation
         return buffer.GetString();
     }
 
-    void RevisionCounterValidator::processIntersectionArray(const rapidjson::Value &intersections,
+    const void RevisionCounterValidator::processIntersectionArray(const rapidjson::Value &intersections,
                                                             std::unordered_map<int, IntersectionState> &prevStates,
                                                             const std::string &messageType,
                                                             RevisionCounterResult &result,

--- a/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.h
@@ -174,7 +174,7 @@ namespace IntersectionValidation
          * @param result The result to populate (intersectionChanges + violations).
          * @param anyChanged Set true if any intersection's content changed.
          */
-        const void processIntersectionArray(const rapidjson::Value &intersections,
+        void processIntersectionArray(const rapidjson::Value &intersections,
                                       std::unordered_map<int, IntersectionState> &prevStates,
                                       const std::string &messageType,
                                       RevisionCounterResult &result,

--- a/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.h
@@ -23,6 +23,17 @@ namespace IntersectionValidation
 {
 
     /**
+     * @brief Info for changing revision count
+     */
+    struct IntersectionChangeInfo
+    {
+        int id = -1;
+        bool contentChanged = false;
+        bool revisionChanged = false;
+        int currentRevision = -1;
+    };
+
+    /**
      * @brief Result of a revision counter validation check.
      */
     struct RevisionCounterResult
@@ -30,6 +41,13 @@ namespace IntersectionValidation
         bool valid = true;
         bool comparisonPerformed = false;
         std::vector<std::string> violations;
+        std::vector<IntersectionChangeInfo> intersectionChanges;
+
+        // Message-level revision state. Populated for MAP only; for SPaT
+        // hasMsgRevision stays false and the planner ignores these fields.
+        int  currentMsgRevision = -1;
+        bool msgRevisionChanged = false;
+        bool hasMsgRevision     = false; // true once a previous MAP message exists to compare against
     };
 
     /**
@@ -49,7 +67,7 @@ namespace IntersectionValidation
 
         /**
          * @brief Validate SPaT intersection revision counters. For each intersection in SPaT message,
-         * 
+         *
          * - Strip timestamp field for the comparison
          * - If content is changed, check if revision was increased
          * - If content is not changed, check if revision stayed the same
@@ -143,6 +161,24 @@ namespace IntersectionValidation
                                                           const IntersectionState &prevState,
                                                           const std::string &messageType,
                                                           RevisionCounterResult &result);
+
+        /**
+         * @brief Walk an intersections JSON array, build per-intersection IntersectionChangeInfo,
+         *        report CTI 4501 violations, and update the supplied previous-state map.
+         *
+         *        Shared by SPaT and MAP so the per-intersection rule lives in one place.
+         *
+         * @param intersections The intersections JSON array.
+         * @param prevStates Previous-state map for this message type (SPaT or MAP).
+         * @param messageType "SPaT" or "MAP" for violation messages.
+         * @param result The result to populate (intersectionChanges + violations).
+         * @param anyChanged Set true if any intersection's content changed.
+         */
+        void processIntersectionArray(const rapidjson::Value &intersections,
+                                      std::unordered_map<int, IntersectionState> &prevStates,
+                                      const std::string &messageType,
+                                      RevisionCounterResult &result,
+                                      bool &anyChanged);
 
         /**
          * @brief Validate revision counters for each intersection in a MAP message.

--- a/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.h
@@ -174,7 +174,7 @@ namespace IntersectionValidation
          * @param result The result to populate (intersectionChanges + violations).
          * @param anyChanged Set true if any intersection's content changed.
          */
-        void processIntersectionArray(const rapidjson::Value &intersections,
+        const void processIntersectionArray(const rapidjson::Value &intersections,
                                       std::unordered_map<int, IntersectionState> &prevStates,
                                       const std::string &messageType,
                                       RevisionCounterResult &result,

--- a/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/RevisionCounterValidator.h
@@ -23,7 +23,7 @@ namespace IntersectionValidation
 {
 
     /**
-     * @brief Info for changing revision count
+     * @brief Change information for a single intersection, 
      */
     struct IntersectionChangeInfo
     {
@@ -41,7 +41,7 @@ namespace IntersectionValidation
         bool valid = true;
         bool comparisonPerformed = false;
         std::vector<std::string> violations;
-        std::vector<IntersectionChangeInfo> intersectionChanges;
+        std::vector<IntersectionChangeInfo> intersectionChanges; // Vector to represent all intersection changes in a MAP/SPaT message
 
         // Message-level revision state. Populated for MAP only; for SPaT
         // hasMsgRevision stays false and the planner ignores these fields.

--- a/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
@@ -23,6 +23,7 @@
 #include "MessageIntervalValidator.h"
 #include "FieldValidation.h"
 #include "RevisionCounterValidator.h"
+#include "ODEForwarding.h"
 
 using namespace tmx::messages;
 using namespace IntersectionValidation;
@@ -5273,6 +5274,226 @@ namespace
     EXPECT_FALSE(result.valid);
     EXPECT_TRUE(result.violations.size() >= 1);
     EXPECT_NE(std::string::npos, result.violations[0].find("Failed to parse MAP JSON"));
+  }
+
+  // Frequency Throttling Test
+  
+  IntersectionChangeInfo makeChange(int id, bool content, bool rev, int curRev)
+  {
+    IntersectionChangeInfo c;
+    c.id = id;
+    c.contentChanged = content;
+    c.revisionChanged = rev;
+    c.currentRevision = curRev;
+    return c;
+  }
+
+  rapidjson::Document parseDoc(const std::string &json)
+  {
+    rapidjson::Document d;
+    d.Parse(json.c_str());
+    return d;
+  }
+
+  TEST(PlanForwardingTest, FirstMessageForwardsNoCorrections)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = false;
+    auto plan = planForwarding(r);
+
+    EXPECT_TRUE(plan.shouldForward);
+    EXPECT_TRUE(plan.corrections.empty());
+    EXPECT_EQ(plan.msgRevisionCorrection, -1);
+  }
+
+  TEST(PlanForwardingTest, NoChangesDoesNotForward)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.intersectionChanges.push_back(makeChange(1, false, false, 5));
+    auto plan = planForwarding(r);
+
+    EXPECT_FALSE(plan.shouldForward);
+    EXPECT_TRUE(plan.corrections.empty());
+  }
+
+  TEST(PlanForwardingTest, ContentAndRevisionChangedForwardsNoCorrection)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.intersectionChanges.push_back(makeChange(1, true, true, 5));
+    auto plan = planForwarding(r);
+
+    EXPECT_TRUE(plan.shouldForward);
+    EXPECT_TRUE(plan.corrections.empty()); // revision increased correctly, nothing to fix
+  }
+
+  TEST(PlanForwardingTest, ContentChangedRevisionStuckProducesCorrection)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.intersectionChanges.push_back(makeChange(42, true, false, 34));
+    auto plan = planForwarding(r);
+
+    EXPECT_TRUE(plan.shouldForward);
+    ASSERT_EQ(plan.corrections.count(42), 1u);
+    EXPECT_EQ(plan.corrections.at(42), 35);
+  }
+
+  TEST(PlanForwardingTest, RevisionCorrectionWrapsAt128)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.intersectionChanges.push_back(makeChange(42, true, false, 127));
+    auto plan = planForwarding(r);
+
+    ASSERT_EQ(plan.corrections.count(42), 1u);
+    EXPECT_EQ(plan.corrections.at(42), 0);
+  }
+
+  TEST(PlanForwardingTest, SpatIgnoresMessageLevelFields)
+  {
+    // hasMsgRevision == false (SPaT)
+    // msgRevisionChanged set but SPaT doesn't have it so no forward
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.hasMsgRevision = false;
+    r.msgRevisionChanged = true;
+    r.currentMsgRevision = 5;
+    r.intersectionChanges.push_back(makeChange(1, false, false, 5));
+    auto plan = planForwarding(r);
+
+    EXPECT_FALSE(plan.shouldForward);
+    EXPECT_EQ(plan.msgRevisionCorrection, -1);
+  }
+
+  TEST(PlanForwardingTest, MapContentChangedMsgRevisionStuckCorrectsMsgRevision)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.hasMsgRevision = true;
+    r.msgRevisionChanged = false;
+    r.currentMsgRevision = 10;
+    r.intersectionChanges.push_back(makeChange(1, true, true, 3));
+    auto plan = planForwarding(r);
+
+    EXPECT_TRUE(plan.shouldForward);
+    EXPECT_TRUE(plan.corrections.empty());
+    EXPECT_EQ(plan.msgRevisionCorrection, 11);
+  }
+
+  TEST(PlanForwardingTest, MapBothCountersStuckCorrectsBoth)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.hasMsgRevision = true;
+    r.msgRevisionChanged = false;
+    r.currentMsgRevision = 10;
+    r.intersectionChanges.push_back(makeChange(7, true, false, 20));
+    auto plan = planForwarding(r);
+
+    EXPECT_TRUE(plan.shouldForward);
+    ASSERT_EQ(plan.corrections.count(7), 1u);
+    EXPECT_EQ(plan.corrections.at(7), 21);
+    EXPECT_EQ(plan.msgRevisionCorrection, 11);
+  }
+
+  TEST(PlanForwardingTest, MapContentChangedMsgRevisionMovedNoMsgCorrection)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.hasMsgRevision = true;
+    r.msgRevisionChanged = true; // sender increased msgIssueRevision correctly
+    r.currentMsgRevision = 11;
+    r.intersectionChanges.push_back(makeChange(1, true, true, 3));
+    auto plan = planForwarding(r);
+
+    EXPECT_TRUE(plan.shouldForward);
+    EXPECT_EQ(plan.msgRevisionCorrection, -1); // nothing to correct
+  }
+
+  TEST(PlanForwardingTest, MapMsgRevisionCorrectionWrapsAt128)
+  {
+    RevisionCounterResult r;
+    r.comparisonPerformed = true;
+    r.hasMsgRevision = true;
+    r.msgRevisionChanged = false;
+    r.currentMsgRevision = 127;
+    r.intersectionChanges.push_back(makeChange(1, true, true, 3));
+    auto plan = planForwarding(r);
+
+    EXPECT_EQ(plan.msgRevisionCorrection, 0); // should go back to 0
+  }
+
+  TEST(RevisionResultTest, SpatPopulatesIntersectionChanges)
+  {
+    RevisionCounterValidator v;
+    auto d1 = parseDoc(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":34,"status":"0000"}]}}})");
+    v.validateSpatRevision(d1);
+
+    auto d2 = parseDoc(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":35,"status":"0040"}]}}})");
+    auto r = v.validateSpatRevision(d2);
+
+    ASSERT_EQ(r.intersectionChanges.size(), 1u);
+    EXPECT_EQ(r.intersectionChanges[0].id, 59963);
+    EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
+    EXPECT_TRUE(r.intersectionChanges[0].revisionChanged);
+    EXPECT_EQ(r.intersectionChanges[0].currentRevision, 35);
+  }
+
+  TEST(RevisionResultTest, SpatIntersectionChangesFlagsStuckRevision)
+  {
+    RevisionCounterValidator v;
+    auto d1 = parseDoc(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":1},"revision":34,"status":"0000"}]}}})");
+    v.validateSpatRevision(d1);
+
+    auto d2 = parseDoc(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":1},"revision":34,"status":"0040"}]}}})");
+    auto r = v.validateSpatRevision(d2);
+
+    ASSERT_EQ(r.intersectionChanges.size(), 1u);
+    EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
+    EXPECT_FALSE(r.intersectionChanges[0].revisionChanged);
+    EXPECT_EQ(r.intersectionChanges[0].currentRevision, 34);
+  }
+
+  TEST(RevisionResultTest, MapSetsMessageLevelFields)
+  {
+    RevisionCounterValidator v;
+    auto d1 = parseDoc(R"({"value":{"MapData":{"msgIssueRevision":7,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":360}]}}})");
+    auto r1 = v.validateMapRevision(d1);
+    EXPECT_FALSE(r1.hasMsgRevision); // first MAP, nothing to compare
+    EXPECT_EQ(r1.currentMsgRevision, 7);
+
+    auto d2 = parseDoc(R"({"value":{"MapData":{"msgIssueRevision":8,"intersections":[
+        {"id":{"id":1},"revision":1,"laneWidth":370}]}}})");
+    auto r2 = v.validateMapRevision(d2);
+    EXPECT_TRUE(r2.hasMsgRevision);
+    EXPECT_TRUE(r2.msgRevisionChanged);
+    EXPECT_EQ(r2.currentMsgRevision, 8);
+  }
+
+  TEST(RevisionResultTest, MapMsgRevisionUnchangedReportedToPlanner)
+  {
+    RevisionCounterValidator v;
+    auto d1 = parseDoc(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":360}]}}})");
+    v.validateMapRevision(d1);
+
+    // content changes but msgIssueRevision stays 5
+    auto d2 = parseDoc(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":999}]}}})");
+    auto r = v.validateMapRevision(d2);
+
+    EXPECT_TRUE(r.hasMsgRevision);
+    EXPECT_FALSE(r.msgRevisionChanged);
+    EXPECT_EQ(r.currentMsgRevision, 5);
+    ASSERT_EQ(r.intersectionChanges.size(), 1u);
+    EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
   }
 
 } // namespace

--- a/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
@@ -19,11 +19,11 @@
 #include <tmx/j2735_messages/SpatMessage.hpp>
 #include <tmx/j2735_messages/MapDataMessage.hpp>
 
-#include "IntersectionValidationPlugin.h"
-#include "MessageIntervalValidator.h"
-#include "FieldValidation.h"
-#include "RevisionCounterValidator.h"
-#include "ODEForwarding.h"
+#include <IntersectionValidationPlugin.h>
+#include <MessageIntervalValidator.h>
+#include <FieldValidation.h>
+#include <RevisionCounterValidator.h>
+#include <ODEForwarding.h>
 
 using namespace tmx::messages;
 using namespace IntersectionValidation;
@@ -5336,7 +5336,7 @@ namespace
     auto plan = planForwarding(r);
 
     EXPECT_TRUE(plan.shouldForward);
-    ASSERT_EQ(plan.corrections.count(42), 1u);
+    EXPECT_EQ(plan.corrections.count(42), 1u);
     EXPECT_EQ(plan.corrections.at(42), 35);
   }
 
@@ -5347,7 +5347,7 @@ namespace
     r.intersectionChanges.push_back(makeChange(42, true, false, 127));
     auto plan = planForwarding(r);
 
-    ASSERT_EQ(plan.corrections.count(42), 1u);
+    EXPECT_EQ(plan.corrections.count(42), 1u);
     EXPECT_EQ(plan.corrections.at(42), 0);
   }
 
@@ -5393,7 +5393,7 @@ namespace
     auto plan = planForwarding(r);
 
     EXPECT_TRUE(plan.shouldForward);
-    ASSERT_EQ(plan.corrections.count(7), 1u);
+    EXPECT_EQ(plan.corrections.count(7), 1u);
     EXPECT_EQ(plan.corrections.at(7), 21);
     EXPECT_EQ(plan.msgRevisionCorrection, 11);
   }
@@ -5436,7 +5436,7 @@ namespace
         {"id":{"id":59963},"revision":35,"status":"0040"}]}}})");
     auto r = v.validateSpatRevision(d2);
 
-    ASSERT_EQ(r.intersectionChanges.size(), 1u);
+    EXPECT_EQ(r.intersectionChanges.size(), 1u);
     EXPECT_EQ(r.intersectionChanges[0].id, 59963);
     EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
     EXPECT_TRUE(r.intersectionChanges[0].revisionChanged);
@@ -5454,7 +5454,7 @@ namespace
         {"id":{"id":1},"revision":34,"status":"0040"}]}}})");
     auto r = v.validateSpatRevision(d2);
 
-    ASSERT_EQ(r.intersectionChanges.size(), 1u);
+    EXPECT_EQ(r.intersectionChanges.size(), 1u);
     EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
     EXPECT_FALSE(r.intersectionChanges[0].revisionChanged);
     EXPECT_EQ(r.intersectionChanges[0].currentRevision, 34);
@@ -5492,7 +5492,7 @@ namespace
     EXPECT_TRUE(r.hasMsgRevision);
     EXPECT_FALSE(r.msgRevisionChanged);
     EXPECT_EQ(r.currentMsgRevision, 5);
-    ASSERT_EQ(r.intersectionChanges.size(), 1u);
+    EXPECT_EQ(r.intersectionChanges.size(), 1u);
     EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
   }
 

--- a/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
@@ -5277,223 +5277,101 @@ namespace
   }
 
   // Frequency Throttling Test
-  
-  IntersectionChangeInfo makeChange(int id, bool content, bool rev, int curRev)
+
+    IntersectionChangeInfo makeChange(int id, bool contentChanged)
   {
     IntersectionChangeInfo c;
     c.id = id;
-    c.contentChanged = content;
-    c.revisionChanged = rev;
-    c.currentRevision = curRev;
+    c.contentChanged = contentChanged;
     return c;
   }
-
-  rapidjson::Document parseDoc(const std::string &json)
-  {
-    rapidjson::Document d;
-    d.Parse(json.c_str());
-    return d;
-  }
-
-  TEST(PlanForwardingTest, FirstMessageForwardsNoCorrections)
+ 
+  TEST(ShouldForwardTest, FirstMessageForwards)
   {
     RevisionCounterResult r;
     r.comparisonPerformed = false;
-    auto plan = planForwarding(r);
-
-    EXPECT_TRUE(plan.shouldForward);
-    EXPECT_TRUE(plan.corrections.empty());
-    EXPECT_EQ(plan.msgRevisionCorrection, -1);
+    EXPECT_TRUE(planForwarding(r));
   }
-
-  TEST(PlanForwardingTest, NoChangesDoesNotForward)
+ 
+  TEST(ShouldForwardTest, NoContentChangeDoesNotForward)
   {
     RevisionCounterResult r;
     r.comparisonPerformed = true;
-    r.intersectionChanges.push_back(makeChange(1, false, false, 5));
-    auto plan = planForwarding(r);
-
-    EXPECT_FALSE(plan.shouldForward);
-    EXPECT_TRUE(plan.corrections.empty());
+    r.intersectionChanges.push_back(makeChange(1, false));
+    EXPECT_FALSE(planForwarding(r));
   }
-
-  TEST(PlanForwardingTest, ContentAndRevisionChangedForwardsNoCorrection)
+ 
+  TEST(ShouldForwardTest, ContentChangedForwards)
   {
     RevisionCounterResult r;
     r.comparisonPerformed = true;
-    r.intersectionChanges.push_back(makeChange(1, true, true, 5));
-    auto plan = planForwarding(r);
-
-    EXPECT_TRUE(plan.shouldForward);
-    EXPECT_TRUE(plan.corrections.empty()); // revision increased correctly, nothing to fix
+    r.intersectionChanges.push_back(makeChange(1, true));
+    EXPECT_TRUE(planForwarding(r));
   }
-
-  TEST(PlanForwardingTest, ContentChangedRevisionStuckProducesCorrection)
+ 
+  TEST(ShouldForwardTest, AnyIntersectionChangedForwards)
   {
     RevisionCounterResult r;
     r.comparisonPerformed = true;
-    r.intersectionChanges.push_back(makeChange(42, true, false, 34));
-    auto plan = planForwarding(r);
-
-    EXPECT_TRUE(plan.shouldForward);
-    EXPECT_EQ(plan.corrections.count(42), 1u);
-    EXPECT_EQ(plan.corrections.at(42), 35);
+    r.intersectionChanges.push_back(makeChange(59963, false));
+    r.intersectionChanges.push_back(makeChange(18364, true));
+    EXPECT_TRUE(planForwarding(r));
   }
-
-  TEST(PlanForwardingTest, RevisionCorrectionWrapsAt128)
+ 
+  TEST(ShouldForwardTest, AllIntersectionsUnchangedDoesNotForward)
   {
     RevisionCounterResult r;
     r.comparisonPerformed = true;
-    r.intersectionChanges.push_back(makeChange(42, true, false, 127));
-    auto plan = planForwarding(r);
-
-    EXPECT_EQ(plan.corrections.count(42), 1u);
-    EXPECT_EQ(plan.corrections.at(42), 0);
+    r.intersectionChanges.push_back(makeChange(59963, false));
+    r.intersectionChanges.push_back(makeChange(18364, false));
+    EXPECT_FALSE(planForwarding(r));
   }
-
-  TEST(PlanForwardingTest, SpatIgnoresMessageLevelFields)
+ 
+  TEST(RevisionResultTest, SpatContentChangeFlaggedInIntersectionChanges)
   {
-    // hasMsgRevision == false (SPaT)
-    // msgRevisionChanged set but SPaT doesn't have it so no forward
-    RevisionCounterResult r;
-    r.comparisonPerformed = true;
-    r.hasMsgRevision = false;
-    r.msgRevisionChanged = true;
-    r.currentMsgRevision = 5;
-    r.intersectionChanges.push_back(makeChange(1, false, false, 5));
-    auto plan = planForwarding(r);
-
-    EXPECT_FALSE(plan.shouldForward);
-    EXPECT_EQ(plan.msgRevisionCorrection, -1);
-  }
-
-  TEST(PlanForwardingTest, MapContentChangedMsgRevisionStuckCorrectsMsgRevision)
-  {
-    RevisionCounterResult r;
-    r.comparisonPerformed = true;
-    r.hasMsgRevision = true;
-    r.msgRevisionChanged = false;
-    r.currentMsgRevision = 10;
-    r.intersectionChanges.push_back(makeChange(1, true, true, 3));
-    auto plan = planForwarding(r);
-
-    EXPECT_TRUE(plan.shouldForward);
-    EXPECT_TRUE(plan.corrections.empty());
-    EXPECT_EQ(plan.msgRevisionCorrection, 11);
-  }
-
-  TEST(PlanForwardingTest, MapBothCountersStuckCorrectsBoth)
-  {
-    RevisionCounterResult r;
-    r.comparisonPerformed = true;
-    r.hasMsgRevision = true;
-    r.msgRevisionChanged = false;
-    r.currentMsgRevision = 10;
-    r.intersectionChanges.push_back(makeChange(7, true, false, 20));
-    auto plan = planForwarding(r);
-
-    EXPECT_TRUE(plan.shouldForward);
-    EXPECT_EQ(plan.corrections.count(7), 1u);
-    EXPECT_EQ(plan.corrections.at(7), 21);
-    EXPECT_EQ(plan.msgRevisionCorrection, 11);
-  }
-
-  TEST(PlanForwardingTest, MapContentChangedMsgRevisionMovedNoMsgCorrection)
-  {
-    RevisionCounterResult r;
-    r.comparisonPerformed = true;
-    r.hasMsgRevision = true;
-    r.msgRevisionChanged = true; // sender increased msgIssueRevision correctly
-    r.currentMsgRevision = 11;
-    r.intersectionChanges.push_back(makeChange(1, true, true, 3));
-    auto plan = planForwarding(r);
-
-    EXPECT_TRUE(plan.shouldForward);
-    EXPECT_EQ(plan.msgRevisionCorrection, -1); // nothing to correct
-  }
-
-  TEST(PlanForwardingTest, MapMsgRevisionCorrectionWrapsAt128)
-  {
-    RevisionCounterResult r;
-    r.comparisonPerformed = true;
-    r.hasMsgRevision = true;
-    r.msgRevisionChanged = false;
-    r.currentMsgRevision = 127;
-    r.intersectionChanges.push_back(makeChange(1, true, true, 3));
-    auto plan = planForwarding(r);
-
-    EXPECT_EQ(plan.msgRevisionCorrection, 0); // should go back to 0
-  }
-
-  TEST(RevisionResultTest, SpatPopulatesIntersectionChanges)
-  {
-    RevisionCounterValidator v;
-    auto d1 = parseDoc(R"({"value":{"SPAT":{"intersections":[
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"SPAT":{"intersections":[
         {"id":{"id":59963},"revision":34,"status":"0000"}]}}})");
-    v.validateSpatRevision(d1);
-
-    auto d2 = parseDoc(R"({"value":{"SPAT":{"intersections":[
-        {"id":{"id":59963},"revision":35,"status":"0040"}]}}})");
-    auto r = v.validateSpatRevision(d2);
-
+    validator.validateSpatRevision(d1);
+ 
+    auto d2 = parseJson(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":34,"status":"0040"}]}}})");
+    auto r = validator.validateSpatRevision(d2);
+ 
     EXPECT_EQ(r.intersectionChanges.size(), 1u);
     EXPECT_EQ(r.intersectionChanges[0].id, 59963);
     EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
-    EXPECT_TRUE(r.intersectionChanges[0].revisionChanged);
-    EXPECT_EQ(r.intersectionChanges[0].currentRevision, 35);
   }
-
-  TEST(RevisionResultTest, SpatIntersectionChangesFlagsStuckRevision)
+ 
+  TEST(RevisionResultTest, SpatNoContentChangeFlaggedFalse)
   {
-    RevisionCounterValidator v;
-    auto d1 = parseDoc(R"({"value":{"SPAT":{"intersections":[
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"SPAT":{"intersections":[
         {"id":{"id":1},"revision":34,"status":"0000"}]}}})");
-    v.validateSpatRevision(d1);
-
-    auto d2 = parseDoc(R"({"value":{"SPAT":{"intersections":[
-        {"id":{"id":1},"revision":34,"status":"0040"}]}}})");
-    auto r = v.validateSpatRevision(d2);
-
+    validator.validateSpatRevision(d1);
+ 
+    auto d2 = parseJson(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":1},"revision":34,"status":"0000"}]}}})"); // identical
+    auto r = validator.validateSpatRevision(d2);
+ 
     EXPECT_EQ(r.intersectionChanges.size(), 1u);
-    EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
-    EXPECT_FALSE(r.intersectionChanges[0].revisionChanged);
-    EXPECT_EQ(r.intersectionChanges[0].currentRevision, 34);
+    EXPECT_FALSE(r.intersectionChanges[0].contentChanged);
   }
-
-  TEST(RevisionResultTest, MapSetsMessageLevelFields)
+ 
+  TEST(RevisionResultTest, MapContentChangeFlaggedInIntersectionChanges)
   {
-    RevisionCounterValidator v;
-    auto d1 = parseDoc(R"({"value":{"MapData":{"msgIssueRevision":7,"intersections":[
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
         {"id":{"id":1},"revision":0,"laneWidth":360}]}}})");
-    auto r1 = v.validateMapRevision(d1);
-    EXPECT_FALSE(r1.hasMsgRevision); // first MAP, nothing to compare
-    EXPECT_EQ(r1.currentMsgRevision, 7);
-
-    auto d2 = parseDoc(R"({"value":{"MapData":{"msgIssueRevision":8,"intersections":[
-        {"id":{"id":1},"revision":1,"laneWidth":370}]}}})");
-    auto r2 = v.validateMapRevision(d2);
-    EXPECT_TRUE(r2.hasMsgRevision);
-    EXPECT_TRUE(r2.msgRevisionChanged);
-    EXPECT_EQ(r2.currentMsgRevision, 8);
-  }
-
-  TEST(RevisionResultTest, MapMsgRevisionUnchangedReportedToPlanner)
-  {
-    RevisionCounterValidator v;
-    auto d1 = parseDoc(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
-        {"id":{"id":1},"revision":0,"laneWidth":360}]}}})");
-    v.validateMapRevision(d1);
-
-    // content changes but msgIssueRevision stays 5
-    auto d2 = parseDoc(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
-        {"id":{"id":1},"revision":0,"laneWidth":999}]}}})");
-    auto r = v.validateMapRevision(d2);
-
-    EXPECT_TRUE(r.hasMsgRevision);
-    EXPECT_FALSE(r.msgRevisionChanged);
-    EXPECT_EQ(r.currentMsgRevision, 5);
+    validator.validateMapRevision(d1);
+ 
+    auto d2 = parseJson(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":999}]}}})"); // content moved
+    auto r = validator.validateMapRevision(d2);
+ 
     EXPECT_EQ(r.intersectionChanges.size(), 1u);
     EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
   }
+
 
 } // namespace

--- a/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
@@ -5372,6 +5372,117 @@ namespace
     EXPECT_EQ(r.intersectionChanges.size(), 1u);
     EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
   }
+  
+  TEST(RevisionResultTest, SpatMultiIntersectionOnlyFirstChanged)
+  {
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":0,"status":"0000"},
+        {"id":{"id":18364},"revision":0,"status":"0000"}]}}})");
+    validator.validateSpatRevision(d1);
 
+    auto d2 = parseJson(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":0,"status":"0040"},
+        {"id":{"id":18364},"revision":0,"status":"0000"}]}}})"); // only #1 moved
+    auto r = validator.validateSpatRevision(d2);
+
+    ASSERT_EQ(r.intersectionChanges.size(), 2u);
+    EXPECT_EQ(r.intersectionChanges[0].id, 59963);
+    EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
+    EXPECT_EQ(r.intersectionChanges[1].id, 18364);
+    EXPECT_FALSE(r.intersectionChanges[1].contentChanged);
+  }
+
+  TEST(RevisionResultTest, SpatMultiIntersectionBothChanged)
+  {
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":0,"status":"0000"},
+        {"id":{"id":18364},"revision":0,"status":"0000"}]}}})");
+    validator.validateSpatRevision(d1);
+
+    auto d2 = parseJson(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":0,"status":"0040"},
+        {"id":{"id":18364},"revision":0,"status":"0080"}]}}})"); // both moved
+    auto r = validator.validateSpatRevision(d2);
+
+    ASSERT_EQ(r.intersectionChanges.size(), 2u);
+    EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
+    EXPECT_TRUE(r.intersectionChanges[1].contentChanged);
+  }
+
+  TEST(RevisionResultTest, SpatMultiIntersectionNoneChanged)
+  {
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":0,"status":"0000"},
+        {"id":{"id":18364},"revision":0,"status":"0000"}]}}})");
+    validator.validateSpatRevision(d1);
+
+    auto d2 = parseJson(R"({"value":{"SPAT":{"intersections":[
+        {"id":{"id":59963},"revision":0,"status":"0000"},
+        {"id":{"id":18364},"revision":0,"status":"0000"}]}}})"); // identical
+    auto r = validator.validateSpatRevision(d2);
+
+    ASSERT_EQ(r.intersectionChanges.size(), 2u);
+    EXPECT_FALSE(r.intersectionChanges[0].contentChanged);
+    EXPECT_FALSE(r.intersectionChanges[1].contentChanged);
+  }
+
+  TEST(RevisionResultTest, MapMultiIntersectionOnlyFirstChanged)
+  {
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":360},
+        {"id":{"id":2},"revision":0,"laneWidth":720}]}}})");
+    validator.validateMapRevision(d1);
+
+    auto d2 = parseJson(R"({"value":{"MapData":{"msgIssueRevision":6,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":999},
+        {"id":{"id":2},"revision":0,"laneWidth":720}]}}})"); // only #1 moved
+    auto r = validator.validateMapRevision(d2);
+
+    ASSERT_EQ(r.intersectionChanges.size(), 2u);
+    EXPECT_EQ(r.intersectionChanges[0].id, 1);
+    EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
+    EXPECT_EQ(r.intersectionChanges[1].id, 2);
+    EXPECT_FALSE(r.intersectionChanges[1].contentChanged);
+  }
+
+  TEST(RevisionResultTest, MapMultiIntersectionBothChanged)
+  {
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":360},
+        {"id":{"id":2},"revision":0,"laneWidth":720}]}}})");
+    validator.validateMapRevision(d1);
+
+    auto d2 = parseJson(R"({"value":{"MapData":{"msgIssueRevision":6,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":999},
+        {"id":{"id":2},"revision":0,"laneWidth":888}]}}})"); // both moved
+    auto r = validator.validateMapRevision(d2);
+
+    ASSERT_EQ(r.intersectionChanges.size(), 2u);
+    EXPECT_TRUE(r.intersectionChanges[0].contentChanged);
+    EXPECT_TRUE(r.intersectionChanges[1].contentChanged);
+  }
+
+  TEST(RevisionResultTest, MapMultiIntersectionNoneChanged)
+  {
+    RevisionCounterValidator validator;
+    auto d1 = parseJson(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":360},
+        {"id":{"id":2},"revision":0,"laneWidth":720}]}}})");
+    validator.validateMapRevision(d1);
+
+    auto d2 = parseJson(R"({"value":{"MapData":{"msgIssueRevision":5,"intersections":[
+        {"id":{"id":1},"revision":0,"laneWidth":360},
+        {"id":{"id":2},"revision":0,"laneWidth":720}]}}})"); // identical
+    auto r = validator.validateMapRevision(d2);
+
+    ASSERT_EQ(r.intersectionChanges.size(), 2u);
+    EXPECT_FALSE(r.intersectionChanges[0].contentChanged);
+    EXPECT_FALSE(r.intersectionChanges[1].contentChanged);
+  }
 
 } // namespace

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
@@ -121,6 +121,12 @@ namespace ODEForwardPlugin
 	}
 
 	void ODEForwardPlugin::HandleSPaTPublish([[maybe_unused]] SpatMessage &msg, routeable_message &routeableMsg) {
+		PLOG(logDEBUG) << "ODE HandleSPaT flags=" << routeableMsg.get_flags();
+		if (!(routeableMsg.get_flags() & IvpMsgFlags_Validated)) {
+			PLOG(logDEBUG) << "ODE skip, not validated";
+        	return;
+		}
+		
 		try {
 			sendUDPMessage(routeableMsg, UDPMessageType::SPAT);
 			++_spatFwdCount;
@@ -146,6 +152,10 @@ namespace ODEForwardPlugin
 
 
 	void ODEForwardPlugin::HandleMapPublish([[maybe_unused]] MapDataMessage &msg, routeable_message &routeableMsg) {
+		if (!(routeableMsg.get_flags() & IvpMsgFlags_Validated)) {
+			PLOG(logDEBUG) << "ODE skip, not validated";
+        	return;
+		}
 		try {
 			sendUDPMessage(routeableMsg, UDPMessageType::MAP);
 			++_mapFwdCount;


### PR DESCRIPTION


<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Added frequency throttling for MAP and SPAT messages. Now, only messages with their content changed are forwarded to ODE

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[VH-1527](https://usdot-carma.atlassian.net/browse/VH-1527?atlOrigin=eyJpIjoiNGQ1OGFjMDQ0MDJhNDY1NWFmMTEwM2RjZmQ0YWY2YWYiLCJwIjoiaiJ9)

## Motivation and Context

Frequency throttling for IntersectionValidationPlugin

## How Has This Been Tested?

Local deployment testing, unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[VH-1527]: https://usdot-carma.atlassian.net/browse/VH-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ