### PR TITLE
Added rest of fields to CTI Event

### DIFF
--- a/src/v2i-hub/IntersectionValidationPlugin/README.md
+++ b/src/v2i-hub/IntersectionValidationPlugin/README.md
@@ -10,7 +10,7 @@ A list of plugins related to the Intersection Validation Plugin.
 
 ## Configuration/Deployment
 
-There are no unique configuration parameters for this plugin, although the log level can be set to "Warning" to view any message interval violations, and "Debug" to view the decoded MAP and SPaT messages in a JSON format that undergo message validation. The log level can be set to "Error" to view any errors from the message validation and where in the message the violation exists. 
+There is one unique configuration parameter for this plugin, the rsuSource, which is the IP address of a connected RSU sending SPAT and MAP messages. This configuration parameter is only used when the plugin creates CTI 4501 Validation events, where the "rsuSource" is attached to the "source" field of every event prior to being forwarded by the ODE Plugin to a consumer. The log level can be set to "Warning" to view any message interval violations, and "Debug" to view the decoded MAP and SPaT messages in a JSON format that undergo message validation. The log level can be set to "Error" to view any errors from the message validation and where in the message the violation exists. 
 
 The JSON schemas, which detail the proper structure and required fields in a MAP and SPaT message, for message validation exist under the `resources/` directory. Both the MAP and SPaT schemas are custom and include additional required fields specified by the CTI 4501 standard, on top of the required fields specified by the J2735 standard. For SPaT messages, those additional fields include:
 

--- a/src/v2i-hub/IntersectionValidationPlugin/manifest.json
+++ b/src/v2i-hub/IntersectionValidationPlugin/manifest.json
@@ -31,7 +31,7 @@
     {
       "key": "rsuSource",
       "default": "-",
-      "description": "IP Address of the RSU"
+      "description": "IP Address of the RSU that sends the SPAT/MAP messages that are validated by this plugin. The IP is added to the 'source' field of all CTI 4501 Validation events so that consumers can attribute the event to the reporting RSU."
     }
   ]
 }

--- a/src/v2i-hub/IntersectionValidationPlugin/manifest.json
+++ b/src/v2i-hub/IntersectionValidationPlugin/manifest.json
@@ -27,6 +27,11 @@
 			"key": "LogOutput",
 			"default": "-",
 			"description": "Name of the log file for this plugin. If a relative path is provided, this file will create a directory under /var/log/<PluginName> and add the file here. Not including this parameter or setting to (-) will direct log output to stdout which is the default behavior. NOTE: File logging for plugins should only be used for temporary data collection. Current file logging does not have mechanisms to purge data after a certain time or size."
-		}
+		},
+    {
+      "key": "rsuSource",
+      "default": "-",
+      "description": "IP Address of the RSU"
+    }
   ]
 }

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -66,8 +66,6 @@ namespace IntersectionValidation
     {
         // RSU identifier
         GetConfigValue<std::string>("rsuSource", rsuSource);
-
-        SetStatus("RSU Source", rsuSource.empty() ? "(not configured)" : rsuSource);
     }
 
 	void IntersectionValidationPlugin::OnConfigChanged(const char *key, const char *value)

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -64,7 +64,10 @@ namespace IntersectionValidation
 
     void IntersectionValidationPlugin::UpdateConfigSettings()
     {
-        // TODO
+        // RSU identifier
+        GetConfigValue<std::string>("rsuSource", rsuSource);
+
+        SetStatus("RSU Source", rsuSource.empty() ? "(not configured)" : rsuSource);
     }
 
 	void IntersectionValidationPlugin::OnConfigChanged(const char *key, const char *value)

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -64,7 +64,7 @@ namespace IntersectionValidation
         uint spatValidationPassed = 0;
         uint mapFieldValidationErrors = 0;
         uint mapValidationPassed = 0;
-        std::string rsuSource;
+        std::string rsuSource; // TODO: Instead of setting the rsu IP here, have the message receiver grab the IP and attach it to the message
 
         uint spatRevisionPassed = 0;
         uint mapRevisionPassed = 0;

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -72,8 +72,8 @@ namespace IntersectionValidation
         uint mapRevisionFailed = 0;
 
         // Identifier of the measured input stream, reported as topicName on a BroadcastRate event
-        std::string spatInputTopic;
-        std::string mapInputTopic;
+        std::string spatInputTopic = "topic.ProcessedSpat";
+        std::string mapInputTopic = "topic.ProcessedMap";
 
         /**
          * @brief Measure message interval and broadcast TmxEventLogMessage if threshold exceeded.


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds the rsu source IP address to the configuration of the Intersection Validation Plugin, as well as the CTI4501 events.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[VH-1597](https://usdot-carma.atlassian.net/browse/VH-1597)

## Motivation and Context

Required fields for the CTI 4501 events to so they can properly be ingested by the CV Manager

## How Has This Been Tested?

Local deployment testing, sending SPAT/MAP messages to v2xhub and triggering events

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


[VH-1597]: https://usdot-carma.atlassian.net/browse/VH-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ