### PR TITLE
Fixed Populating CTI Events for CV Manager to Read

### DIFF
--- a/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.cpp
@@ -22,15 +22,18 @@
 #include <cstring>
 #include <rapidjson/pointer.h>
 
-// Collects missing required fields. This functionality creates a list of the missing data elements
-// based on the format that CV Manager expects.
-namespace
+namespace IntersectionValidation
 {
+
+    class FileLoadException : public std::runtime_error
+    {
+    public:
+        using std::runtime_error::runtime_error;
+    };
+
     // Depth cap guards against $ref cycles.
     constexpr int MAX_SCHEMA_DEPTH = 64;
 
-    // Resolve a local "#/..." $ref against the root schema. Returns nullptr for
-    // external or unresolvable refs.
     const rapidjson::Value *resolveRef(const rapidjson::Value &node,
                                        const rapidjson::Value &schemaRoot)
     {
@@ -52,8 +55,6 @@ namespace
         return rapidjson::Pointer(refStr.substr(1).c_str()).Get(schemaRoot);
     }
 
-    // Following a $ref re-bases reported schema references on the ref target, so
-    // entries cite "#/$defs/J2735TimeMark" rather than the full inline path
     std::string refOr(const rapidjson::Value &node, const std::string &fallback)
     {
         if (node.IsObject())
@@ -67,8 +68,6 @@ namespace
         return fallback;
     }
 
-    // Schema reference to cite for a missing property: the property's own $ref if it
-    // has one, otherwise the inline "<parent>/properties/<name>" fallback.
     std::string propertySchemaRef(const rapidjson::Value &schema, const char *name,
                                   const std::string &fallback)
     {
@@ -85,17 +84,6 @@ namespace
         return refOr(propSchema->value, fallback);
     }
 
-    // Forward declaration so handleObject can recurse back into the entry point.
-    void collectMissingRequired(const rapidjson::Value &schemaNode,
-                                const rapidjson::Value &instance,
-                                const rapidjson::Value &schemaRoot,
-                                const std::string &jsonPath,
-                                const std::string &schemaPath,
-                                std::vector<std::string> &out,
-                                int depth = 0);
-
-    // Object handling on its own so its two required/descend loops reset the nesting
-    // baseline and stay within the depth limit
     void handleObject(const rapidjson::Value &schema, const rapidjson::Value &instance,
                       const rapidjson::Value &schemaRoot, const std::string &jsonPath,
                       const std::string &resolvedSchemaPath,
@@ -144,8 +132,6 @@ namespace
         }
     }
 
-    // Recursively compare the document against the schema and collect every required
-    // property that is absent
     void collectMissingRequired(const rapidjson::Value &schemaNode,
                                 const rapidjson::Value &instance,
                                 const rapidjson::Value &schemaRoot,
@@ -201,17 +187,6 @@ namespace
             }
         }
     }
-}
-
-
-namespace IntersectionValidation
-{
-
-    class FileLoadException : public std::runtime_error
-    {
-    public:
-        using std::runtime_error::runtime_error;
-    };
 
     std::string loadFileContents(const std::string &filePath)
     {

--- a/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.cpp
@@ -20,6 +20,188 @@
 #include <sstream>
 #include <stdexcept>
 #include <cstring>
+#include <rapidjson/pointer.h>
+
+// Collects missing required fields. This functionality creates a list of the missing data elements
+// based on the format that CV Manager expects.
+namespace
+{
+    // Depth cap guards against $ref cycles.
+    constexpr int MAX_SCHEMA_DEPTH = 64;
+
+    // Resolve a local "#/..." $ref against the root schema. Returns nullptr for
+    // external or unresolvable refs.
+    const rapidjson::Value *resolveRef(const rapidjson::Value &node,
+                                       const rapidjson::Value &schemaRoot)
+    {
+        auto ref = node.FindMember("$ref");
+        if (ref == node.MemberEnd() || !ref->value.IsString())
+        {
+            return &node;
+        }
+
+        const std::string refStr = ref->value.GetString();
+        if (refStr.empty() || refStr[0] != '#')
+        {
+            return nullptr;
+        }
+        if (refStr == "#")
+        {
+            return &schemaRoot;
+        }
+        return rapidjson::Pointer(refStr.substr(1).c_str()).Get(schemaRoot);
+    }
+
+    // Following a $ref re-bases reported schema references on the ref target, so
+    // entries cite "#/$defs/J2735TimeMark" rather than the full inline path
+    std::string refOr(const rapidjson::Value &node, const std::string &fallback)
+    {
+        if (node.IsObject())
+        {
+            if (auto ref = node.FindMember("$ref");
+                ref != node.MemberEnd() && ref->value.IsString())
+            {
+                return ref->value.GetString();
+            }
+        }
+        return fallback;
+    }
+
+    // Schema reference to cite for a missing property: the property's own $ref if it
+    // has one, otherwise the inline "<parent>/properties/<name>" fallback.
+    std::string propertySchemaRef(const rapidjson::Value &schema, const char *name,
+                                  const std::string &fallback)
+    {
+        auto properties = schema.FindMember("properties");
+        if (properties == schema.MemberEnd() || !properties->value.IsObject())
+        {
+            return fallback;
+        }
+        auto propSchema = properties->value.FindMember(name);
+        if (propSchema == properties->value.MemberEnd())
+        {
+            return fallback;
+        }
+        return refOr(propSchema->value, fallback);
+    }
+
+    // Forward declaration so handleObject can recurse back into the entry point.
+    void collectMissingRequired(const rapidjson::Value &schemaNode,
+                                const rapidjson::Value &instance,
+                                const rapidjson::Value &schemaRoot,
+                                const std::string &jsonPath,
+                                const std::string &schemaPath,
+                                std::vector<std::string> &out,
+                                int depth = 0);
+
+    // Object handling on its own so its two required/descend loops reset the nesting
+    // baseline and stay within the depth limit
+    void handleObject(const rapidjson::Value &schema, const rapidjson::Value &instance,
+                      const rapidjson::Value &schemaRoot, const std::string &jsonPath,
+                      const std::string &resolvedSchemaPath,
+                      std::vector<std::string> &out, int depth)
+    {
+        if (!instance.IsObject())
+        {
+            return;
+        }
+
+        // Required properties absent from this object
+        if (auto required = schema.FindMember("required");
+            required != schema.MemberEnd() && required->value.IsArray())
+        {
+            for (const auto &name : required->value.GetArray())
+            {
+                if (!name.IsString() || instance.HasMember(name.GetString()))
+                {
+                    continue;
+                }
+                const std::string elementSchemaPath = propertySchemaRef(
+                    schema, name.GetString(),
+                    resolvedSchemaPath + "/properties/" + name.GetString());
+                out.emplace_back(jsonPath + "." + name.GetString() +
+                                 " is missing (" + elementSchemaPath + ")");
+            }
+        }
+
+        // Descend into the properties that are actually present
+        if (auto properties = schema.FindMember("properties");
+            properties != schema.MemberEnd() && properties->value.IsObject())
+        {
+            for (auto it = properties->value.MemberBegin();
+                 it != properties->value.MemberEnd(); ++it)
+            {
+                if (auto child = instance.FindMember(it->name);
+                    child != instance.MemberEnd())
+                {
+                    collectMissingRequired(it->value, child->value, schemaRoot,
+                                           jsonPath + "." + it->name.GetString(),
+                                           resolvedSchemaPath + "/properties/" +
+                                               it->name.GetString(),
+                                           out, depth + 1);
+                }
+            }
+        }
+    }
+
+    // Recursively compare the document against the schema and collect every required
+    // property that is absent
+    void collectMissingRequired(const rapidjson::Value &schemaNode,
+                                const rapidjson::Value &instance,
+                                const rapidjson::Value &schemaRoot,
+                                const std::string &jsonPath,
+                                const std::string &schemaPath,
+                                std::vector<std::string> &out,
+                                int depth)
+    {
+        if (depth > MAX_SCHEMA_DEPTH)
+        {
+            return;
+        }
+
+        const std::string resolvedSchemaPath = refOr(schemaNode, schemaPath);
+
+        const rapidjson::Value *schema = resolveRef(schemaNode, schemaRoot);
+        if (schema == nullptr || !schema->IsObject())
+        {
+            return;
+        }
+
+        // Objects: missing-required plus descent into present properties.
+        handleObject(*schema, instance, schemaRoot, jsonPath, resolvedSchemaPath, out, depth);
+
+        // Arrays: descend into each element against the "items" subschema.
+        if (instance.IsArray())
+        {
+            if (auto items = schema->FindMember("items");
+                items != schema->MemberEnd() && items->value.IsObject())
+            {
+                rapidjson::SizeType index = 0;
+                for (const auto &element : instance.GetArray())
+                {
+                    collectMissingRequired(items->value, element, schemaRoot,
+                                           jsonPath + "[" + std::to_string(index) + "]",
+                                           resolvedSchemaPath + "/items", out, depth + 1);
+                    ++index;
+                }
+            }
+        }
+
+        // allOf applies every subschema, so its required constraints all hold.
+        if (auto allOf = schema->FindMember("allOf");
+            allOf != schema->MemberEnd() && allOf->value.IsArray())
+        {
+            rapidjson::SizeType index = 0;
+            for (const auto &sub : allOf->value.GetArray())
+            {
+                collectMissingRequired(sub, instance, schemaRoot, jsonPath,
+                                       resolvedSchemaPath + "/allOf/" + std::to_string(index),
+                                       out, depth + 1);
+                ++index;
+            }
+        }
+    }
+}
 
 
 namespace IntersectionValidation
@@ -256,6 +438,18 @@ namespace IntersectionValidation
                 ++it;
             }
         }
+    }
+
+    std::vector<std::string> collectMissingRequiredFields(const rapidjson::Value &schema,
+                                                          const rapidjson::Value &doc)
+    {
+        // Enumerate every missing required element in conflictmonitor's minimum-data
+        // string format. Operates on the caller's already-preprocessed document; it
+        // does not parse or mutate. The root schema doubles as the $ref resolution
+        // base, so it is passed as both the current node and the root.
+        std::vector<std::string> missing;
+        collectMissingRequired(schema, doc, schema, "$", "#", missing);
+        return missing;
     }
 
     FieldValidation validateJsonAgainstSchema(const std::string &jsonStr, const std::string &schemaStr)

--- a/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.h
@@ -34,7 +34,7 @@ namespace IntersectionValidation
      * @brief Recursively convert numeric strings in a RapidJSON value to integers, except for keys named "status".
      * @param value The RapidJSON value to process.
      * @param allocator The RapidJSON allocator for modifying the value.
-     * @param key The current key being processed (used to skip "status" fields).
+     * @param schema The JSON Schema node providing type context for the value.
      */
     void convertNumericStrings(rapidjson::Value &value,
                                       rapidjson::Document::AllocatorType &allocator,
@@ -46,45 +46,6 @@ namespace IntersectionValidation
      */
     std::string loadFileContents(const std::string &filePath);
 
-    /**
-     * @brief Check if a JSON Schema node declares a specific type (e.g., "integer"), handling both string and array forms of the "type" keyword.
-     * @param schema The JSON Schema node to check.
-     * @param typeName The type name to look for (e.g., "integer").
-     * @return True if the schema declares the type, false otherwise.
-     */
-    static bool schemaHasType(const rapidjson::Value &schema, const char *typeName);
-
-    /**
-     * @brief Get the schema node for a property key, or nullptr if not found.
-     *        First checks the direct "properties" object, If not found, then 
-     *        search through the oneOf, anyOf, allOf branches recursively.
-     * @param schema The JSON Schema node representing the parent object.
-     * @param key The property key to look up.
-     * @return Pointer to the schema node for the property, or nullptr if not found.
-     */
-    static const rapidjson::Value *getPropertySchema(const rapidjson::Value &schema, const char *key);
-   
-    /**
-     * @brief Get the schema node for array items, or nullptr if not found.
-     * @param schema The JSON Schema node representing the array.
-     * @return Pointer to the schema node for the array items, or nullptr if not found
-     */
-    static const rapidjson::Value *getItemsSchema(const rapidjson::Value &schema);
-
-    /**
-     * @brief Attempt to convert a RapidJSON value from a numeric string to an integer. Returns true if conversion was successful.
-     * @param value The RapidJSON value to convert. Must be a string containing a valid integer representation.
-     * @return True if the value was successfully converted to an integer, false otherwise.
-     */
-    static bool tryConvertToInt(rapidjson::Value &value);
-
-    /**
-     * @brief Attempt to convert a RapidJSON value from a string to a boolean. Returns true if conversion was successful.
-     * @param value The RapidJSON value to convert. Must be a string "true" or "false".
-     * @return True if the value was successfully converted to a boolean, false otherwise.
-     */
-    static bool tryConvertToBool(rapidjson::Value &value);
-    
     /**
      * @brief Validate a JSON string against a JSON Schema string using RapidJSON SchemaValidator.
      * @param jsonStr The JSON string to validate.
@@ -103,6 +64,18 @@ namespace IntersectionValidation
      * @param allocator The document allocator.
      */
     void removeEmptyStrings(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator);
+
+    /**
+     * @brief Enumerate every required property absent from the document, as JSON-path
+     *        strings matching conflictmonitor's minimum-data format
+     *        (e.g. "$.value.SPAT.intersections[0].roadAuthorityID is missing (#/...)").
+     *
+     * @param schema The root JSON Schema node.
+     * @param doc    The instance document to check against the schema.
+     * @return One string per missing required element; empty if none are missing.
+     */
+    std::vector<std::string> collectMissingRequiredFields(const rapidjson::Value &schema,
+                                                          const rapidjson::Value &doc);
 
     /**
      * @brief Validate a JSON string against a JSON Schema.

--- a/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.h
@@ -31,6 +31,78 @@ namespace IntersectionValidation
     };
 
     /**
+     * @brief Resolve a local "#/..." $ref against the root schema. Returns nullptr for
+     * external or unresolvable refs
+     * @param node The schema node that may contain a $ref member
+     * @param schemaRoot The root schema against which local pointers are resolved
+     * @return The resolved schema node, the node itself if it has no "$ref", or nullptr if unresolvable
+     */
+    const rapidjson::Value *resolveRef(const rapidjson::Value &node,
+                                       const rapidjson::Value &schemaRoot);
+
+    /**
+     * @brief Return a node's own "$ref" string if it declares one, otherwise the supplied fallback
+     * @param node The schema node that may declare a "$ref"
+     * @param fallback The schema path to return when the node has no "$ref"
+     * @return The node's "$ref" string, or @p fallback when it declares none
+     */
+    std::string refOr(const rapidjson::Value &node, const std::string &fallback);
+
+    /**
+     * @brief Determine the schema reference to cite for a missing required property
+     * @param schema The parent (object) schema node containing the "properties" map
+     * @param name The name of the missing required property
+     * @param fallback The inline schema path to use when no property "$ref" is found
+     * @return The property's "$ref", or @p fallback.
+     */
+    std::string propertySchemaRef(const rapidjson::Value &schema, const char *name,
+                                  const std::string &fallback);
+
+                                  
+    /**
+     * @brief Collect missing required properties for an object instance and recurse into present ones
+     * @param schema The (already $ref-resolved) object schema node
+     * @param instance The instance value being validated
+     * @param schemaRoot The root schema, used to resolve "$ref" during recursion
+     * @param jsonPath The JSON-path prefix of @p instance (e.g. "$.value.SPAT")
+     * @param resolvedSchemaPath The schema-path prefix used when citing missing elements
+     * @param out Output list; one formatted string is appended per missing element
+     * @param depth Current recursion depth, capped to guard against "$ref" cycles
+     */
+    void handleObject(const rapidjson::Value &schema, const rapidjson::Value &instance,
+                      const rapidjson::Value &schemaRoot, const std::string &jsonPath,
+                      const std::string &resolvedSchemaPath,
+                      std::vector<std::string> &out, int depth);
+
+    /**
+     * @brief Recursively compare an instance against a schema and collect every absent required property
+     * @param schemaNode The schema node (may carry a "$ref") to compare against
+     * @param instance The instance value being validated
+     * @param schemaRoot The root schema, used to resolve local "$ref" pointers
+     * @param jsonPath The JSON-path prefix of @p instance
+     * @param schemaPath The schema-path prefix used when citing missing elements
+     * @param out Output list; one formatted string is appended per missing element
+     * @param depth Current recursion depth, capped to guard against "$ref" cycles
+     */
+    void collectMissingRequired(const rapidjson::Value &schemaNode,
+                                const rapidjson::Value &instance,
+                                const rapidjson::Value &schemaRoot,
+                                const std::string &jsonPath,
+                                const std::string &schemaPath,
+                                std::vector<std::string> &out,
+                                int depth = 0);
+
+    /**
+     * @brief Enumerate every required property absent from the document, as JSON-path strings
+     * @param schema The root JSON Schema node
+     * @param doc The instance document to check against the schema
+     * @return One string per missing required element; empty if none are missing
+     */
+    std::vector<std::string> collectMissingRequiredFields(const rapidjson::Value &schema,
+                                                          const rapidjson::Value &doc);
+
+
+    /**
      * @brief Recursively convert numeric strings in a RapidJSON value to integers, except for keys named "status".
      * @param value The RapidJSON value to process.
      * @param allocator The RapidJSON allocator for modifying the value.
@@ -66,23 +138,10 @@ namespace IntersectionValidation
     void removeEmptyStrings(rapidjson::Value &value, rapidjson::Document::AllocatorType &allocator);
 
     /**
-     * @brief Enumerate every required property absent from the document, as JSON-path
-     *        strings matching conflictmonitor's minimum-data format
-     *        (e.g. "$.value.SPAT.intersections[0].roadAuthorityID is missing (#/...)").
-     *
-     * @param schema The root JSON Schema node.
-     * @param doc    The instance document to check against the schema.
-     * @return One string per missing required element; empty if none are missing.
-     */
-    std::vector<std::string> collectMissingRequiredFields(const rapidjson::Value &schema,
-                                                          const rapidjson::Value &doc);
-
-    /**
      * @brief Validate a JSON string against a JSON Schema.
      * @param jsonStr The JSON string to validate.
      * @param schemaFilePath Path to the JSON Schema file.
      * @return FieldValidation containing validity and list of errors.
      */
     FieldValidation validateJsonAgainstSchemaFile(const std::string &jsonStr, const std::string &schemaFilePath);
-
 }

--- a/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/FieldValidation.h
@@ -119,6 +119,45 @@ namespace IntersectionValidation
     std::string loadFileContents(const std::string &filePath);
 
     /**
+     * @brief Check if a JSON Schema node declares a specific type (e.g., "integer"), handling both string and array forms of the "type" keyword.
+     * @param schema The JSON Schema node to check.
+     * @param typeName The type name to look for (e.g., "integer").
+     * @return True if the schema declares the type, false otherwise.
+     */
+    static bool schemaHasType(const rapidjson::Value &schema, const char *typeName);
+
+    /**
+     * @brief Get the schema node for a property key, or nullptr if not found.
+     *        First checks the direct "properties" object, If not found, then 
+     *        search through the oneOf, anyOf, allOf branches recursively.
+     * @param schema The JSON Schema node representing the parent object.
+     * @param key The property key to look up.
+     * @return Pointer to the schema node for the property, or nullptr if not found.
+     */
+    static const rapidjson::Value *getPropertySchema(const rapidjson::Value &schema, const char *key);
+   
+    /**
+     * @brief Get the schema node for array items, or nullptr if not found.
+     * @param schema The JSON Schema node representing the array.
+     * @return Pointer to the schema node for the array items, or nullptr if not found
+     */
+    static const rapidjson::Value *getItemsSchema(const rapidjson::Value &schema);
+
+    /**
+     * @brief Attempt to convert a RapidJSON value from a numeric string to an integer. Returns true if conversion was successful.
+     * @param value The RapidJSON value to convert. Must be a string containing a valid integer representation.
+     * @return True if the value was successfully converted to an integer, false otherwise.
+     */
+    static bool tryConvertToInt(rapidjson::Value &value);
+
+    /**
+     * @brief Attempt to convert a RapidJSON value from a string to a boolean. Returns true if conversion was successful.
+     * @param value The RapidJSON value to convert. Must be a string "true" or "false".
+     * @return True if the value was successfully converted to a boolean, false otherwise.
+     */
+    static bool tryConvertToBool(rapidjson::Value &value);
+
+    /**
      * @brief Validate a JSON string against a JSON Schema string using RapidJSON SchemaValidator.
      * @param jsonStr The JSON string to validate.
      * @param schemaStr The JSON Schema as a string.

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -48,32 +48,6 @@ namespace
         return out.str();
     }
 
-    // Turn a rapidjson instanceRef ("#/value/SPAT/intersections/0/states/0/timing")
-    // into a path relative to the message body ("intersections/0/states/0/timing"),
-    // so a reported element reads as a location an operator can find in the message.
-    std::string trimInstanceRef(const std::string &instanceRef)
-    {
-        std::string path = instanceRef;
-        if (path.rfind("#/", 0) == 0)
-        {
-            path.erase(0, 2);
-        }
-        else if (path == "#")
-        {
-            path.clear();
-        }
-
-        for (const std::string &prefix : {std::string("value/SPAT/"), std::string("value/MapData/")})
-        {
-            if (path.rfind(prefix, 0) == 0)
-            {
-                path.erase(0, prefix.size());
-                break;
-            }
-        }
-        return path;
-    }
-
     // Resolve a local "#/..." $ref against the root schema. Returns nullptr for
     // external or unresolvable refs.
     const rapidjson::Value *resolveRef(const rapidjson::Value &node,
@@ -98,17 +72,12 @@ namespace
     }
 
     // Recursively compare the document against the schema and collect every required
-    // property that is absent, as "path/to/object/fieldName".
-    //
-    // conflictmonitor's missingDataElements is a list of the absent elements, not a
-    // single validator diagnostic. rapidjson 1.1.0 has no continue-on-error, so the
-    // validator only reports the first failure; walking the schema ourselves reports
-    // all of them. anyOf/oneOf are deliberately not descended into: which branch was
-    // intended is ambiguous, so reporting from them would produce false positives.
+    // property that is absent
     void collectMissingRequired(const rapidjson::Value &schemaNode,
                                 const rapidjson::Value &instance,
                                 const rapidjson::Document &schemaRoot,
-                                const std::string &path,
+                                const std::string &jsonPath,
+                                const std::string &schemaPath,
                                 std::vector<MissingDataElement> &out,
                                 int depth = 0)
     {
@@ -118,31 +87,63 @@ namespace
             return;
         }
 
+        // Following a $ref re-bases the reported schema reference on the ref target,
+        // so entries cite "#/$defs/J2735TimeMark" rather than the full inline path.
+        std::string resolvedSchemaPath = schemaPath;
+        if (schemaNode.IsObject())
+        {
+            auto ref = schemaNode.FindMember("$ref");
+            if (ref != schemaNode.MemberEnd() && ref->value.IsString())
+            {
+                resolvedSchemaPath = ref->value.GetString();
+            }
+        }
+
         const rapidjson::Value *schema = resolveRef(schemaNode, schemaRoot);
         if (schema == nullptr || !schema->IsObject())
         {
             return;
         }
 
-        // Required properties absent from this object
         if (instance.IsObject())
         {
+            auto properties = schema->FindMember("properties");
+
+            // Required properties absent from this object
             auto required = schema->FindMember("required");
             if (required != schema->MemberEnd() && required->value.IsArray())
             {
                 for (const auto &name : required->value.GetArray())
                 {
-                    if (name.IsString() && !instance.HasMember(name.GetString()))
+                    if (!name.IsString() || instance.HasMember(name.GetString()))
                     {
-                        out.emplace_back(path.empty()
-                                             ? std::string(name.GetString())
-                                             : path + "/" + name.GetString());
+                        continue;
                     }
+
+                    // Prefer the missing property's own schema reference
+                    std::string elementSchemaPath =
+                        resolvedSchemaPath + "/properties/" + name.GetString();
+                    if (properties != schema->MemberEnd() && properties->value.IsObject())
+                    {
+                        auto propSchema = properties->value.FindMember(name.GetString());
+                        if (propSchema != properties->value.MemberEnd() &&
+                            propSchema->value.IsObject())
+                        {
+                            auto propRef = propSchema->value.FindMember("$ref");
+                            if (propRef != propSchema->value.MemberEnd() &&
+                                propRef->value.IsString())
+                            {
+                                elementSchemaPath = propRef->value.GetString();
+                            }
+                        }
+                    }
+
+                    out.emplace_back(jsonPath + "." + name.GetString() +
+                                     " is missing (" + elementSchemaPath + ")");
                 }
             }
 
             // Descend into the properties that are actually present
-            auto properties = schema->FindMember("properties");
             if (properties != schema->MemberEnd() && properties->value.IsObject())
             {
                 for (auto it = properties->value.MemberBegin();
@@ -151,10 +152,11 @@ namespace
                     auto child = instance.FindMember(it->name);
                     if (child != instance.MemberEnd())
                     {
-                        const std::string childPath =
-                            path.empty() ? it->name.GetString() : path + "/" + it->name.GetString();
                         collectMissingRequired(it->value, child->value, schemaRoot,
-                                               childPath, out, depth + 1);
+                                               jsonPath + "." + it->name.GetString(),
+                                               resolvedSchemaPath + "/properties/" +
+                                                   it->name.GetString(),
+                                               out, depth + 1);
                     }
                 }
             }
@@ -170,7 +172,9 @@ namespace
                 for (const auto &element : instance.GetArray())
                 {
                     collectMissingRequired(items->value, element, schemaRoot,
-                                           path + "/" + std::to_string(index), out, depth + 1);
+                                           jsonPath + "[" + std::to_string(index) + "]",
+                                           resolvedSchemaPath + "/items",
+                                           out, depth + 1);
                     ++index;
                 }
             }
@@ -180,9 +184,13 @@ namespace
         auto allOf = schema->FindMember("allOf");
         if (allOf != schema->MemberEnd() && allOf->value.IsArray())
         {
+            rapidjson::SizeType index = 0;
             for (const auto &sub : allOf->value.GetArray())
             {
-                collectMissingRequired(sub, instance, schemaRoot, path, out, depth + 1);
+                collectMissingRequired(sub, instance, schemaRoot, jsonPath,
+                                       resolvedSchemaPath + "/allOf/" + std::to_string(index),
+                                       out, depth + 1);
+                ++index;
             }
         }
     }
@@ -345,25 +353,27 @@ namespace IntersectionValidation
 
         if (!doc.Accept(validator))
         {
-            // One entry per missing element, e.g. "intersections/0/states/0/timing/minEndTime"
+            // One entry per missing element, formatted to match conflictmonitor's own
+            // minimum-data strings.
             std::vector<MissingDataElement> elements;
-            collectMissingRequired(schemaDoc, doc, schemaDoc, "", elements);
+            collectMissingRequired(schemaDoc, doc, schemaDoc, "$", "#", elements);
 
             if (elements.empty())
             {
                 // Validation failed for a reason other than a missing required property
-                // (type mismatch, enum, range). Report the failing keyword and location
-                // so the event still says something useful.
-                rapidjson::StringBuffer sb;
+                rapidjson::StringBuffer docSb;
+                rapidjson::StringBuffer schemaSb;
                 const char *keyword = validator.GetInvalidSchemaKeyword();
-                validator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
-                elements.emplace_back(std::string(keyword ? keyword : "unknown") + " at " +
-                                      trimInstanceRef(sb.GetString()));
+                validator.GetInvalidDocumentPointer().StringifyUriFragment(docSb);
+                validator.GetInvalidSchemaPointer().StringifyUriFragment(schemaSb);
+                elements.emplace_back(std::string(docSb.GetString()) + " failed " +
+                                      (keyword ? keyword : "validation") + " (" +
+                                      schemaSb.GetString() + ")");
             }
 
             for (const auto &element : elements)
             {
-                PLOG(logWARNING) << messageType << " field validation failure: missing " << element.value;
+                PLOG(logWARNING) << messageType << " field validation failure: " << element.value;
             }
 
             uint64_t handlerEndMs = PluginClientClockAware::getClock()->nowInMilliseconds();

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -22,7 +22,6 @@
 
 #include <ctime>
 #include <cstdio>
-#include <rapidjson/pointer.h>
 
 using namespace tmx;
 using namespace tmx::utils;
@@ -46,153 +45,6 @@ namespace
         std::ostringstream out;
         out << buf.data() << '.' << std::setfill('0') << std::setw(3) << millis << 'Z';
         return out.str();
-    }
-
-    // Resolve a local "#/..." $ref against the root schema. Returns nullptr for
-    // external or unresolvable refs.
-    const rapidjson::Value *resolveRef(const rapidjson::Value &node,
-                                       const rapidjson::Document &schemaRoot)
-    {
-        auto ref = node.FindMember("$ref");
-        if (ref == node.MemberEnd() || !ref->value.IsString())
-        {
-            return &node;
-        }
-
-        const std::string refStr = ref->value.GetString();
-        if (refStr.empty() || refStr[0] != '#')
-        {
-            return nullptr;
-        }
-        if (refStr == "#")
-        {
-            return &schemaRoot;
-        }
-        return rapidjson::Pointer(refStr.substr(1).c_str()).Get(schemaRoot);
-    }
-
-    // Recursively compare the document against the schema and collect every required
-    // property that is absent
-    void collectMissingRequired(const rapidjson::Value &schemaNode,
-                                const rapidjson::Value &instance,
-                                const rapidjson::Document &schemaRoot,
-                                const std::string &jsonPath,
-                                const std::string &schemaPath,
-                                std::vector<MissingDataElement> &out,
-                                int depth = 0)
-    {
-        constexpr int MAX_DEPTH = 64; // guards against $ref cycles
-        if (depth > MAX_DEPTH)
-        {
-            return;
-        }
-
-        // Following a $ref re-bases the reported schema reference on the ref target,
-        // so entries cite "#/$defs/J2735TimeMark" rather than the full inline path.
-        std::string resolvedSchemaPath = schemaPath;
-        if (schemaNode.IsObject())
-        {
-            auto ref = schemaNode.FindMember("$ref");
-            if (ref != schemaNode.MemberEnd() && ref->value.IsString())
-            {
-                resolvedSchemaPath = ref->value.GetString();
-            }
-        }
-
-        const rapidjson::Value *schema = resolveRef(schemaNode, schemaRoot);
-        if (schema == nullptr || !schema->IsObject())
-        {
-            return;
-        }
-
-        if (instance.IsObject())
-        {
-            auto properties = schema->FindMember("properties");
-
-            // Required properties absent from this object
-            auto required = schema->FindMember("required");
-            if (required != schema->MemberEnd() && required->value.IsArray())
-            {
-                for (const auto &name : required->value.GetArray())
-                {
-                    if (!name.IsString() || instance.HasMember(name.GetString()))
-                    {
-                        continue;
-                    }
-
-                    // Prefer the missing property's own schema reference
-                    std::string elementSchemaPath =
-                        resolvedSchemaPath + "/properties/" + name.GetString();
-                    if (properties != schema->MemberEnd() && properties->value.IsObject())
-                    {
-                        auto propSchema = properties->value.FindMember(name.GetString());
-                        if (propSchema != properties->value.MemberEnd() &&
-                            propSchema->value.IsObject())
-                        {
-                            auto propRef = propSchema->value.FindMember("$ref");
-                            if (propRef != propSchema->value.MemberEnd() &&
-                                propRef->value.IsString())
-                            {
-                                elementSchemaPath = propRef->value.GetString();
-                            }
-                        }
-                    }
-
-                    out.emplace_back(jsonPath + "." + name.GetString() +
-                                     " is missing (" + elementSchemaPath + ")");
-                }
-            }
-
-            // Descend into the properties that are actually present
-            if (properties != schema->MemberEnd() && properties->value.IsObject())
-            {
-                for (auto it = properties->value.MemberBegin();
-                     it != properties->value.MemberEnd(); ++it)
-                {
-                    auto child = instance.FindMember(it->name);
-                    if (child != instance.MemberEnd())
-                    {
-                        collectMissingRequired(it->value, child->value, schemaRoot,
-                                               jsonPath + "." + it->name.GetString(),
-                                               resolvedSchemaPath + "/properties/" +
-                                                   it->name.GetString(),
-                                               out, depth + 1);
-                    }
-                }
-            }
-        }
-
-        // Descend into array elements
-        if (instance.IsArray())
-        {
-            auto items = schema->FindMember("items");
-            if (items != schema->MemberEnd() && items->value.IsObject())
-            {
-                rapidjson::SizeType index = 0;
-                for (const auto &element : instance.GetArray())
-                {
-                    collectMissingRequired(items->value, element, schemaRoot,
-                                           jsonPath + "[" + std::to_string(index) + "]",
-                                           resolvedSchemaPath + "/items",
-                                           out, depth + 1);
-                    ++index;
-                }
-            }
-        }
-
-        // allOf applies every subschema, so its required constraints all hold
-        auto allOf = schema->FindMember("allOf");
-        if (allOf != schema->MemberEnd() && allOf->value.IsArray())
-        {
-            rapidjson::SizeType index = 0;
-            for (const auto &sub : allOf->value.GetArray())
-            {
-                collectMissingRequired(sub, instance, schemaRoot, jsonPath,
-                                       resolvedSchemaPath + "/allOf/" + std::to_string(index),
-                                       out, depth + 1);
-                ++index;
-            }
-        }
     }
 }
 
@@ -353,10 +205,13 @@ namespace IntersectionValidation
 
         if (!doc.Accept(validator))
         {
-            // One entry per missing element, formatted to match conflictmonitor's own
-            // minimum-data strings.
+            // Enumerate every missing required element then
+            // wrap the JSON-path strings into MissingDataElement for the event.
             std::vector<MissingDataElement> elements;
-            collectMissingRequired(schemaDoc, doc, schemaDoc, "$", "#", elements);
+            for (const auto &field : IntersectionValidation::collectMissingRequiredFields(schemaDoc, doc))
+            {
+                elements.emplace_back(field);
+            }
 
             if (elements.empty())
             {

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -22,6 +22,7 @@
 
 #include <ctime>
 #include <cstdio>
+#include <rapidjson/pointer.h>
 
 using namespace tmx;
 using namespace tmx::utils;
@@ -47,6 +48,144 @@ namespace
         return out.str();
     }
 
+    // Turn a rapidjson instanceRef ("#/value/SPAT/intersections/0/states/0/timing")
+    // into a path relative to the message body ("intersections/0/states/0/timing"),
+    // so a reported element reads as a location an operator can find in the message.
+    std::string trimInstanceRef(const std::string &instanceRef)
+    {
+        std::string path = instanceRef;
+        if (path.rfind("#/", 0) == 0)
+        {
+            path.erase(0, 2);
+        }
+        else if (path == "#")
+        {
+            path.clear();
+        }
+
+        for (const std::string &prefix : {std::string("value/SPAT/"), std::string("value/MapData/")})
+        {
+            if (path.rfind(prefix, 0) == 0)
+            {
+                path.erase(0, prefix.size());
+                break;
+            }
+        }
+        return path;
+    }
+
+    // Resolve a local "#/..." $ref against the root schema. Returns nullptr for
+    // external or unresolvable refs.
+    const rapidjson::Value *resolveRef(const rapidjson::Value &node,
+                                       const rapidjson::Document &schemaRoot)
+    {
+        auto ref = node.FindMember("$ref");
+        if (ref == node.MemberEnd() || !ref->value.IsString())
+        {
+            return &node;
+        }
+
+        const std::string refStr = ref->value.GetString();
+        if (refStr.empty() || refStr[0] != '#')
+        {
+            return nullptr;
+        }
+        if (refStr == "#")
+        {
+            return &schemaRoot;
+        }
+        return rapidjson::Pointer(refStr.substr(1).c_str()).Get(schemaRoot);
+    }
+
+    // Recursively compare the document against the schema and collect every required
+    // property that is absent, as "path/to/object/fieldName".
+    //
+    // conflictmonitor's missingDataElements is a list of the absent elements, not a
+    // single validator diagnostic. rapidjson 1.1.0 has no continue-on-error, so the
+    // validator only reports the first failure; walking the schema ourselves reports
+    // all of them. anyOf/oneOf are deliberately not descended into: which branch was
+    // intended is ambiguous, so reporting from them would produce false positives.
+    void collectMissingRequired(const rapidjson::Value &schemaNode,
+                                const rapidjson::Value &instance,
+                                const rapidjson::Document &schemaRoot,
+                                const std::string &path,
+                                std::vector<MissingDataElement> &out,
+                                int depth = 0)
+    {
+        constexpr int MAX_DEPTH = 64; // guards against $ref cycles
+        if (depth > MAX_DEPTH)
+        {
+            return;
+        }
+
+        const rapidjson::Value *schema = resolveRef(schemaNode, schemaRoot);
+        if (schema == nullptr || !schema->IsObject())
+        {
+            return;
+        }
+
+        // Required properties absent from this object
+        if (instance.IsObject())
+        {
+            auto required = schema->FindMember("required");
+            if (required != schema->MemberEnd() && required->value.IsArray())
+            {
+                for (const auto &name : required->value.GetArray())
+                {
+                    if (name.IsString() && !instance.HasMember(name.GetString()))
+                    {
+                        out.emplace_back(path.empty()
+                                             ? std::string(name.GetString())
+                                             : path + "/" + name.GetString());
+                    }
+                }
+            }
+
+            // Descend into the properties that are actually present
+            auto properties = schema->FindMember("properties");
+            if (properties != schema->MemberEnd() && properties->value.IsObject())
+            {
+                for (auto it = properties->value.MemberBegin();
+                     it != properties->value.MemberEnd(); ++it)
+                {
+                    auto child = instance.FindMember(it->name);
+                    if (child != instance.MemberEnd())
+                    {
+                        const std::string childPath =
+                            path.empty() ? it->name.GetString() : path + "/" + it->name.GetString();
+                        collectMissingRequired(it->value, child->value, schemaRoot,
+                                               childPath, out, depth + 1);
+                    }
+                }
+            }
+        }
+
+        // Descend into array elements
+        if (instance.IsArray())
+        {
+            auto items = schema->FindMember("items");
+            if (items != schema->MemberEnd() && items->value.IsObject())
+            {
+                rapidjson::SizeType index = 0;
+                for (const auto &element : instance.GetArray())
+                {
+                    collectMissingRequired(items->value, element, schemaRoot,
+                                           path + "/" + std::to_string(index), out, depth + 1);
+                    ++index;
+                }
+            }
+        }
+
+        // allOf applies every subschema, so its required constraints all hold
+        auto allOf = schema->FindMember("allOf");
+        if (allOf != schema->MemberEnd() && allOf->value.IsArray())
+        {
+            for (const auto &sub : allOf->value.GetArray())
+            {
+                collectMissingRequired(sub, instance, schemaRoot, path, out, depth + 1);
+            }
+        }
+    }
 }
 
 namespace IntersectionValidation
@@ -206,26 +345,28 @@ namespace IntersectionValidation
 
         if (!doc.Accept(validator))
         {
-            // Build error string with keyword, document path, and schema path
-            rapidjson::StringBuffer sb;
+            // One entry per missing element, e.g. "intersections/0/states/0/timing/minEndTime"
+            std::vector<MissingDataElement> elements;
+            collectMissingRequired(schemaDoc, doc, schemaDoc, "", elements);
 
-            const char *keyword = validator.GetInvalidSchemaKeyword();
-            std::string error = "Schema validation failed: keyword=";
-            error += keyword ? keyword : "unknown";
+            if (elements.empty())
+            {
+                // Validation failed for a reason other than a missing required property
+                // (type mismatch, enum, range). Report the failing keyword and location
+                // so the event still says something useful.
+                rapidjson::StringBuffer sb;
+                const char *keyword = validator.GetInvalidSchemaKeyword();
+                validator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
+                elements.emplace_back(std::string(keyword ? keyword : "unknown") + " at " +
+                                      trimInstanceRef(sb.GetString()));
+            }
 
-            validator.GetInvalidDocumentPointer().StringifyUriFragment(sb);
-            error += ", document_path=" + std::string(sb.GetString());
-            sb.Clear();
-
-            validator.GetInvalidSchemaPointer().StringifyUriFragment(sb);
-            error += ", schema_path=" + std::string(sb.GetString());
-
-            PLOG(logWARNING) << messageType << " field validation failure: " << error;
+            for (const auto &element : elements)
+            {
+                PLOG(logWARNING) << messageType << " field validation failure: missing " << element.value;
+            }
 
             uint64_t handlerEndMs = PluginClientClockAware::getClock()->nowInMilliseconds();
-
-            std::vector<MissingDataElement> elements;
-            elements.emplace_back(error);
 
             CTI4501ValidationMessage eventMsg;
             eventMsg.set_eventGeneratedAt(handlerEndMs);

--- a/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
@@ -5634,7 +5634,6 @@ namespace
     EXPECT_FALSE(change.progressionViolation);
   }
 
-
   rapidjson::Document parse(const char *json)
   {
     rapidjson::Document doc;
@@ -5726,7 +5725,7 @@ TEST(RefOrTest, ReturnsFallbackWhenNoRef)
 
 TEST(RefOrTest, ReturnsFallbackWhenNotObject)
 {
-  rapidjson::Document node = parse(R"("just a string")");l
+  rapidjson::Document node = parse(R"("just a string")");
   EXPECT_EQ(refOr(node, "fallback"), "fallback");
 }
  

--- a/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
@@ -5634,4 +5634,318 @@ namespace
     EXPECT_FALSE(change.progressionViolation);
   }
 
+
+  rapidjson::Document parse(const char *json)
+  {
+    rapidjson::Document doc;
+    doc.Parse(json);
+    EXPECT_FALSE(doc.HasParseError()) << "test fixture JSON failed to parse: " << json;
+    return doc;
+  }
+ 
+  // True if any collected element string contains the given substring.
+  bool contains(const std::vector<std::string> &elements, const std::string &needle)
+  {
+    return std::any_of(elements.begin(), elements.end(),
+                      [&](const std::string &e) { return e.find(needle) != std::string::npos; });
+  }
+
+  // Tests for helper functions for populating MinimumDataEvent 
+  TEST(ResolveRefTest, ReturnsNodeItselfWhenNoRef)
+  {
+    rapidjson::Document root = parse(R"({"type": "object"})");
+    rapidjson::Document node = parse(R"({"type": "string"})");
+ 
+    const rapidjson::Value *resolved = resolveRef(node, root);
+ 
+    EXPECT_NE(resolved, nullptr);
+    EXPECT_EQ(resolved, &node); // same node returned, not a copy
+}
+ 
+TEST(ResolveRefTest, ResolvesLocalPointerAgainstRoot)
+{
+    rapidjson::Document root = parse(R"({
+        "definitions": { "Foo": { "type": "integer" } }
+    })");
+    rapidjson::Document node = parse(R"({"$ref": "#/definitions/Foo"})");
+ 
+    const rapidjson::Value *resolved = resolveRef(node, root);
+ 
+    EXPECT_NE(resolved, nullptr);
+    EXPECT_TRUE(resolved->IsObject());
+    EXPECT_TRUE(resolved->HasMember("type"));
+    EXPECT_STREQ((*resolved)["type"].GetString(), "integer");
+}
+ 
+TEST(ResolveRefTest, RootPointerReturnsRoot)
+{
+    rapidjson::Document root = parse(R"({"type": "object"})");
+    rapidjson::Document node = parse(R"({"$ref": "#"})");
+ 
+    const rapidjson::Value *resolved = resolveRef(node, root);
+ 
+    EXPECT_EQ(resolved, &root);
+}
+ 
+TEST(ResolveRefTest, ExternalRefReturnsNull)
+{
+  rapidjson::Document root = parse(R"({"type": "object"})");
+  rapidjson::Document node = parse(R"({"$ref": "other.json#/Foo"})");
+ 
+  EXPECT_EQ(resolveRef(node, root), nullptr);
+}
+ 
+TEST(ResolveRefTest, UnresolvableLocalPointerReturnsNull)
+{
+  rapidjson::Document root = parse(R"({"definitions": {}})");
+  rapidjson::Document node = parse(R"({"$ref": "#/definitions/DoesNotExist"})");
+ 
+  EXPECT_EQ(resolveRef(node, root), nullptr);
+}
+ 
+TEST(ResolveRefTest, NonStringRefIsTreatedAsNoRef)
+{
+  rapidjson::Document root = parse(R"({"type": "object"})");
+  rapidjson::Document node = parse(R"({"$ref": 42})");
+ 
+  // A non-string $ref is ignored; the node itself is returned.
+  EXPECT_EQ(resolveRef(node, root), &node);
+}
+ 
+TEST(RefOrTest, ReturnsRefStringWhenPresent)
+{
+    rapidjson::Document node = parse(R"({"$ref": "#/$defs/J2735TimeMark"})");
+    EXPECT_EQ(refOr(node, "fallback"), "#/$defs/J2735TimeMark");
+}
+ 
+TEST(RefOrTest, ReturnsFallbackWhenNoRef)
+{
+  rapidjson::Document node = parse(R"({"type": "integer"})");
+  EXPECT_EQ(refOr(node, "fallback/path"), "fallback/path");
+}
+
+TEST(RefOrTest, ReturnsFallbackWhenNotObject)
+{
+  rapidjson::Document node = parse(R"("just a string")");l
+  EXPECT_EQ(refOr(node, "fallback"), "fallback");
+}
+ 
+TEST(PropertySchemaRefTest, ReturnsPropertyRefWhenDeclared)
+{
+  rapidjson::Document schema = parse(R"({
+    "properties": { "startTime": { "$ref": "#/$defs/TimeMark" } }
+  })");
+  EXPECT_EQ(propertySchemaRef(schema, "startTime", "fallback"),
+    "#/$defs/TimeMark");
+}
+ 
+TEST(PropertySchemaRefTest, ReturnsFallbackWhenPropertyHasNoRef)
+{
+  rapidjson::Document schema = parse(R"({
+  "properties": { "startTime": { "type": "integer" } }
+    })");
+  EXPECT_EQ(propertySchemaRef(schema, "startTime", "inline/path"),
+    "inline/path");
+}
+ 
+TEST(PropertySchemaRefTest, ReturnsFallbackWhenPropertyMissing)
+{
+  rapidjson::Document schema = parse(R"({
+        "properties": { "other": { "type": "integer" } }
+  })");
+  EXPECT_EQ(propertySchemaRef(schema, "startTime", "inline/path"),
+        "inline/path");
+}
+ 
+TEST(CollectMissingRequiredFieldsTest, EmptyWhenAllRequiredPresent)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object",
+        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+        "required": ["a", "b"]
+    })");
+    rapidjson::Document doc = parse(R"({"a": 1, "b": 2})");
+
+    EXPECT_TRUE(collectMissingRequiredFields(schema, doc).empty());
+}
+
+TEST(CollectMissingRequiredFieldsTest, ReportsSingleMissingTopLevel)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object",
+        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+        "required": ["a", "b"]
+    })");
+    rapidjson::Document doc = parse(R"({"a": 1})");
+
+    auto missing = collectMissingRequiredFields(schema, doc);
+
+    ASSERT_EQ(missing.size(), 1u);
+    EXPECT_TRUE(contains(missing, "$.b is missing"));
+}
+
+TEST(CollectMissingRequiredFieldsTest, ReportsAllMissingNotJustFirst)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object",
+        "properties": { "a": {}, "b": {}, "c": {} },
+        "required": ["a", "b", "c"]
+    })");
+    rapidjson::Document doc = parse(R"({"b": 2})");
+
+    auto missing = collectMissingRequiredFields(schema, doc);
+
+    EXPECT_EQ(missing.size(), 2u);
+    EXPECT_TRUE(contains(missing, "$.a is missing"));
+    EXPECT_TRUE(contains(missing, "$.c is missing"));
+}
+
+TEST(CollectMissingRequiredFieldsTest, DescendsIntoNestedObjects)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "object",
+                "properties": { "region": {}, "id": {} },
+                "required": ["id"]
+            }
+        },
+        "required": ["id"]
+    })");
+    rapidjson::Document doc = parse(R"({"id": {"region": 1}})");
+
+    auto missing = collectMissingRequiredFields(schema, doc);
+
+    ASSERT_EQ(missing.size(), 1u);
+    EXPECT_TRUE(contains(missing, "$.id.id is missing"));
+}
+
+TEST(CollectMissingRequiredFieldsTest, DescendsIntoArrayItemsWithIndex)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object",
+        "properties": {
+            "states": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": { "eventState": {}, "timing": {} },
+                    "required": ["eventState", "timing"]
+                }
+            }
+        },
+        "required": ["states"]
+    })");
+
+    rapidjson::Document doc = parse(R"({
+        "states": [
+            {"eventState": "stop", "timing": {}},
+            {"eventState": "go"}
+        ]
+    })");
+
+    auto missing = collectMissingRequiredFields(schema, doc);
+
+    ASSERT_EQ(missing.size(), 1u);
+    EXPECT_TRUE(contains(missing, "$.states[1].timing is missing"));
+}
+
+TEST(CollectMissingRequiredFieldsTest, ProducesConflictMonitorStyleString)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object",
+        "properties": {
+            "value": {
+                "type": "object",
+                "properties": {
+                    "SPAT": {
+                        "type": "object",
+                        "properties": { "timeStamp": {}, "intersections": {} },
+                        "required": ["timeStamp", "intersections"]
+                    }
+                },
+                "required": ["SPAT"]
+            }
+        },
+        "required": ["value"]
+    })");
+    rapidjson::Document doc = parse(R"({"value": {"SPAT": {"timeStamp": 1}}})");
+
+    auto missing = collectMissingRequiredFields(schema, doc);
+
+    ASSERT_EQ(missing.size(), 1u);
+    // Full expected string, path + schema-pointer citation.
+    EXPECT_EQ(missing.front(),
+              "$.value.SPAT.intersections is missing "
+              "(#/properties/value/properties/SPAT/properties/intersections)");
+}
+
+TEST(HandleObjectTest, NoOpForNonObjectInstance)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object", "properties": { "a": {} }, "required": ["a"]
+    })");
+    rapidjson::Document instance = parse(R"([1, 2, 3])"); // array, not object
+
+    std::vector<std::string> out;
+    handleObject(schema, instance, schema, "$", "#", out, 0);
+
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(HandleObjectTest, CollectsMissingAndRecursesPresent)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object",
+        "properties": {
+            "a": {},
+            "nested": {
+                "type": "object",
+                "properties": { "x": {} },
+                "required": ["x"]
+            }
+        },
+        "required": ["a", "nested"]
+    })");
+    // "a" missing; "nested" present but missing its required "x".
+    rapidjson::Document instance = parse(R"({"nested": {}})");
+
+    std::vector<std::string> out;
+    handleObject(schema, instance, schema, "$", "#", out, 0);
+
+    EXPECT_EQ(out.size(), 2u);
+    EXPECT_TRUE(contains(out, "$.a is missing"));
+    EXPECT_TRUE(contains(out, "$.nested.x is missing"));
+}
+
+TEST(CollectMissingRequiredTest, DepthGuardStopsRecursion)
+{
+    // Passing a depth over the cap short-circuits before any collection.
+    rapidjson::Document schema = parse(R"({
+        "type": "object", "properties": { "a": {} }, "required": ["a"]
+    })");
+    rapidjson::Document doc = parse(R"({})");
+
+    std::vector<std::string> out;
+    collectMissingRequired(schema, doc, schema, "$", "#", out, /*depth=*/1000);
+
+    EXPECT_TRUE(out.empty());
+}
+ 
+TEST(CollectMissingRequiredTest, DefaultDepthCollectsNormally)
+{
+    rapidjson::Document schema = parse(R"({
+        "type": "object", "properties": { "a": {} }, "required": ["a"]
+    })");
+    rapidjson::Document doc = parse(R"({})");
+
+    std::vector<std::string> out;
+    collectMissingRequired(schema, doc, schema, "$", "#", out); // default depth 0
+
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_TRUE(contains(out, "$.a is missing"));
+}
+
+
 } // namespace

--- a/src/v2i-hub/ODEForwardPlugin/CMakeLists.txt
+++ b/src/v2i-hub/ODEForwardPlugin/CMakeLists.txt
@@ -11,7 +11,7 @@ TARGET_LINK_LIBRARIES (${PROJECT_NAME} tmxutils rdkafka++)
 #############
 enable_testing()
 add_library(${PROJECT_NAME}_lib 
-    src/UDPMessageForwarder.cpp)
+    src/UDPMessageForwarder.cpp src/ODEForwardConversion.cpp)
 target_link_libraries(${PROJECT_NAME}_lib PUBLIC tmxutils)
 target_include_directories(${PROJECT_NAME}_lib PUBLIC ${PROJECT_SOURCE_DIR}/src)
 

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardConversion.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardConversion.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include "ODEForwardConversion.h"
+
+#include <cstdint>
+#include <exception>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+namespace ODEForwardPlugin
+{
+
+	void toNumber(rapidjson::Value &parent, const std::vector<std::string> &fields,
+	              const ConversionWarningLog &warn)
+	{
+		for (const auto &field : fields)
+		{
+			auto it = parent.FindMember(field.c_str());
+			if (it == parent.MemberEnd() || !it->value.IsString())
+			{
+				continue;
+			}
+
+			const std::string raw = it->value.GetString();
+			try
+			{
+				size_t consumed = 0;
+				const int64_t parsed = std::stoll(raw, &consumed);
+				// Only replace on a clean, complete parse; leave anything else as-is.
+				if (consumed == raw.size())
+				{
+					it->value.SetInt64(parsed);
+				}
+			}
+			catch (const std::exception &e)
+			{
+				// Not an integer (invalid_argument / out_of_range)
+				if (warn)
+				{
+					warn("Failed to convert field '" + field + "' to number: " + e.what());
+				}
+			}
+		}
+	}
+
+	std::string convertToNum(const std::string &json, const ConversionWarningLog &warn)
+	{
+		static const std::vector<std::string> numericFields {
+			"eventGeneratedAt", "intersectionID", "roadRegulatorID",
+			"numberOfMessages", "messageCountA", "messageCountB"
+		};
+		static const std::vector<std::string> timePeriodFields { "beginTimestamp", "endTimestamp" };
+
+		rapidjson::Document doc;
+		doc.Parse(json.c_str());
+		if (doc.HasParseError() || !doc.IsObject())
+		{
+			return json;
+		}
+
+		toNumber(doc, numericFields, warn);
+
+		auto timePeriod = doc.FindMember("timePeriod");
+		if (timePeriod != doc.MemberEnd() && timePeriod->value.IsObject())
+		{
+			toNumber(timePeriod->value, timePeriodFields, warn);
+		}
+
+		rapidjson::StringBuffer buffer;
+		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+		doc.Accept(writer);
+		return buffer.GetString();
+	}
+
+} /* namespace ODEForwardPlugin */

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardConversion.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardConversion.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#pragma once
+#include <functional>
+#include <string>
+#include <vector>
+#include <rapidjson/document.h>
+
+namespace ODEForwardPlugin
+{
+
+	/**
+	 * @brief Object for warning when conversion to number fails 
+	 */
+	using ConversionWarningLog = std::function<void(const std::string &)>;
+
+	/**
+	 * @brief Convert the named string fields of @p parent to integers in place.
+	 * @param parent The JSON object whose fields may be converted.
+	 * @param fields The names of the fields to attempt to convert.
+	 * @param warn Object invoked once per field that throws during parsing
+	 */
+	void toNumber(rapidjson::Value &parent, const std::vector<std::string> &fields,
+	              const ConversionWarningLog &warn = {});
+
+	/**
+	 * @brief Convert TMX's all-string CTI 4501 event JSON into correctly typed numbers.
+	 * @param json The validation-event JSON payload as emitted by TMX.
+	 * @param warn Object for per-field conversion-failure messages.
+	 * @return The JSON with numeric fields typed as numbers, or the input unchanged on parse failure.
+	 */
+	std::string convertToNum(const std::string &json, const ConversionWarningLog &warn = {});
+
+} /* namespace ODEForwardPlugin */

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
@@ -16,6 +16,13 @@
 
 
 #include "ODEForwardPlugin.h"
+
+#include <string>
+#include <vector>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
 using namespace std;
 using namespace tmx;
 using namespace tmx::utils;
@@ -216,6 +223,60 @@ namespace ODEForwardPlugin
 		}
 	}
 
+	std::string ODEForwardPlugin::convertToNum(const std::string &json) const {
+		static const std::vector<std::string> numericFields {
+			"eventGeneratedAt", "intersectionID", "roadRegulatorID",
+			"numberOfMessages", "messageCountA", "messageCountB"
+		};
+		static const std::vector<std::string> timePeriodFields { "beginTimestamp", "endTimestamp" };
+
+		rapidjson::Document doc;
+		doc.Parse(json.c_str());
+		if (doc.HasParseError() || !doc.IsObject())
+		{
+			return json;
+		}
+
+		auto toNumber = [](rapidjson::Value &parent, const std::vector<std::string> &fields) {
+			for (const auto &field : fields)
+			{
+				auto member = parent.FindMember(field.c_str());
+				if (member == parent.MemberEnd() || !member->value.IsString())
+				{
+					continue;
+				}
+				const std::string raw = member->value.GetString();
+				try
+				{
+					size_t consumed = 0;
+					const int64_t parsed = std::stoll(raw, &consumed);
+					// Only replace on a clean, complete parse; leave anything else as-is.
+					if (consumed == raw.size())
+					{
+						member->value.SetInt64(parsed);
+					}
+				}
+				catch (const std::exception &)
+				{
+					// Not an integer; leave the original string in place.
+				}
+			}
+		};
+
+		toNumber(doc, numericFields);
+
+		auto timePeriod = doc.FindMember("timePeriod");
+		if (timePeriod != doc.MemberEnd() && timePeriod->value.IsObject())
+		{
+			toNumber(timePeriod->value, timePeriodFields);
+		}
+
+		rapidjson::StringBuffer buffer;
+		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+		doc.Accept(writer);
+		return buffer.GetString();
+	}
+
 	void ODEForwardPlugin::HandleValidationEvent(CTI4501ValidationMessage &msg, routeable_message &routeableMsg) {
 		const std::string eventType = msg.get_eventType();
 
@@ -241,8 +302,8 @@ namespace ODEForwardPlugin
 		}
 
 		try {
-			// Forward the payload unchanged
-			const std::string payload = routeableMsg.get_payload_str();
+			// Convert TMX's all-string values into correctly typed JSON numbers
+			const std::string payload = convertToNum(routeableMsg.get_payload_str());
 			_kafkaProducer->send(payload, it->second);
 			PLOG(logDEBUG) << "Forwarded validation event '" << eventType
 			               << "' to Kafka topic '" << it->second << "'.";

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
@@ -19,9 +19,9 @@
 
 #include <string>
 #include <vector>
-#include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
+// #include <rapidjson/document.h>
+// #include <rapidjson/stringbuffer.h>
+// #include <rapidjson/writer.h>
 
 using namespace std;
 using namespace tmx;
@@ -223,6 +223,37 @@ namespace ODEForwardPlugin
 		}
 	}
 
+	// Convert the numerical strings to integers
+	void ODEForwardPlugin::toNumber(rapidjson::Value &parent, const std::vector<std::string> &fields) const
+	{
+		for (const auto &field : fields)
+		{
+			auto it = parent.FindMember(field.c_str());
+			if (it == parent.MemberEnd() || !it->value.IsString())
+			{
+				continue;
+			}
+
+			const std::string raw = it->value.GetString();
+			try
+			{
+				size_t consumed = 0;
+				const int64_t parsed = std::stoll(raw, &consumed);
+				// Only replace on a clean, complete parse; leave anything else as-is.
+				if (consumed == raw.size())
+				{
+					it->value.SetInt64(parsed);
+				}
+			}
+			catch (const std::exception &e)
+			{
+				PLOG(logWARNING) << "Failed to convert field '" << field
+					             << "' to number: " << e.what();
+				// Not an integer; leave the original string in place.
+			}
+		}
+	}
+
 	std::string ODEForwardPlugin::convertToNum(const std::string &json) const {
 		static const std::vector<std::string> numericFields {
 			"eventGeneratedAt", "intersectionID", "roadRegulatorID",
@@ -237,36 +268,10 @@ namespace ODEForwardPlugin
 			return json;
 		}
 
-		auto toNumber = [](rapidjson::Value &parent, const std::vector<std::string> &fields) {
-			for (const auto &field : fields)
-			{
-				auto member = parent.FindMember(field.c_str());
-				if (member == parent.MemberEnd() || !member->value.IsString())
-				{
-					continue;
-				}
-				const std::string raw = member->value.GetString();
-				try
-				{
-					size_t consumed = 0;
-					const int64_t parsed = std::stoll(raw, &consumed);
-					// Only replace on a clean, complete parse; leave anything else as-is.
-					if (consumed == raw.size())
-					{
-						member->value.SetInt64(parsed);
-					}
-				}
-				catch (const std::exception &)
-				{
-					// Not an integer; leave the original string in place.
-				}
-			}
-		};
-
 		toNumber(doc, numericFields);
 
-		auto timePeriod = doc.FindMember("timePeriod");
-		if (timePeriod != doc.MemberEnd() && timePeriod->value.IsObject())
+		if (auto timePeriod = doc.FindMember("timePeriod"); timePeriod != doc.MemberEnd() 
+															&& timePeriod->value.IsObject())
 		{
 			toNumber(timePeriod->value, timePeriodFields);
 		}

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
@@ -19,9 +19,6 @@
 
 #include <string>
 #include <vector>
-// #include <rapidjson/document.h>
-// #include <rapidjson/stringbuffer.h>
-// #include <rapidjson/writer.h>
 
 using namespace std;
 using namespace tmx;

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.cpp
@@ -18,7 +18,6 @@
 #include "ODEForwardPlugin.h"
 
 #include <string>
-#include <vector>
 
 using namespace std;
 using namespace tmx;
@@ -220,65 +219,6 @@ namespace ODEForwardPlugin
 		}
 	}
 
-	// Convert the numerical strings to integers
-	void ODEForwardPlugin::toNumber(rapidjson::Value &parent, const std::vector<std::string> &fields) const
-	{
-		for (const auto &field : fields)
-		{
-			auto it = parent.FindMember(field.c_str());
-			if (it == parent.MemberEnd() || !it->value.IsString())
-			{
-				continue;
-			}
-
-			const std::string raw = it->value.GetString();
-			try
-			{
-				size_t consumed = 0;
-				const int64_t parsed = std::stoll(raw, &consumed);
-				// Only replace on a clean, complete parse; leave anything else as-is.
-				if (consumed == raw.size())
-				{
-					it->value.SetInt64(parsed);
-				}
-			}
-			catch (const std::exception &e)
-			{
-				PLOG(logWARNING) << "Failed to convert field '" << field
-					             << "' to number: " << e.what();
-				// Not an integer; leave the original string in place.
-			}
-		}
-	}
-
-	std::string ODEForwardPlugin::convertToNum(const std::string &json) const {
-		static const std::vector<std::string> numericFields {
-			"eventGeneratedAt", "intersectionID", "roadRegulatorID",
-			"numberOfMessages", "messageCountA", "messageCountB"
-		};
-		static const std::vector<std::string> timePeriodFields { "beginTimestamp", "endTimestamp" };
-
-		rapidjson::Document doc;
-		doc.Parse(json.c_str());
-		if (doc.HasParseError() || !doc.IsObject())
-		{
-			return json;
-		}
-
-		toNumber(doc, numericFields);
-
-		if (auto timePeriod = doc.FindMember("timePeriod"); timePeriod != doc.MemberEnd() 
-															&& timePeriod->value.IsObject())
-		{
-			toNumber(timePeriod->value, timePeriodFields);
-		}
-
-		rapidjson::StringBuffer buffer;
-		rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-		doc.Accept(writer);
-		return buffer.GetString();
-	}
-
 	void ODEForwardPlugin::HandleValidationEvent(CTI4501ValidationMessage &msg, routeable_message &routeableMsg) {
 		const std::string eventType = msg.get_eventType();
 
@@ -305,7 +245,9 @@ namespace ODEForwardPlugin
 
 		try {
 			// Convert TMX's all-string values into correctly typed JSON numbers
-			const std::string payload = convertToNum(routeableMsg.get_payload_str());
+			const std::string payload = convertToNum(
+				routeableMsg.get_payload_str(),
+				[this](const std::string &m) { PLOG(logWARNING) << m; });
 			_kafkaProducer->send(payload, it->second);
 			PLOG(logDEBUG) << "Forwarded validation event '" << eventType
 			               << "' to Kafka topic '" << it->second << "'.";

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
@@ -30,6 +30,7 @@
 #include <map>
 #include <mutex>
 #include <memory>
+#include <vector>
 #include <boost/algorithm/string.hpp>
 #include <tmx/messages/IvpJ2735.h>
 #include <tmx/j2735_messages/BasicSafetyMessage.hpp>
@@ -46,6 +47,7 @@
 #include <rapidjson/writer.h>
 #include "UDPMessageForwarder.h"
 #include "CTI4501ValidationMessage.h"
+#include "ODEForwardConversion.h"
 
  
 
@@ -86,10 +88,6 @@ namespace ODEForwardPlugin
 		private:
 
 			void sendUDPMessage(tmx::routeable_message &routeableMsg, UDPMessageType udpMessageType) const;
-
-			void toNumber(rapidjson::Value &parent, const std::vector<std::string> &fields) const;
-
-			std::string convertToNum(const std::string &json) const;
 
 
 			// Forwarded/skipped counters for one message stream

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
@@ -84,6 +84,8 @@ namespace ODEForwardPlugin
 
 			void sendUDPMessage(tmx::routeable_message &routeableMsg, UDPMessageType udpMessageType) const;
 
+			std::string convertToNum(const std::string &json) const;
+
 
 			// Forwarded/skipped counters for one message stream
 			struct ForwardStats

--- a/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
+++ b/src/v2i-hub/ODEForwardPlugin/src/ODEForwardPlugin.h
@@ -41,6 +41,9 @@
 #include <tmx/json/cJSON.h>
 #include <environment/EnvUtils.h>
 #include <kafka/kafka_client.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 #include "UDPMessageForwarder.h"
 #include "CTI4501ValidationMessage.h"
 
@@ -83,6 +86,8 @@ namespace ODEForwardPlugin
 		private:
 
 			void sendUDPMessage(tmx::routeable_message &routeableMsg, UDPMessageType udpMessageType) const;
+
+			void toNumber(rapidjson::Value &parent, const std::vector<std::string> &fields) const;
 
 			std::string convertToNum(const std::string &json) const;
 

--- a/src/v2i-hub/ODEForwardPlugin/test/test_ODEForwardConversion.cpp
+++ b/src/v2i-hub/ODEForwardPlugin/test/test_ODEForwardConversion.cpp
@@ -1,0 +1,197 @@
+/**
+ * Copyright (C) 2026 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include <rapidjson/document.h>
+
+#include "ODEForwardConversion.h"
+
+namespace ODEForwardPlugin
+{
+    namespace
+    {
+        rapidjson::Document parse(const char *json)
+        {
+            rapidjson::Document doc;
+            doc.Parse(json);
+            EXPECT_FALSE(doc.HasParseError()) << "test fixture JSON failed to parse: " << json;
+            return doc;
+        }
+
+        rapidjson::Document reparse(const std::string &json)
+        {
+            rapidjson::Document doc;
+            doc.Parse(json.c_str());
+            EXPECT_FALSE(doc.HasParseError()) << "convertToNum produced unparseable JSON: " << json;
+            return doc;
+        }
+    }
+
+    // toNumber
+
+    TEST(ToNumberTest, ConvertsNumericStrings)
+    {
+        // Positive and negative (roadRegulatorID of -1 is the real-world default).
+        rapidjson::Document doc = parse(R"json({"intersectionID": "105", "roadRegulatorID": "-1"})json");
+
+        toNumber(doc, {"intersectionID", "roadRegulatorID"});
+
+        EXPECT_TRUE(doc["intersectionID"].IsInt64());
+        EXPECT_EQ(doc["intersectionID"].GetInt64(), 105);
+        EXPECT_TRUE(doc["roadRegulatorID"].IsInt64());
+        EXPECT_EQ(doc["roadRegulatorID"].GetInt64(), -1);
+    }
+
+    TEST(ToNumberTest, LeavesUnparseableOrIneligibleValuesAsStrings)
+    {
+        // Non-numeric text, trailing garbage, and embedded non-digits all fail
+        rapidjson::Document doc = parse(R"json({
+            "eventType": "SpatMinimumData",
+            "trailing": "42 ",
+            "embedded": "12x34"
+        })json");
+
+        toNumber(doc, {"eventType", "trailing", "embedded"});
+
+        EXPECT_TRUE(doc["eventType"].IsString());
+        EXPECT_TRUE(doc["trailing"].IsString());
+        EXPECT_TRUE(doc["embedded"].IsString());
+    }
+
+    TEST(ToNumberTest, SkipsAbsentAndNonStringFields)
+    {
+        rapidjson::Document doc = parse(R"json({"already": 105})json");
+
+        toNumber(doc, {"missing", "already"});
+
+        EXPECT_FALSE(doc.HasMember("missing"));
+        EXPECT_TRUE(doc["already"].IsInt64());
+        EXPECT_EQ(doc["already"].GetInt64(), 105);
+    }
+
+    TEST(ToNumberTest, WarnsOnlyOnParseException)
+    {
+        rapidjson::Document doc = parse(R"json({
+            "bad": "abc",
+            "huge": "99999999999999999999",
+            "trailing": "42 "
+        })json");
+
+        std::vector<std::string> warnings;
+        toNumber(doc, {"bad", "huge", "trailing"},
+            [&warnings](const std::string &m) { warnings.push_back(m); });
+
+
+        // Two throwing fields warned; the trailing-space field did not
+        ASSERT_EQ(warnings.size(), 2u);
+        // Messages name the offending field.
+        EXPECT_NE(warnings[0].find("'bad'"), std::string::npos);
+        EXPECT_NE(warnings[1].find("'huge'"), std::string::npos);
+
+        // All three left as strings regardless of whether they warned
+        EXPECT_TRUE(doc["bad"].IsString());
+        EXPECT_TRUE(doc["huge"].IsString());
+        EXPECT_TRUE(doc["trailing"].IsString());
+    }
+
+    TEST(ToNumberTest, DoesNotInvokeWarnOnCleanConversion)
+    {
+        rapidjson::Document doc = parse(R"json({"intersectionID": "105"})json");
+
+        std::vector<std::string> warnings;
+        toNumber(doc, {"intersectionID"},
+                 [&warnings](const std::string &m) { warnings.push_back(m); });
+
+
+        EXPECT_TRUE(warnings.empty());
+        EXPECT_TRUE(doc["intersectionID"].IsInt64());
+    }
+
+    // convertToNum
+
+    TEST(ConvertToNumTest, FullEventRoundTrips)
+    {
+        const std::string input = R"json({
+            "eventGeneratedAt": "1785779824579",
+            "eventType": "SpatMinimumData",
+            "intersectionID": "105",
+            "roadRegulatorID": "-1",
+            "source": "192.168.60.42",
+            "numberOfMessages": "2",
+            "messageCountA": "10",
+            "messageCountB": "11",
+            "missingDataElements": ["$.value.SPAT.intersections[0].roadAuthorityID is missing (#/properties/value)"],
+            "timePeriod": {
+                "beginTimestamp": "1785779824574",
+                "endTimestamp": "1785779824579"
+            }
+        })json";
+
+        rapidjson::Document out = reparse(convertToNum(input));
+
+        // Numeric fields typed as numbers
+        EXPECT_TRUE(out["eventGeneratedAt"].IsInt64());
+        EXPECT_EQ(out["eventGeneratedAt"].GetInt64(), 1785779824579LL);
+        EXPECT_TRUE(out["intersectionID"].IsInt64());
+        EXPECT_TRUE(out["roadRegulatorID"].IsInt64());
+        EXPECT_EQ(out["roadRegulatorID"].GetInt64(), -1);
+        EXPECT_TRUE(out["numberOfMessages"].IsInt64());
+        EXPECT_TRUE(out["messageCountA"].IsInt64());
+        EXPECT_TRUE(out["messageCountB"].IsInt64());
+
+        // Nested timePeriod converts
+        EXPECT_TRUE(out["timePeriod"]["beginTimestamp"].IsInt64());
+        EXPECT_TRUE(out["timePeriod"]["endTimestamp"].IsInt64());
+
+        // String fields and the array are left alone
+        EXPECT_TRUE(out["eventType"].IsString());
+        EXPECT_TRUE(out["source"].IsString());
+        EXPECT_TRUE(out["missingDataElements"].IsArray());
+        EXPECT_TRUE(out["missingDataElements"][0].IsString());
+    }
+
+    TEST(ConvertToNumTest, ReturnsInputUnchangedOnBadInput)
+    {
+        // Unparseable JSON and non-object JSON are both forwarded
+        // verbatim rather than dropped or throwing
+        const std::string malformed = "{ this is not valid json";
+        EXPECT_EQ(convertToNum(malformed), malformed);
+
+        const std::string notObject = R"json([1, 2, 3])json";
+        EXPECT_EQ(convertToNum(notObject), notObject);
+    }
+
+    TEST(ConvertToNumTest, LeavesNonNumericValueInNumericFieldAsString)
+    {
+        // A field in the numeric list whose value isn't a clean integer stays a string
+        rapidjson::Document out = reparse(convertToNum(R"json({"intersectionID": "not-a-number"})json"));
+        EXPECT_TRUE(out["intersectionID"].IsString());
+    }
+
+    TEST(ConvertToNumTest, ForwardsWarnSinkToFields)
+    {
+        // A throwing value in a numeric field routes a warning
+        std::vector<std::string> warnings;
+        convertToNum(R"json({"intersectionID": "abc"})json",
+                     [&warnings](const std::string &m) { warnings.push_back(m); });
+
+        EXPECT_EQ(warnings.size(), 1u);
+        EXPECT_NE(warnings[0].find("'intersectionID'"), std::string::npos);
+    }
+
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Fixed how the Intersection Validation Plugin populates the CTI 4501 Events. For the BroadcastRateEvent, all numbers are now populated as integers rather than strings. For the MinimumDataEvents, the missingDataElements are now populated in the format that CV Manager expects.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[VH-1598](https://usdot-carma.atlassian.net/browse/VH-1598)

## Motivation and Context

Although the CTI 4501 events are being forwarded to the CV Manager system, they do not appear in the UI or in MongoDB. 

## How Has This Been Tested?

Deployed on one intersection on WIL the HIL

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[VH-1598]: https://usdot-carma.atlassian.net/browse/VH-1598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ