### PR TITLE
MinimumDataEvent Throttling

### DIFF
--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.cpp
@@ -175,9 +175,16 @@ namespace IntersectionValidation
         removeEmptyStrings(doc, doc.GetAllocator());
         convertNumericStrings(doc, doc.GetAllocator(), schemaDoc);
 
-        // Run both validations on the same preprocessed document
-        validateMessageFields(doc, schemaDoc, fieldEventType, messageType, intersectionId, handlerBeginMs);
-        return validateRevisionCounters(doc, revisionEventType, messageType, intersectionId);
+        // First run revision validation so that MinimumData event can also be throttled
+        RevisionCounterResult revResult =
+            validateRevisionCounters(doc, revisionEventType, messageType, intersectionId);
+
+        // planForwarding() is true when message content changed (or first seen)
+        const bool contentChanged = planForwarding(revResult);
+        validateMessageFields(doc, schemaDoc, fieldEventType, messageType,
+                              intersectionId, handlerBeginMs, contentChanged);
+
+        return revResult;
     }
 
     void IntersectionValidationPlugin::validateMessageFields(const rapidjson::Document &doc,
@@ -185,7 +192,8 @@ namespace IntersectionValidation
                                                              const std::string &eventType,
                                                              const std::string &messageType,
                                                              int intersectionId,
-                                                             uint64_t handlerBeginMs)
+                                                             uint64_t handlerBeginMs,
+                                                             bool contentChanged)
     {
         uint32_t &passed = (messageType == "SPaT") ? spatValidationPassed : mapValidationPassed;
         uint32_t &failed = (messageType == "SPaT") ? spatFieldValidationErrors : mapFieldValidationErrors;
@@ -205,46 +213,58 @@ namespace IntersectionValidation
 
         if (!doc.Accept(validator))
         {
-            // Enumerate every missing required element then
-            // wrap the JSON-path strings into MissingDataElement for the event.
-            std::vector<MissingDataElement> elements;
-            for (const auto &field : IntersectionValidation::collectMissingRequiredFields(schemaDoc, doc))
-            {
-                elements.emplace_back(field);
-            }
-
-            if (elements.empty())
-            {
-                // Validation failed for a reason other than a missing required property
-                rapidjson::StringBuffer docSb;
-                rapidjson::StringBuffer schemaSb;
-                const char *keyword = validator.GetInvalidSchemaKeyword();
-                validator.GetInvalidDocumentPointer().StringifyUriFragment(docSb);
-                validator.GetInvalidSchemaPointer().StringifyUriFragment(schemaSb);
-                elements.emplace_back(std::string(docSb.GetString()) + " failed " +
-                                      (keyword ? keyword : "validation") + " (" +
-                                      schemaSb.GetString() + ")");
-            }
-
-            for (const auto &element : elements)
-            {
-                PLOG(logWARNING) << messageType << " field validation failure: " << element.value;
-            }
-
-            uint64_t handlerEndMs = PluginClientClockAware::getClock()->nowInMilliseconds();
-
-            CTI4501ValidationMessage eventMsg;
-            eventMsg.set_eventGeneratedAt(handlerEndMs);
-            eventMsg.set_eventType(eventType);
-            eventMsg.set_intersectionID(intersectionId);
-            eventMsg.set_roadRegulatorID(-1);
-            eventMsg.set_source(rsuSource);
-            eventMsg.set_timePeriod(ProcessingTimePeriod(handlerBeginMs, handlerEndMs));
-            eventMsg.set_missingDataElements(elements);
-
-            PluginClient::BroadcastMessage(eventMsg);
-
+            // The validation failure is real regardless of throttling, so count it.
             failed++;
+
+            if (!contentChanged)
+            {
+                // Identical to previous message for this intersection
+                // MinimumDataEvent already fired for this message
+                PLOG(logDEBUG) << messageType
+                               << " minimum-data unchanged from previous message; "
+                                  "throttling duplicate event";
+            }
+            else
+            {
+                // One entry per missing element, formatted to match conflictmonitor's own
+                // minimum-data strings.
+                std::vector<MissingDataElement> elements;
+                for (const auto &field : IntersectionValidation::collectMissingRequiredFields(schemaDoc, doc))
+                {
+                    elements.emplace_back(field);
+                }
+
+                if (elements.empty())
+                {
+                    // Validation failed for a reason other than a missing required property
+                    rapidjson::StringBuffer docSb;
+                    rapidjson::StringBuffer schemaSb;
+                    const char *keyword = validator.GetInvalidSchemaKeyword();
+                    validator.GetInvalidDocumentPointer().StringifyUriFragment(docSb);
+                    validator.GetInvalidSchemaPointer().StringifyUriFragment(schemaSb);
+                    elements.emplace_back(std::string(docSb.GetString()) + " failed " +
+                                          (keyword ? keyword : "validation") + " (" +
+                                          schemaSb.GetString() + ")");
+                }
+
+                for (const auto &element : elements)
+                {
+                    PLOG(logWARNING) << messageType << " field validation failure: " << element.value;
+                }
+
+                uint64_t handlerEndMs = PluginClientClockAware::getClock()->nowInMilliseconds();
+
+                CTI4501ValidationMessage eventMsg;
+                eventMsg.set_eventGeneratedAt(handlerEndMs);
+                eventMsg.set_eventType(eventType);
+                eventMsg.set_intersectionID(intersectionId);
+                eventMsg.set_roadRegulatorID(-1);
+                eventMsg.set_source(rsuSource);
+                eventMsg.set_timePeriod(ProcessingTimePeriod(handlerBeginMs, handlerEndMs));
+                eventMsg.set_missingDataElements(elements);
+
+                PluginClient::BroadcastMessage(eventMsg);
+            }
         }
         else
         {

--- a/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
+++ b/src/v2i-hub/IntersectionValidationPlugin/src/IntersectionValidationPlugin.h
@@ -111,10 +111,12 @@ namespace IntersectionValidation
          * @param messageType The message type label for logging and status updates (e.g. "SPaT", "MAP").
          * @param intersectionId The intersection ID to include in the CTI4501ValidationMessage if validation fails.
          * @param handlerBeginMs Timestamp in milliseconds when message handling began
+         * @param contentChanged Boolean value indicating if the content of the message 
+         has changed
          */
         void validateMessageFields(const rapidjson::Document &doc, const rapidjson::Document &schemaDoc,
                                     const std::string &eventType, const std::string &messageType,
-                                    int intersectionId, uint64_t handlerBeginMs);
+                                    int intersectionId, uint64_t handlerBeginMs, bool contentChanged);
 
 
         /**

--- a/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
+++ b/src/v2i-hub/IntersectionValidationPlugin/test/IntersectionValidationTest.cpp
@@ -5659,292 +5659,391 @@ namespace
  
     EXPECT_NE(resolved, nullptr);
     EXPECT_EQ(resolved, &node); // same node returned, not a copy
-}
- 
-TEST(ResolveRefTest, ResolvesLocalPointerAgainstRoot)
-{
-    rapidjson::Document root = parse(R"({
-        "definitions": { "Foo": { "type": "integer" } }
-    })");
-    rapidjson::Document node = parse(R"({"$ref": "#/definitions/Foo"})");
- 
-    const rapidjson::Value *resolved = resolveRef(node, root);
- 
-    EXPECT_NE(resolved, nullptr);
-    EXPECT_TRUE(resolved->IsObject());
-    EXPECT_TRUE(resolved->HasMember("type"));
-    EXPECT_STREQ((*resolved)["type"].GetString(), "integer");
-}
- 
-TEST(ResolveRefTest, RootPointerReturnsRoot)
-{
+  }
+  
+  TEST(ResolveRefTest, ResolvesLocalPointerAgainstRoot)
+  {
+      rapidjson::Document root = parse(R"({
+          "definitions": { "Foo": { "type": "integer" } }
+      })");
+      rapidjson::Document node = parse(R"({"$ref": "#/definitions/Foo"})");
+  
+      const rapidjson::Value *resolved = resolveRef(node, root);
+  
+      EXPECT_NE(resolved, nullptr);
+      EXPECT_TRUE(resolved->IsObject());
+      EXPECT_TRUE(resolved->HasMember("type"));
+      EXPECT_STREQ((*resolved)["type"].GetString(), "integer");
+  }
+  
+  TEST(ResolveRefTest, RootPointerReturnsRoot)
+  {
+      rapidjson::Document root = parse(R"({"type": "object"})");
+      rapidjson::Document node = parse(R"({"$ref": "#"})");
+  
+      const rapidjson::Value *resolved = resolveRef(node, root);
+  
+      EXPECT_EQ(resolved, &root);
+  }
+  
+  TEST(ResolveRefTest, ExternalRefReturnsNull)
+  {
     rapidjson::Document root = parse(R"({"type": "object"})");
-    rapidjson::Document node = parse(R"({"$ref": "#"})");
- 
-    const rapidjson::Value *resolved = resolveRef(node, root);
- 
-    EXPECT_EQ(resolved, &root);
-}
- 
-TEST(ResolveRefTest, ExternalRefReturnsNull)
-{
-  rapidjson::Document root = parse(R"({"type": "object"})");
-  rapidjson::Document node = parse(R"({"$ref": "other.json#/Foo"})");
- 
-  EXPECT_EQ(resolveRef(node, root), nullptr);
-}
- 
-TEST(ResolveRefTest, UnresolvableLocalPointerReturnsNull)
-{
-  rapidjson::Document root = parse(R"({"definitions": {}})");
-  rapidjson::Document node = parse(R"({"$ref": "#/definitions/DoesNotExist"})");
- 
-  EXPECT_EQ(resolveRef(node, root), nullptr);
-}
- 
-TEST(ResolveRefTest, NonStringRefIsTreatedAsNoRef)
-{
-  rapidjson::Document root = parse(R"({"type": "object"})");
-  rapidjson::Document node = parse(R"({"$ref": 42})");
- 
-  // A non-string $ref is ignored; the node itself is returned.
-  EXPECT_EQ(resolveRef(node, root), &node);
-}
- 
-TEST(RefOrTest, ReturnsRefStringWhenPresent)
-{
-    rapidjson::Document node = parse(R"({"$ref": "#/$defs/J2735TimeMark"})");
-    EXPECT_EQ(refOr(node, "fallback"), "#/$defs/J2735TimeMark");
-}
- 
-TEST(RefOrTest, ReturnsFallbackWhenNoRef)
-{
-  rapidjson::Document node = parse(R"({"type": "integer"})");
-  EXPECT_EQ(refOr(node, "fallback/path"), "fallback/path");
-}
+    rapidjson::Document node = parse(R"({"$ref": "other.json#/Foo"})");
+  
+    EXPECT_EQ(resolveRef(node, root), nullptr);
+  }
+  
+  TEST(ResolveRefTest, UnresolvableLocalPointerReturnsNull)
+  {
+    rapidjson::Document root = parse(R"({"definitions": {}})");
+    rapidjson::Document node = parse(R"({"$ref": "#/definitions/DoesNotExist"})");
+  
+    EXPECT_EQ(resolveRef(node, root), nullptr);
+  }
+  
+  TEST(ResolveRefTest, NonStringRefIsTreatedAsNoRef)
+  {
+    rapidjson::Document root = parse(R"({"type": "object"})");
+    rapidjson::Document node = parse(R"({"$ref": 42})");
+  
+    // A non-string $ref is ignored; the node itself is returned.
+    EXPECT_EQ(resolveRef(node, root), &node);
+  }
+  
+  TEST(RefOrTest, ReturnsRefStringWhenPresent)
+  {
+      rapidjson::Document node = parse(R"({"$ref": "#/$defs/J2735TimeMark"})");
+      EXPECT_EQ(refOr(node, "fallback"), "#/$defs/J2735TimeMark");
+  }
+  
+  TEST(RefOrTest, ReturnsFallbackWhenNoRef)
+  {
+    rapidjson::Document node = parse(R"({"type": "integer"})");
+    EXPECT_EQ(refOr(node, "fallback/path"), "fallback/path");
+  }
 
-TEST(RefOrTest, ReturnsFallbackWhenNotObject)
-{
-  rapidjson::Document node = parse(R"("just a string")");
-  EXPECT_EQ(refOr(node, "fallback"), "fallback");
-}
- 
-TEST(PropertySchemaRefTest, ReturnsPropertyRefWhenDeclared)
-{
-  rapidjson::Document schema = parse(R"({
-    "properties": { "startTime": { "$ref": "#/$defs/TimeMark" } }
-  })");
-  EXPECT_EQ(propertySchemaRef(schema, "startTime", "fallback"),
-    "#/$defs/TimeMark");
-}
- 
-TEST(PropertySchemaRefTest, ReturnsFallbackWhenPropertyHasNoRef)
-{
-  rapidjson::Document schema = parse(R"({
-  "properties": { "startTime": { "type": "integer" } }
-    })");
-  EXPECT_EQ(propertySchemaRef(schema, "startTime", "inline/path"),
-    "inline/path");
-}
- 
-TEST(PropertySchemaRefTest, ReturnsFallbackWhenPropertyMissing)
-{
-  rapidjson::Document schema = parse(R"({
-        "properties": { "other": { "type": "integer" } }
-  })");
-  EXPECT_EQ(propertySchemaRef(schema, "startTime", "inline/path"),
-        "inline/path");
-}
- 
-TEST(CollectMissingRequiredFieldsTest, EmptyWhenAllRequiredPresent)
-{
+  TEST(RefOrTest, ReturnsFallbackWhenNotObject)
+  {
+    rapidjson::Document node = parse(R"("just a string")");
+    EXPECT_EQ(refOr(node, "fallback"), "fallback");
+  }
+  
+  TEST(PropertySchemaRefTest, ReturnsPropertyRefWhenDeclared)
+  {
     rapidjson::Document schema = parse(R"({
-        "type": "object",
-        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
-        "required": ["a", "b"]
+      "properties": { "startTime": { "$ref": "#/$defs/TimeMark" } }
     })");
-    rapidjson::Document doc = parse(R"({"a": 1, "b": 2})");
-
-    EXPECT_TRUE(collectMissingRequiredFields(schema, doc).empty());
-}
-
-TEST(CollectMissingRequiredFieldsTest, ReportsSingleMissingTopLevel)
-{
+    EXPECT_EQ(propertySchemaRef(schema, "startTime", "fallback"),
+      "#/$defs/TimeMark");
+  }
+  
+  TEST(PropertySchemaRefTest, ReturnsFallbackWhenPropertyHasNoRef)
+  {
     rapidjson::Document schema = parse(R"({
-        "type": "object",
-        "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
-        "required": ["a", "b"]
-    })");
-    rapidjson::Document doc = parse(R"({"a": 1})");
-
-    auto missing = collectMissingRequiredFields(schema, doc);
-
-    ASSERT_EQ(missing.size(), 1u);
-    EXPECT_TRUE(contains(missing, "$.b is missing"));
-}
-
-TEST(CollectMissingRequiredFieldsTest, ReportsAllMissingNotJustFirst)
-{
+    "properties": { "startTime": { "type": "integer" } }
+      })");
+    EXPECT_EQ(propertySchemaRef(schema, "startTime", "inline/path"),
+      "inline/path");
+  }
+  
+  TEST(PropertySchemaRefTest, ReturnsFallbackWhenPropertyMissing)
+  {
     rapidjson::Document schema = parse(R"({
-        "type": "object",
-        "properties": { "a": {}, "b": {}, "c": {} },
-        "required": ["a", "b", "c"]
+          "properties": { "other": { "type": "integer" } }
     })");
-    rapidjson::Document doc = parse(R"({"b": 2})");
+    EXPECT_EQ(propertySchemaRef(schema, "startTime", "inline/path"),
+          "inline/path");
+  }
+  
+  TEST(CollectMissingRequiredFieldsTest, EmptyWhenAllRequiredPresent)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object",
+          "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+          "required": ["a", "b"]
+      })");
+      rapidjson::Document doc = parse(R"({"a": 1, "b": 2})");
 
-    auto missing = collectMissingRequiredFields(schema, doc);
+      EXPECT_TRUE(collectMissingRequiredFields(schema, doc).empty());
+  }
 
-    EXPECT_EQ(missing.size(), 2u);
-    EXPECT_TRUE(contains(missing, "$.a is missing"));
-    EXPECT_TRUE(contains(missing, "$.c is missing"));
-}
+  TEST(CollectMissingRequiredFieldsTest, ReportsSingleMissingTopLevel)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object",
+          "properties": { "a": { "type": "integer" }, "b": { "type": "integer" } },
+          "required": ["a", "b"]
+      })");
+      rapidjson::Document doc = parse(R"({"a": 1})");
 
-TEST(CollectMissingRequiredFieldsTest, DescendsIntoNestedObjects)
-{
-    rapidjson::Document schema = parse(R"({
-        "type": "object",
-        "properties": {
-            "id": {
-                "type": "object",
-                "properties": { "region": {}, "id": {} },
-                "required": ["id"]
-            }
-        },
-        "required": ["id"]
-    })");
-    rapidjson::Document doc = parse(R"({"id": {"region": 1}})");
+      auto missing = collectMissingRequiredFields(schema, doc);
 
-    auto missing = collectMissingRequiredFields(schema, doc);
+      ASSERT_EQ(missing.size(), 1u);
+      EXPECT_TRUE(contains(missing, "$.b is missing"));
+  }
 
-    ASSERT_EQ(missing.size(), 1u);
-    EXPECT_TRUE(contains(missing, "$.id.id is missing"));
-}
+  TEST(CollectMissingRequiredFieldsTest, ReportsAllMissingNotJustFirst)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object",
+          "properties": { "a": {}, "b": {}, "c": {} },
+          "required": ["a", "b", "c"]
+      })");
+      rapidjson::Document doc = parse(R"({"b": 2})");
 
-TEST(CollectMissingRequiredFieldsTest, DescendsIntoArrayItemsWithIndex)
-{
-    rapidjson::Document schema = parse(R"({
-        "type": "object",
-        "properties": {
-            "states": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": { "eventState": {}, "timing": {} },
-                    "required": ["eventState", "timing"]
-                }
-            }
-        },
-        "required": ["states"]
-    })");
+      auto missing = collectMissingRequiredFields(schema, doc);
 
-    rapidjson::Document doc = parse(R"({
-        "states": [
-            {"eventState": "stop", "timing": {}},
-            {"eventState": "go"}
-        ]
-    })");
+      EXPECT_EQ(missing.size(), 2u);
+      EXPECT_TRUE(contains(missing, "$.a is missing"));
+      EXPECT_TRUE(contains(missing, "$.c is missing"));
+  }
 
-    auto missing = collectMissingRequiredFields(schema, doc);
+  TEST(CollectMissingRequiredFieldsTest, DescendsIntoNestedObjects)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object",
+          "properties": {
+              "id": {
+                  "type": "object",
+                  "properties": { "region": {}, "id": {} },
+                  "required": ["id"]
+              }
+          },
+          "required": ["id"]
+      })");
+      rapidjson::Document doc = parse(R"({"id": {"region": 1}})");
 
-    ASSERT_EQ(missing.size(), 1u);
-    EXPECT_TRUE(contains(missing, "$.states[1].timing is missing"));
-}
+      auto missing = collectMissingRequiredFields(schema, doc);
 
-TEST(CollectMissingRequiredFieldsTest, ProducesConflictMonitorStyleString)
-{
-    rapidjson::Document schema = parse(R"({
-        "type": "object",
-        "properties": {
-            "value": {
-                "type": "object",
-                "properties": {
-                    "SPAT": {
-                        "type": "object",
-                        "properties": { "timeStamp": {}, "intersections": {} },
-                        "required": ["timeStamp", "intersections"]
-                    }
-                },
-                "required": ["SPAT"]
-            }
-        },
-        "required": ["value"]
-    })");
-    rapidjson::Document doc = parse(R"({"value": {"SPAT": {"timeStamp": 1}}})");
+      ASSERT_EQ(missing.size(), 1u);
+      EXPECT_TRUE(contains(missing, "$.id.id is missing"));
+  }
 
-    auto missing = collectMissingRequiredFields(schema, doc);
+  TEST(CollectMissingRequiredFieldsTest, DescendsIntoArrayItemsWithIndex)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object",
+          "properties": {
+              "states": {
+                  "type": "array",
+                  "items": {
+                      "type": "object",
+                      "properties": { "eventState": {}, "timing": {} },
+                      "required": ["eventState", "timing"]
+                  }
+              }
+          },
+          "required": ["states"]
+      })");
 
-    ASSERT_EQ(missing.size(), 1u);
-    // Full expected string, path + schema-pointer citation.
-    EXPECT_EQ(missing.front(),
-              "$.value.SPAT.intersections is missing "
-              "(#/properties/value/properties/SPAT/properties/intersections)");
-}
+      rapidjson::Document doc = parse(R"({
+          "states": [
+              {"eventState": "stop", "timing": {}},
+              {"eventState": "go"}
+          ]
+      })");
 
-TEST(HandleObjectTest, NoOpForNonObjectInstance)
-{
-    rapidjson::Document schema = parse(R"({
-        "type": "object", "properties": { "a": {} }, "required": ["a"]
-    })");
-    rapidjson::Document instance = parse(R"([1, 2, 3])"); // array, not object
+      auto missing = collectMissingRequiredFields(schema, doc);
 
-    std::vector<std::string> out;
-    handleObject(schema, instance, schema, "$", "#", out, 0);
+      ASSERT_EQ(missing.size(), 1u);
+      EXPECT_TRUE(contains(missing, "$.states[1].timing is missing"));
+  }
 
-    EXPECT_TRUE(out.empty());
-}
+  TEST(CollectMissingRequiredFieldsTest, ProducesConflictMonitorStyleString)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object",
+          "properties": {
+              "value": {
+                  "type": "object",
+                  "properties": {
+                      "SPAT": {
+                          "type": "object",
+                          "properties": { "timeStamp": {}, "intersections": {} },
+                          "required": ["timeStamp", "intersections"]
+                      }
+                  },
+                  "required": ["SPAT"]
+              }
+          },
+          "required": ["value"]
+      })");
+      rapidjson::Document doc = parse(R"({"value": {"SPAT": {"timeStamp": 1}}})");
 
-TEST(HandleObjectTest, CollectsMissingAndRecursesPresent)
-{
-    rapidjson::Document schema = parse(R"({
-        "type": "object",
-        "properties": {
-            "a": {},
-            "nested": {
-                "type": "object",
-                "properties": { "x": {} },
-                "required": ["x"]
-            }
-        },
-        "required": ["a", "nested"]
-    })");
-    // "a" missing; "nested" present but missing its required "x".
-    rapidjson::Document instance = parse(R"({"nested": {}})");
+      auto missing = collectMissingRequiredFields(schema, doc);
 
-    std::vector<std::string> out;
-    handleObject(schema, instance, schema, "$", "#", out, 0);
+      ASSERT_EQ(missing.size(), 1u);
+      // Full expected string, path + schema-pointer citation.
+      EXPECT_EQ(missing.front(),
+                "$.value.SPAT.intersections is missing "
+                "(#/properties/value/properties/SPAT/properties/intersections)");
+  }
 
-    EXPECT_EQ(out.size(), 2u);
-    EXPECT_TRUE(contains(out, "$.a is missing"));
-    EXPECT_TRUE(contains(out, "$.nested.x is missing"));
-}
+  TEST(HandleObjectTest, NoOpForNonObjectInstance)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object", "properties": { "a": {} }, "required": ["a"]
+      })");
+      rapidjson::Document instance = parse(R"([1, 2, 3])"); // array, not object
 
-TEST(CollectMissingRequiredTest, DepthGuardStopsRecursion)
-{
-    // Passing a depth over the cap short-circuits before any collection.
-    rapidjson::Document schema = parse(R"({
-        "type": "object", "properties": { "a": {} }, "required": ["a"]
-    })");
-    rapidjson::Document doc = parse(R"({})");
+      std::vector<std::string> out;
+      handleObject(schema, instance, schema, "$", "#", out, 0);
 
-    std::vector<std::string> out;
-    collectMissingRequired(schema, doc, schema, "$", "#", out, /*depth=*/1000);
+      EXPECT_TRUE(out.empty());
+  }
 
-    EXPECT_TRUE(out.empty());
-}
- 
-TEST(CollectMissingRequiredTest, DefaultDepthCollectsNormally)
-{
-    rapidjson::Document schema = parse(R"({
-        "type": "object", "properties": { "a": {} }, "required": ["a"]
-    })");
-    rapidjson::Document doc = parse(R"({})");
+  TEST(HandleObjectTest, CollectsMissingAndRecursesPresent)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object",
+          "properties": {
+              "a": {},
+              "nested": {
+                  "type": "object",
+                  "properties": { "x": {} },
+                  "required": ["x"]
+              }
+          },
+          "required": ["a", "nested"]
+      })");
+      // "a" missing; "nested" present but missing its required "x".
+      rapidjson::Document instance = parse(R"({"nested": {}})");
 
-    std::vector<std::string> out;
-    collectMissingRequired(schema, doc, schema, "$", "#", out); // default depth 0
+      std::vector<std::string> out;
+      handleObject(schema, instance, schema, "$", "#", out, 0);
 
-    ASSERT_EQ(out.size(), 1u);
-    EXPECT_TRUE(contains(out, "$.a is missing"));
-}
+      EXPECT_EQ(out.size(), 2u);
+      EXPECT_TRUE(contains(out, "$.a is missing"));
+      EXPECT_TRUE(contains(out, "$.nested.x is missing"));
+  }
+
+  TEST(CollectMissingRequiredTest, DepthGuardStopsRecursion)
+  {
+      // Passing a depth over the cap short-circuits before any collection.
+      rapidjson::Document schema = parse(R"({
+          "type": "object", "properties": { "a": {} }, "required": ["a"]
+      })");
+      rapidjson::Document doc = parse(R"({})");
+
+      std::vector<std::string> out;
+      collectMissingRequired(schema, doc, schema, "$", "#", out, /*depth=*/1000);
+
+      EXPECT_TRUE(out.empty());
+  }
+  
+  TEST(CollectMissingRequiredTest, DefaultDepthCollectsNormally)
+  {
+      rapidjson::Document schema = parse(R"({
+          "type": "object", "properties": { "a": {} }, "required": ["a"]
+      })");
+      rapidjson::Document doc = parse(R"({})");
+
+      std::vector<std::string> out;
+      collectMissingRequired(schema, doc, schema, "$", "#", out); // default depth 0
+
+      ASSERT_EQ(out.size(), 1u);
+      EXPECT_TRUE(contains(out, "$.a is missing"));
+  }
+
+  // MinimumDataEvent throttling
+  bool spatWouldEmit(RevisionCounterValidator &validator, const char *json)
+  {
+      rapidjson::Document doc = parse(json);
+      return planForwarding(validator.validateSpatRevision(doc));
+  }
+
+  bool mapWouldEmit(RevisionCounterValidator &validator, const char *json)
+  {
+      rapidjson::Document doc = parse(json);
+      return planForwarding(validator.validateMapRevision(doc));
+  }
+
+  constexpr const char *SPAT_A = R"json({
+      "value": { "SPAT": { "intersections": [
+          {
+              "id": { "id": 105 },
+              "revision": 0,
+              "states": [
+                  { "signalGroup": 1, "state-time-speed": [
+                      { "eventState": "stop-And-Remain", "timing": { "minEndTime": 100 } }
+                  ] }
+              ]
+          }
+      ] } }
+  })json";
+
+  // eventState changed
+  constexpr const char *SPAT_B = R"json({
+      "value": { "SPAT": { "intersections": [
+          {
+              "id": { "id": 105 },
+              "revision": 0,
+              "states": [
+                  { "signalGroup": 1, "state-time-speed": [
+                      { "eventState": "protected-Movement-Allowed", "timing": { "minEndTime": 100 } }
+                  ] }
+              ]
+          }
+      ] } }
+  })json";
+
+  constexpr const char *MAP_A = R"json({
+      "value": { "MapData": {
+          "msgIssueRevision": 0,
+          "intersections": [
+              { "id": { "id": 105 }, "revision": 0, "laneSet": [ { "laneID": 1 } ] }
+          ]
+      } }
+  })json";
+
+  // laneID changed
+  constexpr const char *MAP_B = R"json({
+      "value": { "MapData": {
+          "msgIssueRevision": 0,
+          "intersections": [
+              { "id": { "id": 105 }, "revision": 0, "laneSet": [ { "laneID": 2 } ] }
+          ]
+      } }
+  })json";
+
+  TEST(MinimumDataThrottleTest, FirstFailingSpatEmits)
+  {
+      RevisionCounterValidator validator;
+
+      // First time this intersection is seen
+      EXPECT_TRUE(spatWouldEmit(validator, SPAT_A));
+  }
+
+  TEST(MinimumDataThrottleTest, IdenticalSpatRepeatIsThrottled)
+  {
+      RevisionCounterValidator validator;
+
+      EXPECT_TRUE(spatWouldEmit(validator, SPAT_A));   // first — emits, records state
+      EXPECT_FALSE(spatWouldEmit(validator, SPAT_A));  // identical — throttled
+      EXPECT_FALSE(spatWouldEmit(validator, SPAT_A));  // still identical — still throttled
+  }
+
+  TEST(MinimumDataThrottleTest, ChangedSpatContentReEmits)
+  {
+      RevisionCounterValidator validator;
+
+      EXPECT_TRUE(spatWouldEmit(validator, SPAT_A));   // first — emits
+      EXPECT_FALSE(spatWouldEmit(validator, SPAT_A));  // identical — throttled
+      EXPECT_TRUE(spatWouldEmit(validator, SPAT_B));   // content changed — emits again
+      EXPECT_FALSE(spatWouldEmit(validator, SPAT_B));  // new content now identical — throttled
+  }
+
+  TEST(MinimumDataThrottleTest, MapFollowsSameThrottleRule)
+  {
+      RevisionCounterValidator validator;
+
+      EXPECT_TRUE(mapWouldEmit(validator, MAP_A));    // first — emits
+      EXPECT_FALSE(mapWouldEmit(validator, MAP_A));   // identical — throttled
+      EXPECT_TRUE(mapWouldEmit(validator, MAP_B));    // content changed — emits again
+  }
+
+
 
 
 } // namespace


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

These changes now allow for frequency throttling with MinimumDataEvents as well as unchanged SPaT and MAP messages. Now the revision validation occurs prior to message content validation, and if the previous message is the same as the current one, the MinimumDataEvent doesn't get created for the current message.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[VH-1599](https://usdot-carma.atlassian.net/browse/VH-1599)

## Motivation and Context

Adds frequency throttling to MinimumDataEvents to help further throttle messages forwarded to ODE 

## How Has This Been Tested?

Local deployment testing, testing on HIL environment

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[VH-1599]: https://usdot-carma.atlassian.net/browse/VH-1599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ