### PR TITLE
Add unit tests to cover secured payload

### DIFF
--- a/src/tmx/Messages/include/RawSpdu.h
+++ b/src/tmx/Messages/include/RawSpdu.h
@@ -1,8 +1,7 @@
 /*
  * RawSpdu.h
  */
-#ifndef INCLUDE__RawSpdu _H_
-#define INCLUDE__RawSpdu _H_
+#pragma once
 #include <tmx/messages/message.hpp>
 #include <tmx/messages/byte_stream.hpp>
 #include <memory>
@@ -58,4 +57,3 @@ namespace tmx
         };
     }
 }
-#endif /* INCLUDE__RawSpdu _H_ */

--- a/src/v2i-hub/MessageReceiverPlugin/src/Utils.h
+++ b/src/v2i-hub/MessageReceiverPlugin/src/Utils.h
@@ -81,7 +81,7 @@ inline std::shared_ptr<Ieee1609Dot2Data_t> decodeSpdu(const tmx::byte_stream& da
 {
     Ieee1609Dot2Data_t* decodedPtr = nullptr;
     
-    asn_dec_rval_t rv = oer_decode(nullptr, &asn_DEF_Ieee1609Dot2Data,
+    asn_dec_rval_t rv = oer_decode(0, &asn_DEF_Ieee1609Dot2Data,
                                    (void**)&decodedPtr, data.data(), len);
     
     if (rv.code != RC_OK || !decodedPtr) {

--- a/src/v2i-hub/MessageReceiverPlugin/src/Utils.h
+++ b/src/v2i-hub/MessageReceiverPlugin/src/Utils.h
@@ -81,7 +81,7 @@ inline std::shared_ptr<Ieee1609Dot2Data_t> decodeSpdu(const tmx::byte_stream& da
 {
     Ieee1609Dot2Data_t* decodedPtr = nullptr;
     
-    asn_dec_rval_t rv = oer_decode(0, &asn_DEF_Ieee1609Dot2Data,
+    asn_dec_rval_t rv = oer_decode(nullptr, &asn_DEF_Ieee1609Dot2Data,
                                    (void**)&decodedPtr, data.data(), len);
     
     if (rv.code != RC_OK || !decodedPtr) {

--- a/src/v2i-hub/MessageReceiverPlugin/test/TestUtils.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/test/TestUtils.cpp
@@ -63,6 +63,105 @@ TEST(TestUtils, testDecodeSpdu){
     std::string expectedJson = R"({"protocolVersion":3,"content":{"unsecuredData":"0013680038422E1E7D2FC9DDD32F2E7971F4D3BF709B640800020D766174858008208214C801011910C110C1002C0860853200304104299001021A2189A189806010C10C4C00A0820853200804644304430400D0218214C801C10410A6400C08688626862601C043043130"}})";
     EXPECT_EQ(json, expectedJson);
 }
+TEST(TestUtils, testDecodeSpduSigned) {
+    tmx::byte_stream spdu = byte_stream_decode("0381004003806d00136a003842be5e7d1049ddd32f2e7971f4d3bf7097b4080000e8c4513f05800820809c7c00810d0508e508e02c086028470030410138f80202320a0a4a0a406010c04e3e00a0820271f00604341423942380d02180a11c01c10d052e652e601008c82829282901c0430138f850018200027df99e1f5dfa1738128fd203e9ae11f3810101000301801631afb5fc255d0f50820838ca0cf8a2890d5c5e6f5b000329cf3cb58400a9830101800348010680032040978007008101205ff4100001828001838005008001f0400001270001870002bfee81821212260959f3b3abf3ad90388bf779fec9d2c8b44078bd32ad9eb4e7feaaa9b88083741bc528c5c7ece6f1f0f2d6ddd01f61517e717402eb08609741285557cc65054f51ef089c3e267d71e23d56ac088ef0b01d95161b21a90465cbfd9d0efa798b");
+    /*
+    Ieee1609Dot2Data ::= {
+        protocolVersion: 3
+        content: signedData: SignedData ::= {
+            hashId: 0 (sha256)
+            tbsData: ToBeSignedData ::= {
+                payload: SignedDataPayload ::= {
+                    data: Ieee1609Dot2Data ::= {
+                        protocolVersion: 3
+                        content: unsecuredData: 
+                            00 13 6A 00 38 42 BE 5E 7D 10 49 DD D3 2F 2E 79 
+                            71 F4 D3 BF 70 97 B4 08 00 00 E8 C4 51 3F 05 80 
+                            08 20 80 9C 7C 00 81 0D 05 08 E5 08 E0 2C 08 60 
+                            28 47 00 30 41 01 38 F8 02 02 32 0A 0A 4A 0A 40 
+                            60 10 C0 4E 3E 00 A0 82 02 71 F0 06 04 34 14 23 
+                            94 23 80 D0 21 80 A1 1C 01 C1 0D 05 2E 65 2E 60 
+                            10 08 C8 28 29 28 29 01 C0 43 01 38 F8
+                    }
+                }
+                headerInfo: HeaderInfo ::= {
+                    psid: 130
+                    generationTime: 701461006605818
+                    generationLocation: ThreeDLocation ::= {
+                        latitude: 389550735
+                        longitude: -771495506
+                        elevation: 4595
+                    }
+                }
+            }
+            signer: certificate: SequenceOfCertificate ::= {
+                Certificate ::= {
+                    version: 3
+                    type: 1 (implicit)
+                    issuer: sha256AndDigest: 16 31 AF B5 FC 25 5D 0F
+                    toBeSigned: ToBeSignedCertificate ::= {
+                        id: binaryId: 38 CA 0C F8 A2 89 0D 5C
+                        cracaId: 5E 6F 5B
+                        crlSeries: 3
+                        validityPeriod: ValidityPeriod ::= {
+                            start: 701447349
+                            duration: hours: 169
+                        }
+                        region: identifiedRegion: SequenceOfIdentifiedRegion ::= {
+                            countryOnly: 840
+                        }
+                        appPermissions: SequenceOfPsidSsp ::= {
+                            PsidSsp ::= {
+                                psid: 2113687
+                                ssp: opaque: 00 81 01 20 5F F4 10
+                            }
+                            PsidSsp ::= {
+                                psid: 130
+                            }
+                            PsidSsp ::= {
+                                psid: 131
+                                ssp: opaque: 00 80 01 F0 40
+                            }
+                            PsidSsp ::= {
+                                psid: 39
+                            }
+                            PsidSsp ::= {
+                                psid: 135
+                            }
+                            PsidSsp ::= {
+                                psid: 49134
+                            }
+                        }
+                        verifyKeyIndicator: reconstructionValue: compressed-y-0: 
+                            12 12 26 09 59 F3 B3 AB F3 AD 90 38 8B F7 79 FE 
+                            C9 D2 C8 B4 40 78 BD 32 AD 9E B4 E7 FE AA A9 B8
+                    }
+                }
+            }
+            signature: ecdsaNistP256Signature: EcdsaP256Signature ::= {
+                rSig: compressed-y-1: 
+                    74 1B C5 28 C5 C7 EC E6 F1 F0 F2 D6 DD D0 1F 61 
+                    51 7E 71 74 02 EB 08 60 97 41 28 55 57 CC 65 05
+                sSig: 
+                    4F 51 EF 08 9C 3E 26 7D 71 E2 3D 56 AC 08 8E F0 
+                    B0 1D 95 16 1B 21 A9 04 65 CB FD 9D 0E FA 79 8B
+            }
+        }
+    }
+    */
+    auto decoded = MessageReceiver::decodeSpdu(spdu, spdu.size());
+    asn_fprint(stdout, &asn_DEF_Ieee1609Dot2Data, decoded.get());
+    // All follow on assertions required decoded pointer
+    ASSERT_TRUE(decoded != nullptr);
+    // Convert to JSON and confirm message content
+    std::stringstream ss;
+    jer_encode(&asn_DEF_Ieee1609Dot2Data, decoded.get(), jer_encoder_flags_e::JER_F_MINIFIED,
+				writeToStringStream,
+				static_cast<void *>(&ss));
+    std::string json=ss.str();
+    std::string expectedJson = R"({"protocolVersion":3,"content":{"signedData":{"hashId":"sha256","tbsData":{"payload":{"data":{"protocolVersion":3,"content":{"unsecuredData":"00136A003842BE5E7D1049DDD32F2E7971F4D3BF7097B4080000E8C4513F05800820809C7C00810D0508E508E02C086028470030410138F80202320A0A4A0A406010C04E3E00A0820271F00604341423942380D02180A11C01C10D052E652E601008C82829282901C0430138F8"}}},"headerInfo":{"psid":130,"generationTime":701461006605818,"generationLocation":{"latitude":389550735,"longitude":-771495506,"elevation":4595}}},"signer":{"certificate":[{"version":3,"type":"implicit","issuer":{"sha256AndDigest":"1631AFB5FC255D0F"},"toBeSigned":{"id":{"binaryId":"38CA0CF8A2890D5C"},"cracaId":"5E6F5B","crlSeries":3,"validityPeriod":{"start":701447349,"duration":{"hours":169}},"region":{"identifiedRegion":[{"countryOnly":840}]},"appPermissions":[{"psid":2113687,"ssp":{"opaque":"008101205FF410"}},{"psid":130},{"psid":131,"ssp":{"opaque":"008001F040"}},{"psid":39},{"psid":135},{"psid":49134}],"verifyKeyIndicator":{"reconstructionValue":{"compressed-y-0":"1212260959F3B3ABF3AD90388BF779FEC9D2C8B44078BD32AD9EB4E7FEAAA9B8"}}}}]},"signature":{"ecdsaNistP256Signature":{"rSig":{"compressed-y-1":"741BC528C5C7ECE6F1F0F2D6DDD01F61517E717402EB08609741285557CC6505"},"sSig":"4F51EF089C3E267D71E23D56AC088EF0B01D95161B21A90465CBFD9D0EFA798B"}}}}})";
+    EXPECT_EQ(json, expectedJson);
+}
 
 TEST(TestUtils, testDecodeSpduInvalid){
     tmx::byte_stream spdu = byte_stream_decode("03806b0013680038422e1e7d2fc9ddd32f2e7971f4d3bf709b640800020d766174858008208214c8"
@@ -81,17 +180,15 @@ TEST(TestUtils, testDecodeSpduEmpty){
 }
 
 TEST(TestUtils, testUnwrapSpdu){
-    tmx::byte_stream spdu = byte_stream_decode("03806b0013680038422e1e7d2fc9ddd32f2e7971f4d3bf709b640800020d766174858008208214c8"
-       "01011910c110c1002c0860853200304104299001021a2189a189806010c10c4c00a0820853200804"
-       "644304430400d0218214c801c10410a6400c08688626862601c043043130");
+    tmx::byte_stream spdu = byte_stream_decode("0381004003806d00136a003842be5e7d1049ddd32f2e7971f4d3bf7097b4080000e8c4513f05800820809c7c00810d0508e508e02c086028470030410138f80202320a0a4a0a406010c04e3e00a0820271f00604341423942380d02180a11c01c10d052e652e601008c82829282901c0430138f850018200027df99e1f5dfa1738128fd203e9ae11f3810101000301801631afb5fc255d0f50820838ca0cf8a2890d5c5e6f5b000329cf3cb58400a9830101800348010680032040978007008101205ff4100001828001838005008001f0400001270001870002bfee81821212260959f3b3abf3ad90388bf779fec9d2c8b44078bd32ad9eb4e7feaaa9b88083741bc528c5c7ece6f1f0f2d6ddd01f61517e717402eb08609741285557cc65054f51ef089c3e267d71e23d56ac088ef0b01d95161b21a90465cbfd9d0efa798b");
     auto decoded = MessageReceiver::decodeSpdu(spdu, spdu.size());
     tmx::byte_stream payload;
     uint psid = 0;
     bool psidSet = false;
     bool result = MessageReceiver::unwrapSpdu(decoded.get(), payload, psid, psidSet, 0);
     EXPECT_TRUE(result);
-    EXPECT_FALSE(psidSet);
-    std::string expectedPayloadHex = "0013680038422e1e7d2fc9ddd32f2e7971f4d3bf709b640800020d766174858008208214c801011910c110c1002c0860853200304104299001021a2189a189806010c10c4c00a0820853200804644304430400d0218214c801c10410a6400c08688626862601c043043130";
+    EXPECT_TRUE(psidSet);
+    std::string expectedPayloadHex = "00136a003842be5e7d1049ddd32f2e7971f4d3bf7097b4080000e8c4513f05800820809c7c00810d0508e508e02c086028470030410138f80202320a0a4a0a406010c04e3e00a0820271f00604341423942380d02180a11c01c10d052e652e601008c82829282901c0430138f8";
     std::string actualPayloadHex = byte_stream_encode(payload);
     EXPECT_EQ(actualPayloadHex, expectedPayloadHex);
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Initially thought stol-1609dot2 library had bug that meant in could not read signed messages. Turns out I had a 1609.3 payload which is the wrapper for 1609.2 when broadcasting out of the RSU. NTCIP 1218 mentioned that the secured payload sent using the transmit forward table should only include 1609.2
[NTCIP 1218
](https://www.ntcip.org/file/2025/01/NTCIP-1218-v01A-2024-AsPublished.pdf)
```
rsuXmitMsgFwdingSecure OBJECT-TYPE
 SYNTAX INTEGER (0..1)
 MAX-ACCESS read-create
 STATUS current
 DESCRIPTION "<Definition> A value of 0 indicates the RSU is to forward
only the unsigned SPDU (the WSM message payload without security
headers).
A value of 1 indicates the RSU is to forward the signed SPDU, which
includes all the signatures and trailers. The SPDU is defined in
IEEE 1609.2.
 <Object Identifier> 1.3.6.1.4.1.1206.4.2.18.20.2.1.8"
::= { rsuXmitMsgFwdingEntry 8 }

```
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
DT4IT-124

<!-- e.g. CAR-123 -->

## Motivation and Context
Fix and ensure test coverage

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit testing 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
