### PR TITLE
feat: add SPDU handling in Immediate Forward Plugin 

### DIFF
--- a/src/tmx/TmxUtils/src/rsu/NTCIP_1218_MIB.h
+++ b/src/tmx/TmxUtils/src/rsu/NTCIP_1218_MIB.h
@@ -62,12 +62,25 @@ namespace tmx::utils::rsu::mib::ntcip1218
     // Forward Message Priority. Priority assigned to the Immediate Forward message. Priority values defined by IEEE 1609.3-2016 for DSRC radios.
     static const std::string rsuIFMPriorityOid = "1.3.6.1.4.1.1206.4.2.18.4.2.1.6";
 
-    /* Forward Message Options. 
+    /* Forward Message Options.
     A bit-mapped value as defined below for configuring the message.
         Bit 0 0=Bypass1609.2, 1=Process1609.2
         Bit 1 0=Secure, 1=Unsecure
         Bit 2 0=ContXmit, 1=NoXmitShortTermXceeded
         Bit 3 0=ContXmit, 1=NoXmitLongTermXceeded
+
+    From NTCIP 1218 5.5.2.7, on the two bits this codebase sets:
+        Bit 0 - Indicates if the RSU is to bypass 1609.2 processing of the message to the V2X
+                interface. This allows the RSU to send the message that has been signed and/or
+                encrypted by the TMC. Note the RSU would still wrap the message payload in a WSMP
+                header.
+        Bit 1 - Indicates if the message should be secured (signed or encrypted) prior to
+                transmission to the V2X Interface. How the message is to be secured is determined by
+                its security profile. This bit is ignored if Bit 0=0 (bypass).
+
+    So 00 HEX has the RSU transmit an already secured payload untouched, and 80 HEX has the RSU
+    secure the message itself. Bit 0 is the most significant bit, so Process1609.2 is 80 HEX rather
+    than 01 HEX; this is the numbering a Yunex RSU expects.
     */
     static const std::string rsuIFMOptionsOid = "1.3.6.1.4.1.1206.4.2.18.4.2.1.7";
 

--- a/src/v2i-hub/ImmediateForwardPlugin/CMakeLists.txt
+++ b/src/v2i-hub/ImmediateForwardPlugin/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(${PROJECT_NAME} tmxutils jsoncpp )
 ## Testing ##
 #############
 enable_testing()
-add_library(${PROJECT_NAME}_lib src/ImmediateForwardConfiguration.cpp src/IMFNTCIP1218Worker.cpp)
+add_library(${PROJECT_NAME}_lib src/ImmediateForwardConfiguration.cpp src/IMFNTCIP1218Worker.cpp src/SpduForwarder.cpp)
 target_link_libraries(${PROJECT_NAME}_lib PUBLIC tmxutils jsoncpp)
 target_include_directories(${PROJECT_NAME}_lib PUBLIC ${PROJECT_SOURCE_DIR}/src)
 file(GLOB_RECURSE TEST_SOURCES LIST_DIRECTORIES false test/*.h test/*.cpp)

--- a/src/v2i-hub/ImmediateForwardPlugin/README.md
+++ b/src/v2i-hub/ImmediateForwardPlugin/README.md
@@ -123,8 +123,7 @@ SPDU exactly as it was received. This is used to re-broadcast an already secured
 Hub decoding, re-encoding or re-signing it. `RawSpdu` messages are produced by the
 [Message Receiver Plugin](../MessageReceiverPlugin/README.md) when its **FullSPDUMode** is enabled.
 
-No new configuration keys are needed. The existing `messages` entries are reused, with the following
-differences from the J2735 path:
+Differences from the current J2735 path:
 
 - **tmxType** is matched against the J2735 type of the message *inside* the SPDU, which uses the same
   labels as the J2735 path (`BSM`, `SPAT-P`, `MAP-P`, `PSM-P`, ...). An SPDU whose payload cannot be
@@ -146,9 +145,6 @@ differences from the J2735 path:
 - **channel** is taken from the message configuration when set, otherwise from the DSRC metadata on
   the message, which the Message Receiver Plugin defaults to 183.
 
-> [!IMPORTANT]
-> Set **RouteJ2735** to `false` on the Message Receiver Plugin. Otherwise each received message
-> arrives here twice, once unsecured and once as the SPDU, and is broadcast twice.
 
 ## Functionality Testing
 

--- a/src/v2i-hub/ImmediateForwardPlugin/README.md
+++ b/src/v2i-hub/ImmediateForwardPlugin/README.md
@@ -131,6 +131,9 @@ differences from the J2735 path:
   identified is skipped and counted under `Messages Skipped (Invalid SPDU)`.
 - **psid** is *not* what gets broadcast. The PSID carried by the SPDU is sent instead, so that what
   goes out over the air matches the message that was received. Both values are logged at `DEBUG3`.
+  For NTCIP 1218, the PSID is written to the immediate forward table row on every send rather than
+  only at startup, so a row shared by configured and SPDU traffic always broadcasts under the PSID
+  belonging to the message currently in it.
 - **signMessages** must be `true`. The payload is already signed, so RSU4.1 connections send
   `Signature=True` and NTCIP 1218 rows are initialized with `rsuIFMOptions` `0x80`. SPDUs sent to a
   connection with `signMessages` set to `false` are skipped and logged as an error.

--- a/src/v2i-hub/ImmediateForwardPlugin/README.md
+++ b/src/v2i-hub/ImmediateForwardPlugin/README.md
@@ -132,12 +132,11 @@ differences from the J2735 path:
 - The **PSID** carried by the SPDU is sent instead. For NTCIP 1218, the PSID is written to the immediate forward table row on every send rather than
   only at startup, so a row shared by configured and SPDU traffic always broadcasts under the PSID
   belonging to the message currently in it.
-- **signMessages** is ignored for SPDUs and treated as `true`. The payload is already signed, so
-  RSU4.1 connections always send `Signature=True` and NTCIP 1218 sends always set `rsuIFMOptions` to
-  `0x80`. If the connection is configured with `signMessages` set to `false`, the SPDU is still
-  forwarded as signed and a warning is logged, at most once every 30 seconds per connection. Like the
-  PSID, the options bit is written on every NTCIP 1218 send rather than only at startup, so a row
-  shared by configured and SPDU traffic is always marked correctly for the message currently in it.
+- **signMessages** is ignored for SPDUs and treated as `true`, whatever the connection is configured
+  with. The payload is already signed, so RSU4.1 connections always send `Signature=True` and NTCIP
+  1218 sends always set `rsuIFMOptions` to `0x80`. Like the PSID, the options bit is written on every
+  NTCIP 1218 send rather than only at startup, so a row shared by configured and SPDU traffic is
+  always marked correctly for the message currently in it.
 - **enableHsm** is ignored for SPDUs. The plugin never asks the HSM to sign an already secured
   message.
 - **channel** is taken from the message configuration when set, otherwise from the DSRC metadata on

--- a/src/v2i-hub/ImmediateForwardPlugin/README.md
+++ b/src/v2i-hub/ImmediateForwardPlugin/README.md
@@ -24,7 +24,7 @@ This plugin has several configuration parameters. Below these are listed out as 
                 "address": "127.0.0.1", /** Address of RSU **/
                 "port": 1516, /** Default port for Immediate Forward protocol on RSU4.1 **/
                 "txMode": "CONT", /** Transmission Mode (CONT or ALT) **/
-                "signMessages": false, /** Flag to indicate whether message being forwarded to RSU is already signed**/
+                "signMessages": false, /** Flag to indicate whether the RSU should sign the message before broadcasting it**/
                 "messages": /** A list of V2X messages to be forwarded to this RSU. Any message types not listed here will not be forwarded to this RSU **/
                 [ 
                     { 
@@ -50,7 +50,7 @@ This plugin has several configuration parameters. Below these are listed out as 
                 "address": "127.0.0.1", /** Address of RSU **/
                 "port": 1516, /** Default port for Immediate Forward protocol on RSU4.1 **/
                 "txMode": "CONT", /** Transmission Mode (CONT or ALT) **/
-                "signMessages": true, /** Flag to indicate whether message being forwarded to RSU is already signed**/
+                "signMessages": true, /** Flag to indicate whether the RSU should sign the message before broadcasting it**/
                 "enableHsm": true, /** (Optional : default false) Flag to indicate whether V2X Hub should attempt to sign and verify message signatures via HSM **/ 
                 "hsmUrl": "http://<softhsm raspberrypi IP>:3000/v1/scms/", /** (Optional : only read when enableHsm true) URL of HSM API to provide signatures and verify signatures. **/
                 "messages": /** A list of V2X messages to be forwarded to this RSU. Any message types not listed here will not be forwarded to this RSU **/
@@ -132,11 +132,13 @@ differences from the J2735 path:
 - The **PSID** carried by the SPDU is sent instead. For NTCIP 1218, the PSID is written to the immediate forward table row on every send rather than
   only at startup, so a row shared by configured and SPDU traffic always broadcasts under the PSID
   belonging to the message currently in it.
-- **signMessages** is ignored for SPDUs and treated as `true`, whatever the connection is configured
-  with. The payload is already signed, so RSU4.1 connections always send `Signature=True` and NTCIP
-  1218 sends always set `rsuIFMOptions` to `0x80`. Like the PSID, the options bit is written on every
-  NTCIP 1218 send rather than only at startup, so a row shared by configured and SPDU traffic is
-  always marked correctly for the message currently in it.
+- **signMessages** is ignored for SPDUs and treated as `false`, whatever the connection is configured
+  with. `signMessages` asks the *RSU* to sign the payload before broadcast, and an SPDU is already a
+  complete signed 1609.2 message that must go out untouched. RSU4.1 connections therefore always send
+  `Signature=False`, and NTCIP 1218 sends always set `rsuIFMOptions` to `0x00`, leaving
+  `Bit 0 = Bypass1609.2`. Like the PSID, the options bit is written on every NTCIP 1218 send rather
+  than only at startup, so a row shared by configured and SPDU traffic is always marked correctly for
+  the message currently in it.
 - **enableHsm** is ignored for SPDUs. The plugin never asks the HSM to sign an already secured
   message.
 - **channel** is taken from the message configuration when set, otherwise from the DSRC metadata on

--- a/src/v2i-hub/ImmediateForwardPlugin/README.md
+++ b/src/v2i-hub/ImmediateForwardPlugin/README.md
@@ -136,7 +136,9 @@ differences from the J2735 path:
   with. `signMessages` asks the *RSU* to sign the payload before broadcast, and an SPDU is already a
   complete signed 1609.2 message that must go out untouched. RSU4.1 connections therefore always send
   `Signature=False`, and NTCIP 1218 sends always set `rsuIFMOptions` to `0x00`, leaving
-  `Bit 0 = Bypass1609.2`. Like the PSID, the options bit is written on every NTCIP 1218 send rather
+  `Bit 0 = Bypass1609.2` — per NTCIP 1218 5.5.2.7 this "allows the RSU to send the message that has
+  been signed and/or encrypted by the TMC", wrapping it in a WSMP header and nothing more. Like the
+  PSID, the options bit is written on every NTCIP 1218 send rather
   than only at startup, so a row shared by configured and SPDU traffic is always marked correctly for
   the message currently in it.
 - **enableHsm** is ignored for SPDUs. The plugin never asks the HSM to sign an already secured

--- a/src/v2i-hub/ImmediateForwardPlugin/README.md
+++ b/src/v2i-hub/ImmediateForwardPlugin/README.md
@@ -129,14 +129,15 @@ differences from the J2735 path:
 - **tmxType** is matched against the J2735 type of the message *inside* the SPDU, which uses the same
   labels as the J2735 path (`BSM`, `SPAT-P`, `MAP-P`, `PSM-P`, ...). An SPDU whose payload cannot be
   identified is skipped and counted under `Messages Skipped (Invalid SPDU)`.
-- **psid** is *not* what gets broadcast. The PSID carried by the SPDU is sent instead, so that what
-  goes out over the air matches the message that was received. Both values are logged at `DEBUG3`.
-  For NTCIP 1218, the PSID is written to the immediate forward table row on every send rather than
+- The **PSID** carried by the SPDU is sent instead. For NTCIP 1218, the PSID is written to the immediate forward table row on every send rather than
   only at startup, so a row shared by configured and SPDU traffic always broadcasts under the PSID
   belonging to the message currently in it.
-- **signMessages** must be `true`. The payload is already signed, so RSU4.1 connections send
-  `Signature=True` and NTCIP 1218 rows are initialized with `rsuIFMOptions` `0x80`. SPDUs sent to a
-  connection with `signMessages` set to `false` are skipped and logged as an error.
+- **signMessages** is ignored for SPDUs and treated as `true`. The payload is already signed, so
+  RSU4.1 connections always send `Signature=True` and NTCIP 1218 sends always set `rsuIFMOptions` to
+  `0x80`. If the connection is configured with `signMessages` set to `false`, the SPDU is still
+  forwarded as signed and a warning is logged, at most once every 30 seconds per connection. Like the
+  PSID, the options bit is written on every NTCIP 1218 send rather than only at startup, so a row
+  shared by configured and SPDU traffic is always marked correctly for the message currently in it.
 - **enableHsm** is ignored for SPDUs. The plugin never asks the HSM to sign an already secured
   message.
 - **channel** is taken from the message configuration when set, otherwise from the DSRC metadata on

--- a/src/v2i-hub/ImmediateForwardPlugin/README.md
+++ b/src/v2i-hub/ImmediateForwardPlugin/README.md
@@ -116,5 +116,32 @@ This plugin has several configuration parameters. Below these are listed out as 
 
 All V2X Messages
 
+## Raw SPDU Forwarding
+
+In addition to J2735 messages, this plugin forwards `RawSpdu` messages, which carry an IEEE 1609.2
+SPDU exactly as it was received. This is used to re-broadcast an already secured message without V2X
+Hub decoding, re-encoding or re-signing it. `RawSpdu` messages are produced by the
+[Message Receiver Plugin](../MessageReceiverPlugin/README.md) when its **FullSPDUMode** is enabled.
+
+No new configuration keys are needed. The existing `messages` entries are reused, with the following
+differences from the J2735 path:
+
+- **tmxType** is matched against the J2735 type of the message *inside* the SPDU, which uses the same
+  labels as the J2735 path (`BSM`, `SPAT-P`, `MAP-P`, `PSM-P`, ...). An SPDU whose payload cannot be
+  identified is skipped and counted under `Messages Skipped (Invalid SPDU)`.
+- **psid** is *not* what gets broadcast. The PSID carried by the SPDU is sent instead, so that what
+  goes out over the air matches the message that was received. Both values are logged at `DEBUG3`.
+- **signMessages** must be `true`. The payload is already signed, so RSU4.1 connections send
+  `Signature=True` and NTCIP 1218 rows are initialized with `rsuIFMOptions` `0x80`. SPDUs sent to a
+  connection with `signMessages` set to `false` are skipped and logged as an error.
+- **enableHsm** is ignored for SPDUs. The plugin never asks the HSM to sign an already secured
+  message.
+- **channel** is taken from the message configuration when set, otherwise from the DSRC metadata on
+  the message, which the Message Receiver Plugin defaults to 183.
+
+> [!IMPORTANT]
+> Set **RouteJ2735** to `false` on the Message Receiver Plugin. Otherwise each received message
+> arrives here twice, once unsecured and once as the SPDU, and is broadcast twice.
+
 ## Functionality Testing
 

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
@@ -154,10 +154,12 @@ namespace ImmediateForward {
             'x',
             stripPsidPrefix(psid)
         };
-        // 80 HEX is binary 10000000, which sets Bit 0 = Process1609.2, asking the RSU to build and
-        // sign the 1609.2 layer. 00 HEX leaves Bit 0 = Bypass1609.2, so an already secured payload
-        // is transmitted untouched. Note Bit 0 is the most significant bit here: this is the value
-        // a Yunex RSU expects, see rsuIFMOptionsOid for the bit definitions.
+        // 80 HEX is binary 10000000, setting Bit 0 = Process1609.2, which asks the RSU to secure the
+        // message itself. 00 HEX leaves Bit 0 = Bypass1609.2, which per NTCIP 1218 5.5.2.7 "allows
+        // the RSU to send the message that has been signed and/or encrypted by the TMC", wrapping it
+        // in a WSMP header and nothing more. That is what a forwarded raw SPDU needs. Bit 1
+        // (Secure/Unsecure) is ignored when Bit 0 = 0.
+        // Note Bit 0 is the most significant bit, which is what a Yunex RSU expects.
         snmp_request options{
             rsu::mib::ntcip1218::rsuIFMOptionsOid + "." + std::to_string(index),
             'x',

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
@@ -4,15 +4,9 @@ using namespace tmx::utils;
 
 namespace ImmediateForward {
 
-    namespace {
-        /**
-         * NTCIP writes PSIDs as bare hex digits, while both the plugin configuration and the PSIDs
-         * read out of forwarded SPDUs are written "0x<HEX>". Strip the prefix if one is present.
-         */
-        std::string stripPsidPrefix(const std::string &psid) {
-            size_t pos = psid.find("x");
-            return pos == std::string::npos ? psid : psid.substr(pos + 1);
-        }
+    std::string stripPsidPrefix(const std::string &psid) {
+        size_t pos = psid.find("x");
+        return pos == std::string::npos ? psid : psid.substr(pos + 1);
     }
 
     void clearImmediateForwardTable( tmx::utils::snmp_client* const client) {

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
@@ -143,12 +143,11 @@ namespace ImmediateForward {
     }
 
     void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index, const std::string &psid, bool signMessage){
-
-        // A row is shared by every message of one send type, and a forwarded raw SPDU broadcasts
-        // under the PSID it arrived with rather than the configured one, and must not be signed
-        // again. Writing both on every send keeps the row from carrying over what the previous
-        // message left behind. All requests go out in a single SET PDU, so this costs no additional
-        // round trip.
+        // A row is shared by every message of one send type. The psid and signMessage are
+        // now set for each outbound message since the SPDU should not be signed again and 
+        // its psid might not match the static configuration, but needs to be preserved. 
+        // Writing both on every send keeps the row from carrying over what the previous
+        // message left behind.
         snmp_request psidRequest{
             rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index),
             'x',

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
@@ -8,6 +8,12 @@ namespace ImmediateForward {
         size_t pos = psid.find("x");
         return pos == std::string::npos ? psid : psid.substr(pos + 1);
     }
+    std::string getPSIDWithoutPrefix(const std::string &psid){
+        if (psid.find("x") == std::string::npos) {
+            throw tmx::TmxException("Message PSID " + psid + " is malformed and should be formated 0x<PSID HEX>");
+        }
+        return stripPsidPrefix(psid);
+    }
 
     void clearImmediateForwardTable( tmx::utils::snmp_client* const client) {
 
@@ -74,10 +80,8 @@ namespace ImmediateForward {
             FILE_LOG(logDEBUG1) << "Creating IMF row " + std::to_string(curIndex) ;
             std::vector<snmp_request> requests;
            
-            if (message.psid.find("x") == std::string::npos) {
-                throw tmx::TmxException("Message PSID " + message.psid + " is malformed and should be formated 0x<PSID HEX>");
-            }
-            std::string messagePsidwithoutPrefix = stripPsidPrefix(message.psid);
+            std::string messagePsidwithoutPrefix = getPSIDWithoutPrefix(message.psid);
+
             snmp_request psid{
                 rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(curIndex),
                 'x',

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
@@ -142,16 +142,23 @@ namespace ImmediateForward {
         return tmxMessageTypeToIMFTableIndex;
     }
 
-    void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index, const std::string &psid){
+    void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index, const std::string &psid, bool signedPayload){
 
         // A row is shared by every message of one send type, and a forwarded raw SPDU broadcasts
-        // under the PSID it arrived with rather than the configured one. Writing the PSID on every
-        // send keeps the row from carrying over the PSID the previous message left behind. All
-        // requests go out in a single SET PDU, so this costs no additional round trip.
+        // under the PSID it arrived with rather than the configured one, and is always signed.
+        // Writing both on every send keeps the row from carrying over what the previous message left
+        // behind. All requests go out in a single SET PDU, so this costs no additional round trip.
         snmp_request psidRequest{
             rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index),
             'x',
             stripPsidPrefix(psid)
+        };
+        // Yunex value for signed messages
+        // binary 10000000 to hexidecimal 80 ( see rsuIFMOptionsOid for bit values )
+        snmp_request options{
+            rsu::mib::ntcip1218::rsuIFMOptionsOid + "." + std::to_string(index),
+            'x',
+            signedPayload ? "80" : "00"
         };
         snmp_request payload {
             rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index),
@@ -164,7 +171,7 @@ namespace ImmediateForward {
                 'i',
                 "1"
         };
-        std::vector reqs {psidRequest, payload, enable};
+        std::vector reqs {psidRequest, options, payload, enable};
         client->process_snmp_set_requests(reqs);
     }
 

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
@@ -3,6 +3,18 @@
 using namespace tmx::utils;
 
 namespace ImmediateForward {
+
+    namespace {
+        /**
+         * NTCIP writes PSIDs as bare hex digits, while both the plugin configuration and the PSIDs
+         * read out of forwarded SPDUs are written "0x<HEX>". Strip the prefix if one is present.
+         */
+        std::string stripPsidPrefix(const std::string &psid) {
+            size_t pos = psid.find("x");
+            return pos == std::string::npos ? psid : psid.substr(pos + 1);
+        }
+    }
+
     void clearImmediateForwardTable( tmx::utils::snmp_client* const client) {
 
         FILE_LOG(logDEBUG) << "Retrieving max Imf rows ..." ;
@@ -68,11 +80,10 @@ namespace ImmediateForward {
             FILE_LOG(logDEBUG1) << "Creating IMF row " + std::to_string(curIndex) ;
             std::vector<snmp_request> requests;
            
-            size_t pos = message.psid.find("x");
-            if (pos == std::string::npos) {
+            if (message.psid.find("x") == std::string::npos) {
                 throw tmx::TmxException("Message PSID " + message.psid + " is malformed and should be formated 0x<PSID HEX>");
             }
-            std::string messagePsidwithoutPrefix = message.psid.substr(pos+1);
+            std::string messagePsidwithoutPrefix = stripPsidPrefix(message.psid);
             snmp_request psid{
                 rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(curIndex),
                 'x',
@@ -137,8 +148,17 @@ namespace ImmediateForward {
         return tmxMessageTypeToIMFTableIndex;
     }
 
-    void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index, const std::optional<std::string> &psidOverride){
+    void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index, const std::string &psid){
 
+        // A row is shared by every message of one send type, and a forwarded raw SPDU broadcasts
+        // under the PSID it arrived with rather than the configured one. Writing the PSID on every
+        // send keeps the row from carrying over the PSID the previous message left behind. All
+        // requests go out in a single SET PDU, so this costs no additional round trip.
+        snmp_request psidRequest{
+            rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index),
+            'x',
+            stripPsidPrefix(psid)
+        };
         snmp_request payload {
             rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index),
             'x',
@@ -150,19 +170,7 @@ namespace ImmediateForward {
                 'i',
                 "1"
         };
-        std::vector reqs {payload, enable};
-        if (psidOverride.has_value()) {
-            // All requests go out in a single SET PDU, so updating the row PSID here costs no
-            // additional round trip.
-            size_t pos = psidOverride.value().find("x");
-            std::string psidWithoutPrefix = pos == std::string::npos ? psidOverride.value() : psidOverride.value().substr(pos+1);
-            snmp_request psid{
-                rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index),
-                'x',
-                psidWithoutPrefix
-            };
-            reqs.push_back(psid);
-        }
+        std::vector reqs {psidRequest, payload, enable};
         client->process_snmp_set_requests(reqs);
     }
 

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
@@ -137,8 +137,8 @@ namespace ImmediateForward {
         return tmxMessageTypeToIMFTableIndex;
     }
 
-    void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index){
-        
+    void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index, const std::optional<std::string> &psidOverride){
+
         snmp_request payload {
             rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index),
             'x',
@@ -151,6 +151,18 @@ namespace ImmediateForward {
                 "1"
         };
         std::vector reqs {payload, enable};
+        if (psidOverride.has_value()) {
+            // All requests go out in a single SET PDU, so updating the row PSID here costs no
+            // additional round trip.
+            size_t pos = psidOverride.value().find("x");
+            std::string psidWithoutPrefix = pos == std::string::npos ? psidOverride.value() : psidOverride.value().substr(pos+1);
+            snmp_request psid{
+                rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index),
+                'x',
+                psidWithoutPrefix
+            };
+            reqs.push_back(psid);
+        }
         client->process_snmp_set_requests(reqs);
     }
 

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.cpp
@@ -142,23 +142,26 @@ namespace ImmediateForward {
         return tmxMessageTypeToIMFTableIndex;
     }
 
-    void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index, const std::string &psid, bool signedPayload){
+    void sendNTCIP1218ImfMessage( snmp_client* const client, const std::string &message, unsigned int index, const std::string &psid, bool signMessage){
 
         // A row is shared by every message of one send type, and a forwarded raw SPDU broadcasts
-        // under the PSID it arrived with rather than the configured one, and is always signed.
-        // Writing both on every send keeps the row from carrying over what the previous message left
-        // behind. All requests go out in a single SET PDU, so this costs no additional round trip.
+        // under the PSID it arrived with rather than the configured one, and must not be signed
+        // again. Writing both on every send keeps the row from carrying over what the previous
+        // message left behind. All requests go out in a single SET PDU, so this costs no additional
+        // round trip.
         snmp_request psidRequest{
             rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index),
             'x',
             stripPsidPrefix(psid)
         };
-        // Yunex value for signed messages
-        // binary 10000000 to hexidecimal 80 ( see rsuIFMOptionsOid for bit values )
+        // 80 HEX is binary 10000000, which sets Bit 0 = Process1609.2, asking the RSU to build and
+        // sign the 1609.2 layer. 00 HEX leaves Bit 0 = Bypass1609.2, so an already secured payload
+        // is transmitted untouched. Note Bit 0 is the most significant bit here: this is the value
+        // a Yunex RSU expects, see rsuIFMOptionsOid for the bit definitions.
         snmp_request options{
             rsu::mib::ntcip1218::rsuIFMOptionsOid + "." + std::to_string(index),
             'x',
-            signedPayload ? "80" : "00"
+            signMessage ? "80" : "00"
         };
         snmp_request payload {
             rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index),

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
@@ -71,10 +71,10 @@ namespace ImmediateForward {
      * @param psid PSID to set on the table row, formatted "0x<HEX>" or "<HEX>". Always written,
      * because a single row carries a mix of configured PSIDs and PSIDs taken from forwarded raw
      * SPDUs; leaving the row on whatever the previous send set would broadcast under the wrong PSID.
-     * @param signedPayload Whether the payload already carries its own 1609.2 signature, written to
-     * rsuIFMOptions. Written on every send for the same reason as the PSID: a raw SPDU is always
-     * signed, whatever the connection was configured with.
+     * @param signMessage Whether the RSU should process and sign the 1609.2 layer itself, written to
+     * rsuIFMOptions. Written on every send for the same reason as the PSID: a forwarded raw SPDU is
+     * already signed and must be transmitted as-is, whatever the connection was configured with.
      */
-    void sendNTCIP1218ImfMessage( tmx::utils::snmp_client*  const client, const std::string &message, unsigned int index, const std::string &psid, bool signedPayload);
+    void sendNTCIP1218ImfMessage( tmx::utils::snmp_client*  const client, const std::string &message, unsigned int index, const std::string &psid, bool signMessage);
 
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
@@ -71,7 +71,10 @@ namespace ImmediateForward {
      * @param psid PSID to set on the table row, formatted "0x<HEX>" or "<HEX>". Always written,
      * because a single row carries a mix of configured PSIDs and PSIDs taken from forwarded raw
      * SPDUs; leaving the row on whatever the previous send set would broadcast under the wrong PSID.
+     * @param signedPayload Whether the payload already carries its own 1609.2 signature, written to
+     * rsuIFMOptions. Written on every send for the same reason as the PSID: a raw SPDU is always
+     * signed, whatever the connection was configured with.
      */
-    void sendNTCIP1218ImfMessage( tmx::utils::snmp_client*  const client, const std::string &message, unsigned int index, const std::string &psid);
+    void sendNTCIP1218ImfMessage( tmx::utils::snmp_client*  const client, const std::string &message, unsigned int index, const std::string &psid, bool signedPayload);
 
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
@@ -17,7 +17,6 @@
 #include <SNMPClient.h>
 #include <vector>
 #include <unordered_map>
-#include <optional>
 #include <string>
 #include <rsu/NTCIP_1218_MIB.h>
 #include <rsu/RSU_MIB_4_1.h>
@@ -58,11 +57,10 @@ namespace ImmediateForward {
      * @param client The SNMP client to use for the operation
      * @param message The IMF message to send
      * @param index The index of the message in the table
-     * @param psidOverride Optional PSID, formatted "0x<HEX>" or "<HEX>", to set on the table row
-     * before transmitting. Used when forwarding a raw SPDU, whose PSID comes from the message itself
-     * rather than from the configuration the row was initialized with. When unset the row keeps the
-     * PSID it was initialized with.
+     * @param psid PSID to set on the table row, formatted "0x<HEX>" or "<HEX>". Always written,
+     * because a single row carries a mix of configured PSIDs and PSIDs taken from forwarded raw
+     * SPDUs; leaving the row on whatever the previous send set would broadcast under the wrong PSID.
      */
-    void sendNTCIP1218ImfMessage( tmx::utils::snmp_client*  const client, const std::string &message, unsigned int index, const std::optional<std::string> &psidOverride = std::nullopt);
+    void sendNTCIP1218ImfMessage( tmx::utils::snmp_client*  const client, const std::string &message, unsigned int index, const std::string &psid);
 
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
@@ -17,6 +17,7 @@
 #include <SNMPClient.h>
 #include <vector>
 #include <unordered_map>
+#include <optional>
 #include <string>
 #include <rsu/NTCIP_1218_MIB.h>
 #include <rsu/RSU_MIB_4_1.h>
@@ -57,7 +58,11 @@ namespace ImmediateForward {
      * @param client The SNMP client to use for the operation
      * @param message The IMF message to send
      * @param index The index of the message in the table
+     * @param psidOverride Optional PSID, formatted "0x<HEX>" or "<HEX>", to set on the table row
+     * before transmitting. Used when forwarding a raw SPDU, whose PSID comes from the message itself
+     * rather than from the configuration the row was initialized with. When unset the row keeps the
+     * PSID it was initialized with.
      */
-    void sendNTCIP1218ImfMessage( tmx::utils::snmp_client*  const client, const std::string &message, unsigned int index);
+    void sendNTCIP1218ImfMessage( tmx::utils::snmp_client*  const client, const std::string &message, unsigned int index, const std::optional<std::string> &psidOverride = std::nullopt);
 
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/IMFNTCIP1218Worker.h
@@ -24,7 +24,18 @@
 #include "ImmediateForwardConfiguration.h"
 
 namespace ImmediateForward {
-    
+
+    /**
+     * @brief Strip the "0x" prefix from a PSID.
+     *
+     * NTCIP writes PSIDs as bare hex digits, while both the plugin configuration and the PSIDs read
+     * out of forwarded SPDUs are written "0x<HEX>".
+     *
+     * @param psid The PSID, with or without a "0x" prefix.
+     * @return The hex digits alone. A PSID with no prefix is returned unchanged.
+     */
+    std::string stripPsidPrefix(const std::string &psid);
+
     /**
      * @brief Clear the immediate forward table on the RSU
      * @param client The SNMP client to use for the operation

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -23,12 +23,6 @@ using namespace tmx::utils;
 namespace ImmediateForward
 {	
 	ImmediateForwardPlugin::ImmediateForwardPlugin(const std::string &name) : PluginClient(name),
-		_configRead(false),
-		_skippedNoDsrcMetadata(0),
-		_skippedNoMessageRoute(0),
-		_skippedInvalidUdpClient(0),
-		_skippedSignErrorResponse(0),
-		_skippedInvalidSpdu(0)
 	{
 		AddMessageFilter("J2735", "*", IvpMsgFlags_RouteDSRC);
 		AddMessageFilter("Battelle-DSRC", "*", IvpMsgFlags_RouteDSRC);

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -27,6 +27,7 @@ namespace ImmediateForward
 		_skippedNoDsrcMetadata(0),
 		_skippedNoMessageRoute(0),
 		_skippedInvalidUdpClient(0),
+		_skippedSignErrorResponse(0),
 		_skippedInvalidSpdu(0)
 	{
 		AddMessageFilter("J2735", "*", IvpMsgFlags_RouteDSRC);

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -27,15 +27,20 @@ namespace ImmediateForward
 	const char* Key_SkippedNoMessageRoute = "Messages Skipped (No route)";
 	const char* Key_SkippedSignError = "Message Skipped (Signature Error Response)";
 	const char* Key_SkippedInvalidUdpClient = "Messages Skipped (Invalid UDP Client)";
+	const char* Key_SkippedInvalidSpdu = "Messages Skipped (Invalid SPDU)";
 
 	ImmediateForwardPlugin::ImmediateForwardPlugin(const std::string &name) : PluginClient(name),
 		_configRead(false),
 		_skippedNoDsrcMetadata(0),
 		_skippedNoMessageRoute(0),
-		_skippedInvalidUdpClient(0)
+		_skippedInvalidUdpClient(0),
+		_skippedInvalidSpdu(0)
 	{
 		AddMessageFilter("J2735", "*", IvpMsgFlags_RouteDSRC);
 		AddMessageFilter("Battelle-DSRC", "*", IvpMsgFlags_RouteDSRC);
+		// Raw 1609.2 SPDUs, published by MessageReceiverPlugin in FullSPDUMode, are forwarded to the
+		// radio exactly as received rather than being re-encoded or re-signed.
+		AddMessageFilter(tmx::messages::RawSpdu::MessageType, "*", IvpMsgFlags_RouteDSRC);
 		SubscribeToMessages();
 
 	}
@@ -89,10 +94,12 @@ namespace ImmediateForward
 		_skippedNoMessageRoute = 0;
 		_skippedInvalidUdpClient = 0;
 		_skippedSignErrorResponse = 0;
+		_skippedInvalidSpdu = 0;
 		SetStatus<uint>(Key_SkippedNoDsrcMetadata, _skippedNoDsrcMetadata);
 		SetStatus<uint>(Key_SkippedNoMessageRoute, _skippedNoMessageRoute);
 		SetStatus<uint>(Key_SkippedInvalidUdpClient, _skippedInvalidUdpClient);
 		SetStatus<uint>(Key_SkippedSignError, _skippedSignErrorResponse);
+		SetStatus<uint>(Key_SkippedInvalidSpdu, _skippedInvalidSpdu);
 		std::string immediateForwardConfigurationsJson;
 		GetConfigValue<string>("ImmediateForwardConfigurations", immediateForwardConfigurationsJson);
 		_imfConfigs.clear();
@@ -205,11 +212,11 @@ namespace ImmediateForward
 		base642hex(signedMsg, payloadbyte); // this allows sending hex of the signed message rather than base64
 	}
 
-	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte){
+	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const std::optional<std::string>& psidOverride){
 		stringstream os;
 		os << "Version=0.7" << "\n"
-		   << "Type=" << messageConfig.sendType << "\n" 
-		   << "PSID=" << messageConfig.psid << "\n";
+		   << "Type=" << messageConfig.sendType << "\n"
+		   << "PSID=" << psidOverride.value_or(messageConfig.psid) << "\n";
 		if (!messageConfig.channel.has_value()) {
 			os << "Priority=7" << "\n" 
 			   << "TxMode=" << txModeToString(imfConfig.mode) << "\n"
@@ -235,9 +242,40 @@ namespace ImmediateForward
 		bool foundMessageType = false;
 		static FrequencyThrottle<std::string> _statusThrottle(chrono::milliseconds(2000));
 
+		// A raw SPDU carries its payload as a JSON object rather than a hex string, and routes on the
+		// J2735 type of the message inside the SPDU rather than on the TMX subtype, which is always
+		// "Basic" for a RawSpdu.
+		const bool isSpdu = (strcmp(msg->type, tmx::messages::RawSpdu::MessageType) == 0);
+		tmx::messages::RawSpdu rawSpdu;
+		string tmxType;
+		string spduPayload;
+
+		if (isSpdu)
+		{
+			try {
+				rawSpdu = getRawSpdu(msg);
+			}
+			catch (const std::exception &ex) {
+				SetStatus<uint>(Key_SkippedInvalidSpdu, ++_skippedInvalidSpdu);
+				PLOG(logWARNING) << "Could not forward SPDU. Message Ignored: " << ex.what();
+				return;
+			}
+			tmxType = rawSpdu.get_messageType();
+			spduPayload = toUpperHex(rawSpdu.get_fullByteData());
+		}
+		else
+		{
+			tmxType = msg->subtype;
+
+			// Convert the payload to upper case.
+			for (int i = 0; i < (int)(strlen(msg->payload->valuestring)); i++){
+				msg->payload->valuestring[i] = toupper(msg->payload->valuestring[i]);
+			}
+		}
+
 		int msgCount = 0;
 
-		std::map<std::string, int>::iterator itMsgCount = _messageCountMap.find(msg->subtype);
+		std::map<std::string, int>::iterator itMsgCount = _messageCountMap.find(tmxType);
 
 		if(itMsgCount != _messageCountMap.end())
 		{
@@ -245,16 +283,11 @@ namespace ImmediateForward
 			msgCount ++;
 		}
 
-		_messageCountMap[msg->subtype] = msgCount;
+		_messageCountMap[tmxType] = msgCount;
 
 
-		if (_statusThrottle.Monitor(msg->subtype)) {
-			SetStatus<int>(msg->subtype, msgCount);
-		}
-
-		// Convert the payload to upper case.
-		for (int i = 0; i < (int)(strlen(msg->payload->valuestring)); i++){
-			msg->payload->valuestring[i] = toupper(msg->payload->valuestring[i]);
+		if (_statusThrottle.Monitor(tmxType)) {
+			SetStatus<int>(tmxType.c_str(), msgCount);
 		}
 
 		//loop through all MessageConfig and send to each with the proper TmxType
@@ -262,16 +295,38 @@ namespace ImmediateForward
 		{
 			for ( const auto &messageConfig: imfConfig.messageConfigs )
 			{
-				if (messageConfig.tmxType != msg->subtype){continue;}
-				
+				if (messageConfig.tmxType != tmxType){continue;}
+
 				foundMessageType = true;
 				string payloadbyte="";
+				std::optional<std::string> psidOverride;
 
 				// Format the message using the protocol defined in the
 				// USDOT ROadside Unit Specifications Document v 4.0 Appendix C.
 
+				if (isSpdu)
+				{
+					// NTCIP 1218 rows are initialized once with rsuIFMOptions 0x80 when signMessages
+					// is set, which is what tells the RSU the payload already carries its own
+					// signature. RSU4.1 likewise sends Signature=True from this flag. Forwarding an
+					// already signed SPDU without it would broadcast incorrectly.
+					if (!imfConfig.signMessage)
+					{
+						SetStatus<uint>(Key_SkippedInvalidSpdu, ++_skippedInvalidSpdu);
+						PLOG(logERROR) << "Cannot forward SPDU to " << imfConfig.name
+									   << ": set signMessages to true to forward already signed messages.";
+						continue;
+					}
+					// The SPDU is forwarded byte for byte, with the PSID it was received with, so
+					// that what is broadcast matches the message that came in.
+					payloadbyte = spduPayload;
+					psidOverride = toPsidHex(rawSpdu.get_psid());
+					PLOG(logDEBUG3) << "Forwarding SPDU with PSID " << psidOverride.value()
+									<< " (configured PSID for " << messageConfig.tmxType << " is "
+									<< messageConfig.psid << ")";
+				}
 				/// if signing is Enabled, request signing with HSM
-				if (imfConfig.enableHsm == 1)
+				else if (imfConfig.enableHsm == 1)
 				{
 					try {
 						SignWithHsm(imfConfig, messageConfig, msg, payloadbyte);
@@ -290,26 +345,26 @@ namespace ImmediateForward
 				}
 
 				if (imfConfig.spec == tmx::utils::rsu::RSU_SPEC::RSU_4_1) {
-					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte);
+					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, psidOverride);
 
 					auto &client = _udpClientMap.at(imfConfig.name);
 					client->Send(message);
 
-					PLOG(logDEBUG1) << _logPrefix 
-									<< "Sending - TmxType: " << messageConfig.tmxType 
+					PLOG(logDEBUG1) << _logPrefix
+									<< "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType
-									<< ", PSID: " << messageConfig.psid 
+									<< ", PSID: " << psidOverride.value_or(messageConfig.psid)
 									<< ", Client: " << client->GetAddress()
 									<< ", Channel: " << (messageConfig.channel.has_value() ? ::to_string( msg->dsrcMetadata->channel) : ::to_string(messageConfig.channel.value()))
 									<< ", Port: " << client->GetAddress();
 				}
 				else {
 					const auto &client = _snmpClientMap.at(imfConfig.name);
-					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType]);
+					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psidOverride);
 
-					PLOG(logDEBUG2) << "Sending - TmxType: " << messageConfig.tmxType 
+					PLOG(logDEBUG2) << "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType
-									<< ", PSID: " << messageConfig.psid 
+									<< ", PSID: " << psidOverride.value_or(messageConfig.psid)
 									<< ", Client: " << client->get_port()
 									<< ", Channel: " << (messageConfig.channel.has_value() ? ::to_string( msg->dsrcMetadata->channel) : ::to_string(messageConfig.channel.value()))
 									<< ", Port: " << client->get_port();
@@ -321,7 +376,7 @@ namespace ImmediateForward
 		{
 			SetStatus<uint>(Key_SkippedNoMessageRoute, ++_skippedNoMessageRoute);
 			PLOG(logWARNING)<<" WARNING TMX Subtype not found in configuration. Message Ignored: " <<
-					"Type: " << msg->type << ", Subtype: " << msg->subtype;
+					"Type: " << msg->type << ", Subtype: " << tmxType;
 			return;
 		}
 

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -316,9 +316,6 @@ namespace ImmediateForward
 					// The SPDU is forwarded byte for byte, under its own PSID.
 					payloadbyte = spduPayload;
 					psid = toPsidHex(rawSpdu.get_psid());
-					PLOG(logDEBUG3) << "Forwarding SPDU with PSID " << psid
-									<< " (configured PSID for " << messageConfig.tmxType << " is "
-									<< messageConfig.psid << ")";
 				}
 				/// if signing is Enabled, request signing with HSM
 				else if (imfConfig.enableHsm == 1)

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -212,7 +212,7 @@ namespace ImmediateForward
 		base642hex(signedMsg, payloadbyte); // this allows sending hex of the signed message rather than base64
 	}
 
-	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signature){
+	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signMessage){
 		stringstream os;
 		os << "Version=0.7" << "\n"
 		   << "Type=" << messageConfig.sendType << "\n"
@@ -230,7 +230,7 @@ namespace ImmediateForward
 		os << "TxInterval=0" << "\n" 
 		   << "DeliveryStart=\n" 
 		   << "DeliveryStop=\n"
-		   << "Signature=" << (signature ? "True" : "False") << "\n"
+		   << "Signature=" << (signMessage ? "True" : "False") << "\n"
 		   << "Encryption=False\n"
 		   << "Payload=" << payloadbyte << "\n";
 
@@ -302,17 +302,17 @@ namespace ImmediateForward
 				// A forwarded SPDU broadcasts under the PSID it arrived with, so that what goes out
 				// over the air matches the message that came in.
 				string psid = messageConfig.psid;
-				bool signature = imfConfig.signMessage;
+				bool signMessage = imfConfig.signMessage;
 
 				// Format the message using the protocol defined in the
 				// USDOT ROadside Unit Specifications Document v 4.0 Appendix C.
 
 				if (isSpdu)
 				{
-					// A raw SPDU always carries its own 1609.2 signature, whatever the connection was
-					// configured with, so the signed flag is forced rather than read from the config.
-					// Telling the RSU otherwise would make it sign an already signed payload.
-					signature = true;
+					// A raw SPDU is already a complete, signed 1609.2 message, so the RSU must transmit
+					// it as-is rather than signing it again. signMessages asks the RSU to sign, so it
+					// is forced off here whatever the connection was configured with.
+					signMessage = false;
 					// The SPDU is forwarded byte for byte, under its own PSID.
 					payloadbyte = spduPayload;
 					psid = toPsidHex(rawSpdu.get_psid());
@@ -340,7 +340,7 @@ namespace ImmediateForward
 				}
 
 				if (imfConfig.spec == tmx::utils::rsu::RSU_SPEC::RSU_4_1) {
-					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, psid, signature);
+					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, psid, signMessage);
 
 					auto &client = _udpClientMap.at(imfConfig.name);
 					client->Send(message);
@@ -355,7 +355,7 @@ namespace ImmediateForward
 				}
 				else {
 					const auto &client = _snmpClientMap.at(imfConfig.name);
-					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psid, signature);
+					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psid, signMessage);
 
 					PLOG(logDEBUG2) << "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -204,11 +204,11 @@ namespace ImmediateForward
 		base642hex(signedMsg, payloadbyte); // this allows sending hex of the signed message rather than base64
 	}
 
-	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signMessage){
+	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, bool signMessage){
 		stringstream os;
 		os << "Version=0.7" << "\n"
 		   << "Type=" << messageConfig.sendType << "\n"
-		   << "PSID=" << psid << "\n";
+		   << "PSID=" << messageConfig.psid << "\n";
 		if (!messageConfig.channel.has_value()) {
 			os << "Priority=7" << "\n" 
 			   << "TxMode=" << txModeToString(imfConfig.mode) << "\n"
@@ -321,7 +321,7 @@ namespace ImmediateForward
 				}
 
 				if (imfConfig.spec == tmx::utils::rsu::RSU_SPEC::RSU_4_1) {
-					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, messageConfig.psid, signMessage);
+					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, signMessage);
 
 					auto &client = _udpClientMap.at(imfConfig.name);
 					client->Send(message);

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -38,8 +38,6 @@ namespace ImmediateForward
 	{
 		AddMessageFilter("J2735", "*", IvpMsgFlags_RouteDSRC);
 		AddMessageFilter("Battelle-DSRC", "*", IvpMsgFlags_RouteDSRC);
-		// Raw 1609.2 SPDUs, published by MessageReceiverPlugin in FullSPDUMode, are forwarded to the
-		// radio exactly as received rather than being re-encoded or re-signed.
 		AddMessageFilter(tmx::messages::RawSpdu::MessageType, "*", IvpMsgFlags_RouteDSRC);
 		SubscribeToMessages();
 
@@ -250,10 +248,7 @@ namespace ImmediateForward
 		bool foundMessageType = false;
 		static FrequencyThrottle<std::string> _statusThrottle(chrono::milliseconds(2000));
 
-		// A raw SPDU carries its payload as a JSON object rather than a hex string, and routes on the
-		// J2735 type of the message inside the SPDU rather than on the TMX subtype, which is always
-		// "Basic" for a RawSpdu.
-		const bool isSpdu = (strcmp(msg->type, tmx::messages::RawSpdu::MessageType) == 0);
+		const bool isSpdu = IsSPDU(msg);
 		tmx::messages::RawSpdu rawSpdu;
 		string tmxType;
 		string spduPayload;
@@ -263,7 +258,7 @@ namespace ImmediateForward
 			try {
 				rawSpdu = getRawSpdu(msg);
 			}
-			catch (const std::exception &ex) {
+			catch (const tmx::TmxException &ex) {
 				SetStatus<uint>(Key_SkippedInvalidSpdu, ++_skippedInvalidSpdu);
 				PLOG(logWARNING) << "Could not forward SPDU. Message Ignored: " << ex.what();
 				return;
@@ -307,8 +302,6 @@ namespace ImmediateForward
 
 				foundMessageType = true;
 				string payloadbyte="";
-				// A forwarded SPDU broadcasts under the PSID it arrived with, so that what goes out
-				// over the air matches the message that came in.
 				string psid = messageConfig.psid;
 				bool signMessage = imfConfig.signMessage;
 
@@ -317,13 +310,10 @@ namespace ImmediateForward
 
 				if (isSpdu)
 				{
-					// A raw SPDU is already a complete, signed 1609.2 message, so the RSU must transmit
-					// it as-is rather than signing it again. signMessages asks the RSU to sign, so it
-					// is forced off here whatever the connection was configured with.
+					// A raw SPDU is already signed so the RSU must not sign again. signMessages is thus set to false.
 					signMessage = false;
-					// The SPDU is forwarded byte for byte, under its own PSID.
 					payloadbyte = spduPayload;
-					psid = toPsidHex(rawSpdu.get_psid());
+					psid = toPsidHex(rawSpdu.get_psid());  // The SPDU is forwarded under its own PSID.
 				}
 				/// if signing is Enabled, request signing with HSM
 				else if (imfConfig.enableHsm == 1)
@@ -356,18 +346,20 @@ namespace ImmediateForward
 									<< ", PSID: " << psid
 									<< ", Client: " << client->GetAddress()
 									<< ", Channel: " << (messageConfig.channel.has_value() ? ::to_string( msg->dsrcMetadata->channel) : ::to_string(messageConfig.channel.value()))
-									<< ", Port: " << client->GetAddress();
+									<< ", Port: " << client->GetAddress()
+									<< ", SignMessage: " << signMessage;
 				}
 				else {
 					const auto &client = _snmpClientMap.at(imfConfig.name);
 					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psid, signMessage);
 
-					PLOG(logDEBUG2) << "Sending - TmxType: " << messageConfig.tmxType
+					PLOG(logDEBUG1) << "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType
 									<< ", PSID: " << psid
 									<< ", Client: " << client->get_port()
 									<< ", Channel: " << (messageConfig.channel.has_value() ? ::to_string( msg->dsrcMetadata->channel) : ::to_string(messageConfig.channel.value()))
-									<< ", Port: " << client->get_port();
+									<< ", Port: " << client->get_port()
+									<< ", SignMessage: " << signMessage;
 				}
 		
 			}

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -148,6 +148,14 @@ namespace ImmediateForward
 
 	}
 
+	inline bool ImmediateForwardPlugin::IsSPDU(const IvpMessage *msg)
+	{
+		using tmx::messages::RawSpdu;
+		return msg &&
+			msg->type && strcmp(msg->type, RawSpdu::MessageType) == 0 &&
+			msg->subtype && strcmp(msg->subtype, RawSpdu::MessageSubType) == 0;
+	}
+
 	inline void ImmediateForwardPlugin::SignWithHsm(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, string& payloadbyte)
 	{
 		std::string mType = messageConfig.sendType;

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -22,7 +22,7 @@ using namespace tmx::utils;
 
 namespace ImmediateForward
 {	
-	ImmediateForwardPlugin::ImmediateForwardPlugin(const std::string &name) : PluginClient(name),
+	ImmediateForwardPlugin::ImmediateForwardPlugin(const std::string &name) : PluginClient(name)
 	{
 		AddMessageFilter("J2735", "*", IvpMsgFlags_RouteDSRC);
 		AddMessageFilter("Battelle-DSRC", "*", IvpMsgFlags_RouteDSRC);

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -212,7 +212,7 @@ namespace ImmediateForward
 		base642hex(signedMsg, payloadbyte); // this allows sending hex of the signed message rather than base64
 	}
 
-	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid){
+	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signature){
 		stringstream os;
 		os << "Version=0.7" << "\n"
 		   << "Type=" << messageConfig.sendType << "\n"
@@ -230,7 +230,7 @@ namespace ImmediateForward
 		os << "TxInterval=0" << "\n" 
 		   << "DeliveryStart=\n" 
 		   << "DeliveryStop=\n"
-		   << "Signature=" << (imfConfig.signMessage ? "True" : "False") << "\n" 
+		   << "Signature=" << (signature ? "True" : "False") << "\n"
 		   << "Encryption=False\n"
 		   << "Payload=" << payloadbyte << "\n";
 
@@ -241,6 +241,9 @@ namespace ImmediateForward
 	{
 		bool foundMessageType = false;
 		static FrequencyThrottle<std::string> _statusThrottle(chrono::milliseconds(2000));
+		// Misconfigured signMessages is a persistent condition, so warn about it sparingly rather
+		// than once per forwarded message.
+		static FrequencyThrottle<std::string> _signMessageThrottle(chrono::milliseconds(30000));
 
 		// A raw SPDU carries its payload as a JSON object rather than a hex string, and routes on the
 		// J2735 type of the message inside the SPDU rather than on the TMX subtype, which is always
@@ -302,23 +305,22 @@ namespace ImmediateForward
 				// A forwarded SPDU broadcasts under the PSID it arrived with, so that what goes out
 				// over the air matches the message that came in.
 				string psid = messageConfig.psid;
+				bool signature = imfConfig.signMessage;
 
 				// Format the message using the protocol defined in the
 				// USDOT ROadside Unit Specifications Document v 4.0 Appendix C.
 
 				if (isSpdu)
 				{
-					// NTCIP 1218 rows are initialized once with rsuIFMOptions 0x80 when signMessages
-					// is set, which is what tells the RSU the payload already carries its own
-					// signature. RSU4.1 likewise sends Signature=True from this flag. Forwarding an
-					// already signed SPDU without it would broadcast incorrectly.
-					if (!imfConfig.signMessage)
+					// A raw SPDU always carries its own 1609.2 signature, whatever the connection was
+					// configured with, so the signed flag is forced rather than read from the config.
+					// Telling the RSU otherwise would make it sign an already signed payload.
+					if (!imfConfig.signMessage && _signMessageThrottle.Monitor(imfConfig.name))
 					{
-						SetStatus<uint>(Key_SkippedInvalidSpdu, ++_skippedInvalidSpdu);
-						PLOG(logERROR) << "Cannot forward SPDU to " << imfConfig.name
-									   << ": set signMessages to true to forward already signed messages.";
-						continue;
+						PLOG(logWARNING) << "signMessages is false for " << imfConfig.name
+										 << ", but raw SPDUs are already signed. Forwarding as signed.";
 					}
+					signature = true;
 					// The SPDU is forwarded byte for byte, under its own PSID.
 					payloadbyte = spduPayload;
 					psid = toPsidHex(rawSpdu.get_psid());
@@ -346,7 +348,7 @@ namespace ImmediateForward
 				}
 
 				if (imfConfig.spec == tmx::utils::rsu::RSU_SPEC::RSU_4_1) {
-					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, psid);
+					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, psid, signature);
 
 					auto &client = _udpClientMap.at(imfConfig.name);
 					client->Send(message);
@@ -361,7 +363,7 @@ namespace ImmediateForward
 				}
 				else {
 					const auto &client = _snmpClientMap.at(imfConfig.name);
-					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psid);
+					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psid, signature);
 
 					PLOG(logDEBUG2) << "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -237,9 +237,8 @@ namespace ImmediateForward
 		const bool isSpdu = IsSPDU(msg);
 		string tmxType;
 		string payload;
-		string psid;
 
-		if (isSpdu)  // set tmxType and payload depending on whether it is spdu or not. In case of spdu, also set the psid.
+		if (isSpdu)  // set tmxType and payload depending on whether it is spdu or not.
 		{	
 			tmx::messages::RawSpdu rawSpdu;
 			try {
@@ -252,7 +251,6 @@ namespace ImmediateForward
 			}
 			tmxType = rawSpdu.get_messageType();
 			payload = toUpperHex(rawSpdu.get_fullByteData());
-			psid = toPsidHex(rawSpdu.get_psid());
 		}
 		else
 		{
@@ -292,7 +290,6 @@ namespace ImmediateForward
 
 				foundMessageType = true;
 				string payloadbyte="";
-				if(!isSpdu){psid = messageConfig.psid;}  // if not spdu, use config psid
 				bool signMessage = imfConfig.signMessage;
 
 				// Format the message using the protocol defined in the
@@ -332,7 +329,7 @@ namespace ImmediateForward
 					PLOG(logDEBUG1) << _logPrefix
 									<< "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType
-									<< ", PSID: " << psid
+									<< ", PSID: " << messageConfig.psid
 									<< ", Client: " << client->GetAddress()
 									<< ", Channel: " << (messageConfig.channel.has_value() ? ::to_string( msg->dsrcMetadata->channel) : ::to_string(messageConfig.channel.value()))
 									<< ", Port: " << client->GetAddress()
@@ -344,7 +341,7 @@ namespace ImmediateForward
 
 					PLOG(logDEBUG1) << "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType
-									<< ", PSID: " << psid
+									<< ", PSID: " << messageConfig.psid
 									<< ", Client: " << client->get_port()
 									<< ", Channel: " << (messageConfig.channel.has_value() ? ::to_string( msg->dsrcMetadata->channel) : ::to_string(messageConfig.channel.value()))
 									<< ", Port: " << client->get_port()

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -321,7 +321,7 @@ namespace ImmediateForward
 				}
 
 				if (imfConfig.spec == tmx::utils::rsu::RSU_SPEC::RSU_4_1) {
-					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, psid, signMessage);
+					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, messageConfig.psid, signMessage);
 
 					auto &client = _udpClientMap.at(imfConfig.name);
 					client->Send(message);
@@ -337,7 +337,7 @@ namespace ImmediateForward
 				}
 				else {
 					const auto &client = _snmpClientMap.at(imfConfig.name);
-					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psid, signMessage);
+					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], messageConfig.psid, signMessage);
 
 					PLOG(logDEBUG1) << "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -21,14 +21,7 @@ using namespace std;
 using namespace tmx::utils;
 
 namespace ImmediateForward
-{
-
-	const char* Key_SkippedNoDsrcMetadata = "Messages Skipped (No DSRC metadata)";
-	const char* Key_SkippedNoMessageRoute = "Messages Skipped (No route)";
-	const char* Key_SkippedSignError = "Message Skipped (Signature Error Response)";
-	const char* Key_SkippedInvalidUdpClient = "Messages Skipped (Invalid UDP Client)";
-	const char* Key_SkippedInvalidSpdu = "Messages Skipped (Invalid SPDU)";
-
+{	
 	ImmediateForwardPlugin::ImmediateForwardPlugin(const std::string &name) : PluginClient(name),
 		_configRead(false),
 		_skippedNoDsrcMetadata(0),
@@ -146,12 +139,6 @@ namespace ImmediateForward
 
 	}
 
-	inline bool ImmediateForwardPlugin::IsSPDU(const IvpMessage *msg)
-	{
-		using tmx::messages::RawSpdu;
-		return msg &&
-			msg->type && strcmp(msg->type, RawSpdu::MessageType) == 0;
-	}
 
 	inline void ImmediateForwardPlugin::SignWithHsm(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, string& payloadbyte)
 	{
@@ -248,12 +235,13 @@ namespace ImmediateForward
 		static FrequencyThrottle<std::string> _statusThrottle(chrono::milliseconds(2000));
 
 		const bool isSpdu = IsSPDU(msg);
-		tmx::messages::RawSpdu rawSpdu;
 		string tmxType;
-		string spduPayload;
+		string payload;
+		string psid;
 
-		if (isSpdu)
-		{
+		if (isSpdu)  // set tmxType and payload depending on whether it is spdu or not. In case of spdu, also set the psid.
+		{	
+			tmx::messages::RawSpdu rawSpdu;
 			try {
 				rawSpdu = getRawSpdu(msg);
 			}
@@ -263,7 +251,8 @@ namespace ImmediateForward
 				return;
 			}
 			tmxType = rawSpdu.get_messageType();
-			spduPayload = toUpperHex(rawSpdu.get_fullByteData());
+			payload = toUpperHex(rawSpdu.get_fullByteData());
+			psid = toPsidHex(rawSpdu.get_psid());
 		}
 		else
 		{
@@ -273,6 +262,8 @@ namespace ImmediateForward
 			for (int i = 0; i < (int)(strlen(msg->payload->valuestring)); i++){
 				msg->payload->valuestring[i] = toupper(msg->payload->valuestring[i]);
 			}
+
+			payload = msg->payload->valuestring;
 		}
 
 		int msgCount = 0;
@@ -301,7 +292,7 @@ namespace ImmediateForward
 
 				foundMessageType = true;
 				string payloadbyte="";
-				string psid = messageConfig.psid;
+				if(!isSpdu){psid = messageConfig.psid;}  // if not spdu, use config psid
 				bool signMessage = imfConfig.signMessage;
 
 				// Format the message using the protocol defined in the
@@ -311,8 +302,7 @@ namespace ImmediateForward
 				{
 					// A raw SPDU is already signed so the RSU must not sign again. signMessages is thus set to false.
 					signMessage = false;
-					payloadbyte = spduPayload;
-					psid = toPsidHex(rawSpdu.get_psid());  // The SPDU is forwarded under its own PSID.
+					payloadbyte = payload;
 				}
 				/// if signing is Enabled, request signing with HSM
 				else if (imfConfig.enableHsm == 1)
@@ -330,7 +320,7 @@ namespace ImmediateForward
 				}
 				else
 				{
-					payloadbyte=msg->payload->valuestring;
+					payloadbyte=payload;
 				}
 
 				if (imfConfig.spec == tmx::utils::rsu::RSU_SPEC::RSU_4_1) {

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -150,8 +150,7 @@ namespace ImmediateForward
 	{
 		using tmx::messages::RawSpdu;
 		return msg &&
-			msg->type && strcmp(msg->type, RawSpdu::MessageType) == 0 &&
-			msg->subtype && strcmp(msg->subtype, RawSpdu::MessageSubType) == 0;
+			msg->type && strcmp(msg->type, RawSpdu::MessageType) == 0;
 	}
 
 	inline void ImmediateForwardPlugin::SignWithHsm(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, string& payloadbyte)

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -212,11 +212,11 @@ namespace ImmediateForward
 		base642hex(signedMsg, payloadbyte); // this allows sending hex of the signed message rather than base64
 	}
 
-	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const std::optional<std::string>& psidOverride){
+	inline string ImmediateForwardPlugin::ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid){
 		stringstream os;
 		os << "Version=0.7" << "\n"
 		   << "Type=" << messageConfig.sendType << "\n"
-		   << "PSID=" << psidOverride.value_or(messageConfig.psid) << "\n";
+		   << "PSID=" << psid << "\n";
 		if (!messageConfig.channel.has_value()) {
 			os << "Priority=7" << "\n" 
 			   << "TxMode=" << txModeToString(imfConfig.mode) << "\n"
@@ -299,7 +299,9 @@ namespace ImmediateForward
 
 				foundMessageType = true;
 				string payloadbyte="";
-				std::optional<std::string> psidOverride;
+				// A forwarded SPDU broadcasts under the PSID it arrived with, so that what goes out
+				// over the air matches the message that came in.
+				string psid = messageConfig.psid;
 
 				// Format the message using the protocol defined in the
 				// USDOT ROadside Unit Specifications Document v 4.0 Appendix C.
@@ -317,11 +319,10 @@ namespace ImmediateForward
 									   << ": set signMessages to true to forward already signed messages.";
 						continue;
 					}
-					// The SPDU is forwarded byte for byte, with the PSID it was received with, so
-					// that what is broadcast matches the message that came in.
+					// The SPDU is forwarded byte for byte, under its own PSID.
 					payloadbyte = spduPayload;
-					psidOverride = toPsidHex(rawSpdu.get_psid());
-					PLOG(logDEBUG3) << "Forwarding SPDU with PSID " << psidOverride.value()
+					psid = toPsidHex(rawSpdu.get_psid());
+					PLOG(logDEBUG3) << "Forwarding SPDU with PSID " << psid
 									<< " (configured PSID for " << messageConfig.tmxType << " is "
 									<< messageConfig.psid << ")";
 				}
@@ -345,7 +346,7 @@ namespace ImmediateForward
 				}
 
 				if (imfConfig.spec == tmx::utils::rsu::RSU_SPEC::RSU_4_1) {
-					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, psidOverride);
+					string message = ConstructMessageRSU_4_1(imfConfig, messageConfig, msg, payloadbyte, psid);
 
 					auto &client = _udpClientMap.at(imfConfig.name);
 					client->Send(message);
@@ -353,18 +354,18 @@ namespace ImmediateForward
 					PLOG(logDEBUG1) << _logPrefix
 									<< "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType
-									<< ", PSID: " << psidOverride.value_or(messageConfig.psid)
+									<< ", PSID: " << psid
 									<< ", Client: " << client->GetAddress()
 									<< ", Channel: " << (messageConfig.channel.has_value() ? ::to_string( msg->dsrcMetadata->channel) : ::to_string(messageConfig.channel.value()))
 									<< ", Port: " << client->GetAddress();
 				}
 				else {
 					const auto &client = _snmpClientMap.at(imfConfig.name);
-					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psidOverride);
+					sendNTCIP1218ImfMessage(client.get(), payloadbyte, _imfNtcipMessageTypeIndex[imfConfig.name][messageConfig.sendType], psid);
 
 					PLOG(logDEBUG2) << "Sending - TmxType: " << messageConfig.tmxType
 									<< ", SendType: " << messageConfig.sendType
-									<< ", PSID: " << psidOverride.value_or(messageConfig.psid)
+									<< ", PSID: " << psid
 									<< ", Client: " << client->get_port()
 									<< ", Channel: " << (messageConfig.channel.has_value() ? ::to_string( msg->dsrcMetadata->channel) : ::to_string(messageConfig.channel.value()))
 									<< ", Port: " << client->get_port();

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -241,9 +241,6 @@ namespace ImmediateForward
 	{
 		bool foundMessageType = false;
 		static FrequencyThrottle<std::string> _statusThrottle(chrono::milliseconds(2000));
-		// Misconfigured signMessages is a persistent condition, so warn about it sparingly rather
-		// than once per forwarded message.
-		static FrequencyThrottle<std::string> _signMessageThrottle(chrono::milliseconds(30000));
 
 		// A raw SPDU carries its payload as a JSON object rather than a hex string, and routes on the
 		// J2735 type of the message inside the SPDU rather than on the TMX subtype, which is always
@@ -315,11 +312,6 @@ namespace ImmediateForward
 					// A raw SPDU always carries its own 1609.2 signature, whatever the connection was
 					// configured with, so the signed flag is forced rather than read from the config.
 					// Telling the RSU otherwise would make it sign an already signed payload.
-					if (!imfConfig.signMessage && _signMessageThrottle.Monitor(imfConfig.name))
-					{
-						PLOG(logWARNING) << "signMessages is false for " << imfConfig.name
-										 << ", but raw SPDUs are already signed. Forwarding as signed.";
-					}
 					signature = true;
 					// The SPDU is forwarded byte for byte, under its own PSID.
 					payloadbyte = spduPayload;

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -73,9 +73,12 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		 * @param payloadbyte Hex encoded payload to forward.
 		 * @param psid PSID to broadcast under. Taken from the configuration for J2735 messages, and
 		 * from the SPDU itself when forwarding a raw SPDU.
+		 * @param signature Value of the Signature field, indicating the payload already carries its
+		 * own signature. Taken from imfConfig.signMessage for J2735 messages, and always true when
+		 * forwarding a raw SPDU.
 		 * @return string The formatted message, ready to send to the RSU over UDP.
 		 */
-		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid);
+		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signature);
 
 		// Mutex along with the data it protects.
 		// A map of UDP clients for sending V2X communication to different RSUs for broadcast (RSU Spec 4.1)

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -77,14 +77,12 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		 * @param messageConfig Message configuration providing the send type, PSID and optional channel.
 		 * @param msg TMX message supplying the DSRC channel when messageConfig has none.
 		 * @param payloadbyte Hex encoded payload to forward.
-		 * @param psid PSID to broadcast under. Taken from the configuration for J2735 messages, and
-		 * from the SPDU itself when forwarding a raw SPDU.
 		 * @param signMessage Value of the Signature field, asking the RSU to sign the payload before
 		 * broadcast. Taken from imfConfig.signMessage for J2735 messages, and always false when
 		 * forwarding a raw SPDU, which already carries its own signature.
 		 * @return string The formatted message, ready to send to the RSU over UDP.
 		 */
-		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signMessage);
+		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, bool signMessage);
 
 		/**
 		 * @brief Check whether the incoming message is a SPDU regardless

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -33,6 +33,7 @@
 
 #include "ImmediateForwardConfiguration.h"
 #include "IMFNTCIP1218Worker.h"
+#include "SpduForwarder.h"
 
 namespace ImmediateForward
 {
@@ -70,9 +71,11 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		 * @param messageConfig Message configuration providing the send type, PSID and optional channel.
 		 * @param msg TMX message supplying the DSRC channel when messageConfig has none.
 		 * @param payloadbyte Hex encoded payload to forward.
+		 * @param psidOverride Optional PSID to broadcast instead of the configured one. Used when
+		 * forwarding a raw SPDU, which carries its own PSID.
 		 * @return string The formatted message, ready to send to the RSU over UDP.
 		 */
-		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte);
+		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const std::optional<std::string>& psidOverride = std::nullopt);
 
 		// Mutex along with the data it protects.
 		// A map of UDP clients for sending V2X communication to different RSUs for broadcast (RSU Spec 4.1)
@@ -91,6 +94,7 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		uint _skippedNoMessageRoute;
 		uint _skippedInvalidUdpClient;
 		uint _skippedSignErrorResponse;
+		uint _skippedInvalidSpdu;
 
 	};
 

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -73,12 +73,12 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		 * @param payloadbyte Hex encoded payload to forward.
 		 * @param psid PSID to broadcast under. Taken from the configuration for J2735 messages, and
 		 * from the SPDU itself when forwarding a raw SPDU.
-		 * @param signature Value of the Signature field, indicating the payload already carries its
-		 * own signature. Taken from imfConfig.signMessage for J2735 messages, and always true when
-		 * forwarding a raw SPDU.
+		 * @param signMessage Value of the Signature field, asking the RSU to sign the payload before
+		 * broadcast. Taken from imfConfig.signMessage for J2735 messages, and always false when
+		 * forwarding a raw SPDU, which already carries its own signature.
 		 * @return string The formatted message, ready to send to the RSU over UDP.
 		 */
-		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signature);
+		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signMessage);
 
 		// Mutex along with the data it protects.
 		// A map of UDP clients for sending V2X communication to different RSUs for broadcast (RSU Spec 4.1)

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -80,6 +80,13 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		 */
 		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signMessage);
 
+		/**
+		 * @brief Check whether the incoming message is a SPDU regardless
+		 * of subtype.
+		 * @param ivp 
+		 * @return true (the type is SPDU, regardless of subtype)
+		 * @return false 
+		 */
 		inline bool IsSPDU(const IvpMessage* ivp);
 
 		// Mutex along with the data it protects.

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -80,6 +80,8 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		 */
 		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid, bool signMessage);
 
+		inline bool IsSPDU(const IvpMessage* ivp);
+
 		// Mutex along with the data it protects.
 		// A map of UDP clients for sending V2X communication to different RSUs for broadcast (RSU Spec 4.1)
 		std::unordered_map<std::string, std::unique_ptr<tmx::utils::UdpClient>> _udpClientMap;

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -38,6 +38,12 @@
 namespace ImmediateForward
 {
 
+inline bool IsSPDU(const IvpMessage *msg)
+{
+	return msg &&
+		msg->type && strcmp(msg->type, tmx::messages::RawSpdu::MessageType) == 0;
+}
+
 class ImmediateForwardPlugin : public tmx::utils::PluginClient
 {
 	public:
@@ -87,7 +93,6 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		 * @return true (the type is SPDU, regardless of subtype)
 		 * @return false 
 		 */
-		inline bool IsSPDU(const IvpMessage* ivp);
 
 		// Mutex along with the data it protects.
 		// A map of UDP clients for sending V2X communication to different RSUs for broadcast (RSU Spec 4.1)
@@ -107,6 +112,12 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		uint _skippedInvalidUdpClient;
 		uint _skippedSignErrorResponse;
 		uint _skippedInvalidSpdu;
+
+		static constexpr const char* Key_SkippedNoDsrcMetadata = "Messages Skipped (No DSRC metadata)";
+		static constexpr const char* Key_SkippedNoMessageRoute = "Messages Skipped (No route)";
+		static constexpr const char* Key_SkippedSignError = "Message Skipped (Signature Error Response)";
+		static constexpr const char* Key_SkippedInvalidUdpClient = "Messages Skipped (Invalid UDP Client)";
+		static constexpr const char* Key_SkippedInvalidSpdu = "Messages Skipped (Invalid SPDU)";
 
 	};
 

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -103,13 +103,13 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		std::map<std::string, int> _messageCountMap;
 
 		// Thread safe bool set to true the first time the configuration has been read.
-		std::atomic<bool> _configRead;
+		std::atomic<bool> _configRead = false;
 
-		uint _skippedNoDsrcMetadata;
-		uint _skippedNoMessageRoute;
-		uint _skippedInvalidUdpClient;
-		uint _skippedSignErrorResponse;
-		uint _skippedInvalidSpdu;
+		uint _skippedNoDsrcMetadata = 0;
+		uint _skippedNoMessageRoute = 0;
+		uint _skippedInvalidUdpClient = 0;
+		uint _skippedSignErrorResponse = 0;
+		uint _skippedInvalidSpdu = 0;
 
 		static constexpr const char* Key_SkippedNoDsrcMetadata = "Messages Skipped (No DSRC metadata)";
 		static constexpr const char* Key_SkippedNoMessageRoute = "Messages Skipped (No route)";

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.h
@@ -71,11 +71,11 @@ class ImmediateForwardPlugin : public tmx::utils::PluginClient
 		 * @param messageConfig Message configuration providing the send type, PSID and optional channel.
 		 * @param msg TMX message supplying the DSRC channel when messageConfig has none.
 		 * @param payloadbyte Hex encoded payload to forward.
-		 * @param psidOverride Optional PSID to broadcast instead of the configured one. Used when
-		 * forwarding a raw SPDU, which carries its own PSID.
+		 * @param psid PSID to broadcast under. Taken from the configuration for J2735 messages, and
+		 * from the SPDU itself when forwarding a raw SPDU.
 		 * @return string The formatted message, ready to send to the RSU over UDP.
 		 */
-		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const std::optional<std::string>& psidOverride = std::nullopt);
+		inline string ConstructMessageRSU_4_1(const ImfConfiguration& imfConfig, const MessageConfig& messageConfig, IvpMessage* msg, const string& payloadbyte, const string& psid);
 
 		// Mutex along with the data it protects.
 		// A map of UDP clients for sending V2X communication to different RSUs for broadcast (RSU Spec 4.1)

--- a/src/v2i-hub/ImmediateForwardPlugin/src/SpduForwarder.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/SpduForwarder.cpp
@@ -61,10 +61,4 @@ namespace ImmediateForward
         return hex;
     }
 
-    std::string toPsidHex(int psid)
-    {
-        std::ostringstream os;
-        os << "0x" << std::uppercase << std::hex << psid;
-        return os.str();
-    }
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/src/SpduForwarder.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/SpduForwarder.cpp
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2025 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#include "SpduForwarder.h"
+
+#include <algorithm>
+#include <cctype>
+#include <iomanip>
+#include <sstream>
+
+#include <tmx/messages/routeable_message.hpp>
+
+namespace ImmediateForward
+{
+    tmx::messages::RawSpdu getRawSpdu(IvpMessage *ivpMsg)
+    {
+        if (ivpMsg == nullptr)
+        {
+            throw tmx::TmxException("Cannot read a RawSpdu from a null message.");
+        }
+
+        // routeable_message copies the IvpMessage contents, so the caller keeps ownership of ivpMsg.
+        tmx::routeable_message rMsg(ivpMsg);
+        tmx::messages::RawSpdu rawSpdu = rMsg.get_payload<tmx::messages::RawSpdu>();
+
+        if (rawSpdu.get_fullByteData().empty())
+        {
+            throw tmx::TmxException("SPDU message contains no fullByteData to forward.");
+        }
+
+        // getJ2735SubType records UNKNOWN_SUBTYPE when it cannot identify the unsecured payload, and
+        // there is no tmxType such a message could be routed to.
+        const std::string messageType = rawSpdu.get_messageType();
+        if (messageType.empty() || messageType == UNKNOWN_SUBTYPE)
+        {
+            throw tmx::TmxException("SPDU message carries an unidentified J2735 payload type.");
+        }
+
+        return rawSpdu;
+    }
+
+    std::string toUpperHex(const tmx::byte_stream &bytes)
+    {
+        // byte_stream_encode writes lowercase hex, while the RSU immediate forward payloads this
+        // plugin sends are uppercase.
+        std::string hex = tmx::byte_stream_encode(bytes);
+        std::transform(hex.begin(), hex.end(), hex.begin(),
+                [](unsigned char c){ return std::toupper(c); });
+        return hex;
+    }
+
+    std::string toPsidHex(int psid)
+    {
+        std::ostringstream os;
+        os << "0x" << std::uppercase << std::hex << psid;
+        return os.str();
+    }
+}

--- a/src/v2i-hub/ImmediateForwardPlugin/src/SpduForwarder.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/SpduForwarder.h
@@ -41,9 +41,4 @@ namespace ImmediateForward
      * @brief Hex encode bytes in upper case, the form the immediate forward protocols expect.
      */
     std::string toUpperHex(const tmx::byte_stream &bytes);
-
-    /**
-     * @brief Format a PSID as "0x<HEX>", matching the plugin configuration convention.
-     */
-    std::string toPsidHex(int psid);
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/src/SpduForwarder.h
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/SpduForwarder.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2025 LEIDOS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+#pragma once
+
+#include <string>
+
+#include <RawSpdu.h>
+#include <tmx/IvpMessage.h>
+#include <tmx/TmxException.hpp>
+#include <tmx/messages/byte_stream.hpp>
+
+namespace ImmediateForward
+{
+    /**
+     * @brief Read the RawSpdu payload back out of a received TMX message.
+     *
+     * The payload of a RawSpdu message is a JSON object rather than a hex string, so it cannot be
+     * read through IvpMessage::payload::valuestring the way J2735 payloads are.
+     *
+     * @param ivpMsg The received message. Its contents are copied, not taken over.
+     * @return tmx::messages::RawSpdu
+     * @throws tmx::TmxException if the message is null, carries no SPDU bytes, or carries a J2735
+     * payload whose type could not be identified.
+     */
+    tmx::messages::RawSpdu getRawSpdu(IvpMessage *ivpMsg);
+
+    /**
+     * @brief Hex encode bytes in upper case, the form the immediate forward protocols expect.
+     */
+    std::string toUpperHex(const tmx::byte_stream &bytes);
+
+    /**
+     * @brief Format a PSID as "0x<HEX>", matching the plugin configuration convention.
+     */
+    std::string toPsidHex(int psid);
+}

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
@@ -12,6 +12,18 @@ using testing::Return;
 using testing::SetArgReferee;
 using testing::Throw;
 
+TEST(TestIMFNTCIP1218Worker, testStripPsidPrefix) {
+    // NTCIP wants bare hex digits, while configuration and SPDU PSIDs are written "0x<HEX>"
+    EXPECT_EQ(stripPsidPrefix("0x8002"), "8002");
+    EXPECT_EQ(stripPsidPrefix("0x20"), "20");
+    EXPECT_EQ(stripPsidPrefix("0xBFEE"), "BFEE");
+    // Leading zeros are meaningful to the RSU and are preserved
+    EXPECT_EQ(stripPsidPrefix("0x0027"), "0027");
+    // A PSID that already has no prefix passes through untouched
+    EXPECT_EQ(stripPsidPrefix("8002"), "8002");
+    EXPECT_EQ(stripPsidPrefix(""), "");
+}
+
 TEST(TestIMFNTCIP1218Worker, testClearImmediateForwardTable) {
     // Test the clearImmediateForwardTable function
     // Create a mock SNMP client

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
@@ -281,9 +281,9 @@ TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessage) {
     EXPECT_EQ(requests_1[3].value, "1");
 }
 
-TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageSpduPsidAndSignedOptions) {
-    // A forwarded raw SPDU broadcasts under the PSID it arrived with, not the configured one, and is
-    // always marked signed regardless of what the row was initialized with
+TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageSignMessage) {
+    // Asking the RSU to sign sets Bit 0 = Process1609.2, which a Yunex RSU reads as the most
+    // significant bit ( see rsuIFMOptionsOid for the bit definitions )
     std::unique_ptr mockClient = std::make_unique<mock_snmp_client>("", 0, "", "", "", "");
     std::string message = "0381004003800100";
     unsigned int index = 3;
@@ -296,10 +296,30 @@ TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageSpduPsidAndSignedOptions
     EXPECT_EQ(requests_1.size(), 4);
     EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index));
     EXPECT_EQ(requests_1[0].value, "20");
-    // binary 10000000, the signed bit ( see rsuIFMOptionsOid for bit values )
     EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMOptionsOid + "." + std::to_string(index));
     EXPECT_EQ(requests_1[1].value, "80");
     EXPECT_EQ(requests_1[2].value, message);
+}
+
+TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageAlreadySignedSpdu) {
+    // A forwarded raw SPDU is already a complete signed 1609.2 message, so the RSU must leave
+    // Bit 0 = Bypass1609.2 and transmit the payload untouched rather than signing it again
+    std::unique_ptr mockClient = std::make_unique<mock_snmp_client>("", 0, "", "", "", "");
+    std::string spdu = "0381004003800100";
+    unsigned int index = 3;
+
+    std::vector<snmp_request> requests_1;
+    EXPECT_CALL( *mockClient, process_snmp_set_requests(_) ).Times(1).WillRepeatedly(testing::DoAll(::testing::SaveArg<0>(&requests_1), Return(true)));
+
+    sendNTCIP1218ImfMessage(mockClient.get(), spdu, index, "0x20", false);
+
+    EXPECT_EQ(requests_1.size(), 4);
+    // The SPDU broadcasts under the PSID it arrived with, not the one the row was initialized with
+    EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[0].value, "20");
+    EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMOptionsOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[1].value, "00");
+    EXPECT_EQ(requests_1[2].value, spdu);
 }
 
 TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageAcceptsUnprefixedPsid) {

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
@@ -245,24 +245,29 @@ TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessage) {
     std::vector<snmp_request> requests_1;
     EXPECT_CALL( *mockClient, process_snmp_set_requests(_) ).Times(1).WillRepeatedly(testing::DoAll(::testing::SaveArg<0>(&requests_1), Return(true)));
     
-    sendNTCIP1218ImfMessage(mockClient.get(), message, index);
+    sendNTCIP1218ImfMessage(mockClient.get(), message, index, "0x8002");
     // Happening inside the sendNTCIP1218ImfMessage function
     // snmp_request payload {
     //     rsu::mib::ntcip1218::rsuIFMPayloadOid +  "." + std::to_string(index),
     //     'x',
     //     message
     // }
-    EXPECT_EQ(requests_1.size(), 2);
-    EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1.size(), 3);
+    // The PSID is written on every send so a row never carries over the PSID of the previous
+    // message. The "0x" prefix is stripped, matching how initializeImmediateForwardTable writes it.
+    EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index));
     EXPECT_EQ(requests_1[0].type, 'x');
-    EXPECT_EQ(requests_1[0].value, message);
-    EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMEnableOid + "." + std::to_string(index));
-    EXPECT_EQ(requests_1[1].type, 'i');
-    EXPECT_EQ(requests_1[1].value, "1");
+    EXPECT_EQ(requests_1[0].value, "8002");
+    EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[1].type, 'x');
+    EXPECT_EQ(requests_1[1].value, message);
+    EXPECT_EQ(requests_1[2].oid, rsu::mib::ntcip1218::rsuIFMEnableOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[2].type, 'i');
+    EXPECT_EQ(requests_1[2].value, "1");
 }
 
-TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessagePsidOverride) {
-    // Forwarding a raw SPDU sets the row PSID from the SPDU itself, in the same batch as the payload
+TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageSpduPsid) {
+    // A forwarded raw SPDU broadcasts under the PSID it arrived with, not the configured one
     std::unique_ptr mockClient = std::make_unique<mock_snmp_client>("", 0, "", "", "", "");
     std::string message = "0381004003800100";
     unsigned int index = 3;
@@ -273,14 +278,21 @@ TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessagePsidOverride) {
     sendNTCIP1218ImfMessage(mockClient.get(), message, index, "0x20");
 
     EXPECT_EQ(requests_1.size(), 3);
-    EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index));
-    EXPECT_EQ(requests_1[0].value, message);
-    EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMEnableOid + "." + std::to_string(index));
-    EXPECT_EQ(requests_1[1].value, "1");
-    // The "0x" prefix is stripped, matching how initializeImmediateForwardTable writes the PSID
-    EXPECT_EQ(requests_1[2].oid, rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index));
-    EXPECT_EQ(requests_1[2].type, 'x');
-    EXPECT_EQ(requests_1[2].value, "20");
+    EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[0].value, "20");
+    EXPECT_EQ(requests_1[1].value, message);
+}
+
+TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageAcceptsUnprefixedPsid) {
+    std::unique_ptr mockClient = std::make_unique<mock_snmp_client>("", 0, "", "", "", "");
+    unsigned int index = 1;
+
+    std::vector<snmp_request> requests_1;
+    EXPECT_CALL( *mockClient, process_snmp_set_requests(_) ).Times(1).WillRepeatedly(testing::DoAll(::testing::SaveArg<0>(&requests_1), Return(true)));
+
+    sendNTCIP1218ImfMessage(mockClient.get(), "00", index, "8002");
+
+    EXPECT_EQ(requests_1[0].value, "8002");
 }
 
 TEST(TestIMFNTCIP1218Worker, waitForRSUModeStandby) {

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
@@ -257,29 +257,33 @@ TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessage) {
     std::vector<snmp_request> requests_1;
     EXPECT_CALL( *mockClient, process_snmp_set_requests(_) ).Times(1).WillRepeatedly(testing::DoAll(::testing::SaveArg<0>(&requests_1), Return(true)));
     
-    sendNTCIP1218ImfMessage(mockClient.get(), message, index, "0x8002");
+    sendNTCIP1218ImfMessage(mockClient.get(), message, index, "0x8002", false);
     // Happening inside the sendNTCIP1218ImfMessage function
     // snmp_request payload {
     //     rsu::mib::ntcip1218::rsuIFMPayloadOid +  "." + std::to_string(index),
     //     'x',
     //     message
     // }
-    EXPECT_EQ(requests_1.size(), 3);
-    // The PSID is written on every send so a row never carries over the PSID of the previous
-    // message. The "0x" prefix is stripped, matching how initializeImmediateForwardTable writes it.
+    EXPECT_EQ(requests_1.size(), 4);
+    // The PSID and options are written on every send so a row never carries over what the previous
+    // message left behind. The "0x" prefix is stripped, matching initializeImmediateForwardTable.
     EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index));
     EXPECT_EQ(requests_1[0].type, 'x');
     EXPECT_EQ(requests_1[0].value, "8002");
-    EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMOptionsOid + "." + std::to_string(index));
     EXPECT_EQ(requests_1[1].type, 'x');
-    EXPECT_EQ(requests_1[1].value, message);
-    EXPECT_EQ(requests_1[2].oid, rsu::mib::ntcip1218::rsuIFMEnableOid + "." + std::to_string(index));
-    EXPECT_EQ(requests_1[2].type, 'i');
-    EXPECT_EQ(requests_1[2].value, "1");
+    EXPECT_EQ(requests_1[1].value, "00");
+    EXPECT_EQ(requests_1[2].oid, rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[2].type, 'x');
+    EXPECT_EQ(requests_1[2].value, message);
+    EXPECT_EQ(requests_1[3].oid, rsu::mib::ntcip1218::rsuIFMEnableOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[3].type, 'i');
+    EXPECT_EQ(requests_1[3].value, "1");
 }
 
-TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageSpduPsid) {
-    // A forwarded raw SPDU broadcasts under the PSID it arrived with, not the configured one
+TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageSpduPsidAndSignedOptions) {
+    // A forwarded raw SPDU broadcasts under the PSID it arrived with, not the configured one, and is
+    // always marked signed regardless of what the row was initialized with
     std::unique_ptr mockClient = std::make_unique<mock_snmp_client>("", 0, "", "", "", "");
     std::string message = "0381004003800100";
     unsigned int index = 3;
@@ -287,12 +291,15 @@ TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageSpduPsid) {
     std::vector<snmp_request> requests_1;
     EXPECT_CALL( *mockClient, process_snmp_set_requests(_) ).Times(1).WillRepeatedly(testing::DoAll(::testing::SaveArg<0>(&requests_1), Return(true)));
 
-    sendNTCIP1218ImfMessage(mockClient.get(), message, index, "0x20");
+    sendNTCIP1218ImfMessage(mockClient.get(), message, index, "0x20", true);
 
-    EXPECT_EQ(requests_1.size(), 3);
+    EXPECT_EQ(requests_1.size(), 4);
     EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index));
     EXPECT_EQ(requests_1[0].value, "20");
-    EXPECT_EQ(requests_1[1].value, message);
+    // binary 10000000, the signed bit ( see rsuIFMOptionsOid for bit values )
+    EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMOptionsOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[1].value, "80");
+    EXPECT_EQ(requests_1[2].value, message);
 }
 
 TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageAcceptsUnprefixedPsid) {
@@ -302,7 +309,7 @@ TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessageAcceptsUnprefixedPsid) {
     std::vector<snmp_request> requests_1;
     EXPECT_CALL( *mockClient, process_snmp_set_requests(_) ).Times(1).WillRepeatedly(testing::DoAll(::testing::SaveArg<0>(&requests_1), Return(true)));
 
-    sendNTCIP1218ImfMessage(mockClient.get(), "00", index, "8002");
+    sendNTCIP1218ImfMessage(mockClient.get(), "00", index, "8002", false);
 
     EXPECT_EQ(requests_1[0].value, "8002");
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestIMFNTCIP1218Worker.cpp
@@ -261,6 +261,28 @@ TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessage) {
     EXPECT_EQ(requests_1[1].value, "1");
 }
 
+TEST(TestIMFNTCIP1218Worker, testSendNTCIP1218ImfMessagePsidOverride) {
+    // Forwarding a raw SPDU sets the row PSID from the SPDU itself, in the same batch as the payload
+    std::unique_ptr mockClient = std::make_unique<mock_snmp_client>("", 0, "", "", "", "");
+    std::string message = "0381004003800100";
+    unsigned int index = 3;
+
+    std::vector<snmp_request> requests_1;
+    EXPECT_CALL( *mockClient, process_snmp_set_requests(_) ).Times(1).WillRepeatedly(testing::DoAll(::testing::SaveArg<0>(&requests_1), Return(true)));
+
+    sendNTCIP1218ImfMessage(mockClient.get(), message, index, "0x20");
+
+    EXPECT_EQ(requests_1.size(), 3);
+    EXPECT_EQ(requests_1[0].oid, rsu::mib::ntcip1218::rsuIFMPayloadOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[0].value, message);
+    EXPECT_EQ(requests_1[1].oid, rsu::mib::ntcip1218::rsuIFMEnableOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[1].value, "1");
+    // The "0x" prefix is stripped, matching how initializeImmediateForwardTable writes the PSID
+    EXPECT_EQ(requests_1[2].oid, rsu::mib::ntcip1218::rsuIFMPsidOid + "." + std::to_string(index));
+    EXPECT_EQ(requests_1[2].type, 'x');
+    EXPECT_EQ(requests_1[2].value, "20");
+}
+
 TEST(TestIMFNTCIP1218Worker, waitForRSUModeStandby) {
     // Test the waitForRSUModeStandby function
     // Create a mock SNMP client

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestSpduForwarder.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestSpduForwarder.cpp
@@ -96,11 +96,6 @@ TEST(TestSpduForwarder, toUpperHexMatchesImmediateForwardPayloadFormat) {
     EXPECT_EQ("", toUpperHex(tmx::byte_stream()));
 }
 
-TEST(TestSpduForwarder, formatsPsidUsingConfigurationConvention) {
-    EXPECT_EQ("0x8002", toPsidHex(0x8002));
-    EXPECT_EQ("0x20", toPsidHex(0x20));
-    EXPECT_EQ("0xBFEE", toPsidHex(0xBFEE));
-}
 
 TEST(TestSpduForwarder, testIsSPDU){
     tmx::messages::RawSpdu rawSpdu;

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestSpduForwarder.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestSpduForwarder.cpp
@@ -101,6 +101,6 @@ TEST(TestSpduForwarder, testIsSPDU){
     tmx::messages::RawSpdu rawSpdu;
     tmx::routeable_message rMsg;
     rMsg.initialize<tmx::messages::RawSpdu>(rawSpdu);
-    auto ivpMsg = rMsg.get_message();
+    auto ivpMsg = std::as_const(rMsg).get_message();
     EXPECT_TRUE(IsSPDU(ivpMsg));
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestSpduForwarder.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestSpduForwarder.cpp
@@ -8,6 +8,7 @@
 #include <SpduForwarder.h>
 #include <tmx/messages/byte_stream.hpp>
 #include <tmx/messages/routeable_message.hpp>
+#include "ImmediateForwardPlugin.h"
 
 using namespace ImmediateForward;
 
@@ -99,4 +100,12 @@ TEST(TestSpduForwarder, formatsPsidUsingConfigurationConvention) {
     EXPECT_EQ("0x8002", toPsidHex(0x8002));
     EXPECT_EQ("0x20", toPsidHex(0x20));
     EXPECT_EQ("0xBFEE", toPsidHex(0xBFEE));
+}
+
+TEST(TestSpduForwarder, testIsSPDU){
+    tmx::messages::RawSpdu rawSpdu;
+    tmx::routeable_message rMsg;
+    rMsg.initialize<tmx::messages::RawSpdu>(rawSpdu);
+    auto ivpMsg = rMsg.get_message();
+    EXPECT_TRUE(IsSPDU(ivpMsg));
 }

--- a/src/v2i-hub/ImmediateForwardPlugin/test/TestSpduForwarder.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/test/TestSpduForwarder.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+#include <RawSpdu.h>
+#include <SpduForwarder.h>
+#include <tmx/messages/byte_stream.hpp>
+#include <tmx/messages/routeable_message.hpp>
+
+using namespace ImmediateForward;
+
+namespace {
+
+    // Unsecured BSM payload
+    const std::string bsmHex =
+        "001425067c0eb5842562e66e8a2b9ea6c96408b97fffffff900027d9637d07d0007fff8000640fa0";
+
+    // Stands in for a secured BSM: the BSM payload with bytes around it
+    const std::string spduHex =
+        "3b996de867c7419ad2ec5652d133c1fb" + bsmHex + "8cfae61d57e2bfba0b68242e11d641c2";
+
+    const std::string uuidHex = "0a303030303fdfa7";
+
+    tmx::messages::RawSpdu buildSpdu(const std::string &fullByteDataHex, const std::string &messageType, int psid)
+    {
+        tmx::messages::RawSpdu rawSpdu;
+        rawSpdu.set_fullByteData(tmx::byte_stream_decode(fullByteDataHex));
+        rawSpdu.set_msgByteData(tmx::byte_stream_decode(bsmHex));
+        rawSpdu.set_uuid(tmx::byte_stream_decode(uuidHex));
+        rawSpdu.set_messageType(messageType);
+        rawSpdu.set_timestampMs(1718900000000);
+        rawSpdu.set_psid(psid);
+        return rawSpdu;
+    }
+
+    /**
+     * Publish a RawSpdu into a routeable message the way MessageReceiverPlugin does, so that tests
+     * read it back over the same path the plugin takes on receipt.
+     */
+    void publish(const tmx::messages::RawSpdu &rawSpdu, tmx::routeable_message &rMsg)
+    {
+        tmx::messages::RawSpdu payload = rawSpdu;
+        rMsg.initialize<tmx::messages::RawSpdu>(payload, "", 0, IvpMsgFlags_RouteDSRC);
+        rMsg.addDsrcMetadata(payload.get_psid());
+    }
+
+    std::string upper(const std::string &str)
+    {
+        std::string out = str;
+        std::transform(out.begin(), out.end(), out.begin(),
+                [](unsigned char c){ return std::toupper(c); });
+        return out;
+    }
+}
+
+TEST(TestSpduForwarder, readsBackFullSpduBytesAndPsid) {
+    tmx::routeable_message rMsg;
+    publish(buildSpdu(spduHex, "BSM", 0x20), rMsg);
+    const tmx::routeable_message &constMsg = rMsg;
+
+    tmx::messages::RawSpdu rawSpdu = getRawSpdu(constMsg.get_message());
+
+    // The bytes forwarded to the radio must be the SPDU exactly as it was received
+    EXPECT_EQ(upper(spduHex), toUpperHex(rawSpdu.get_fullByteData()));
+    EXPECT_EQ(0x20, rawSpdu.get_psid());
+    EXPECT_EQ("BSM", rawSpdu.get_messageType());
+}
+
+TEST(TestSpduForwarder, throwsWhenFullByteDataIsEmpty) {
+    tmx::routeable_message rMsg;
+    publish(buildSpdu("", "BSM", 0x20), rMsg);
+    const tmx::routeable_message &constMsg = rMsg;
+
+    EXPECT_THROW(getRawSpdu(constMsg.get_message()), tmx::TmxException);
+}
+
+TEST(TestSpduForwarder, throwsWhenMessageTypeIsUnidentified) {
+    // getJ2735SubType records UNKNOWN_SUBTYPE when it cannot identify the unsecured payload, and
+    // there is no tmxType such a message could be routed to
+    tmx::routeable_message rMsg;
+    publish(buildSpdu(spduHex, UNKNOWN_SUBTYPE, 0x20), rMsg);
+    const tmx::routeable_message &constMsg = rMsg;
+
+    EXPECT_THROW(getRawSpdu(constMsg.get_message()), tmx::TmxException);
+}
+
+TEST(TestSpduForwarder, throwsOnNullMessage) {
+    EXPECT_THROW(getRawSpdu(nullptr), tmx::TmxException);
+}
+
+TEST(TestSpduForwarder, toUpperHexMatchesImmediateForwardPayloadFormat) {
+    EXPECT_EQ("00A1FF", toUpperHex(tmx::byte_stream_decode("00a1ff")));
+    EXPECT_EQ("", toUpperHex(tmx::byte_stream()));
+}
+
+TEST(TestSpduForwarder, formatsPsidUsingConfigurationConvention) {
+    EXPECT_EQ("0x8002", toPsidHex(0x8002));
+    EXPECT_EQ("0x20", toPsidHex(0x20));
+    EXPECT_EQ("0xBFEE", toPsidHex(0xBFEE));
+}

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -216,7 +216,11 @@ int MessageReceiverPlugin::Main()
 						_processedSPDU++;
 						SetStatus<uint>(Key_ProcessedSPDU, _processedSPDU);
 						tmx::routeable_message rMsg;
-						rMsg.initialize<tmx::messages::RawSpdu>(spduMsg);
+						// Flag for DSRC routing so plugins such as ImmediateForward, which filter on
+						// IvpMsgFlags_RouteDSRC, receive the SPDU for re-broadcast.
+						rMsg.initialize<tmx::messages::RawSpdu>(spduMsg, "", 0, IvpMsgFlags_RouteDSRC);
+						// The PSID comes from the SPDU itself; the channel defaults to 183.
+						rMsg.addDsrcMetadata(psid);
 						this->OutgoingMessage(rMsg);
 					}
 				}

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -216,11 +216,7 @@ int MessageReceiverPlugin::Main()
 						_processedSPDU++;
 						SetStatus<uint>(Key_ProcessedSPDU, _processedSPDU);
 						tmx::routeable_message rMsg;
-						// Flag for DSRC routing so plugins such as ImmediateForward, which filter on
-						// IvpMsgFlags_RouteDSRC, receive the SPDU for re-broadcast.
-						rMsg.initialize<tmx::messages::RawSpdu>(spduMsg, "", 0, IvpMsgFlags_RouteDSRC);
-						// The PSID comes from the SPDU itself; the channel defaults to 183.
-						rMsg.addDsrcMetadata(psid);
+						rMsg.initialize<tmx::messages::RawSpdu>(spduMsg);
 						this->OutgoingMessage(rMsg);
 					}
 				}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Adds raw SPDU forwarding to the Immediate Forward Plugin: `RawSpdu` messages are re-broadcast to the RSU byte for byte, preserving the original PSID. 

### NTCIP 1218: PSID and options now written per send

- Previously written once at table initialization, so a row shared by statically configured and SPDU traffic carried over whatever the previous message left behind. Currently both psid and signing are configured for each send so it works for mixed traffic.
- `sendNTCIP1218ImfMessage` takes `psid` and `signMessage` as required parameters and writes both every send, so does the RSU 4.1 path.

### rsuIFMOptions semantics

- `signMessages` when set to `true` is meant for the RSU to perform the signing of the message. 
- Per NTCIP 1218 5.5.2.7, Bit 0 when set to 0 would bypass 1609.2, which "allows the RSU to send the message that has been signed and/or encrypted by the TMC... the RSU would still wrap the message payload in a WSMP header"
- Thus `0x80` translates to "RSU secures the message"; `0x00` translates to already-secured payload sent untouched, matches SPDU use case. Bit 1 is ignored when Bit 0 = 0

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
[DT4IT](https://usdot-carma.atlassian.net/browse/DT4IT-102?atlOrigin=eyJpIjoiNWFiMzRlNmZlMmIyNGI0Mzk3MTEyNDc3MDJlOWFmMGYiLCJwIjoiaiJ9)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
