### PR TITLE
Update Docker Scout comparison with policy evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,15 +204,6 @@ jobs:
             "${{ env.DOCKERHUB_NAMESPACE }}/v2xhub:${FINAL_TAG}-amd64" \
             "${{ env.DOCKERHUB_NAMESPACE }}/v2xhub:${FINAL_TAG}-arm64"
 
-      - name: Docker Scout Policy Evaluation
-        id: docker-scout-policy
-        uses: docker/scout-action@v1.24.0
-        with:
-          command: policy
-          image: ${{ steps.meta.outputs.tags }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          organization: usdotfhwaops
-
       - name: Set Docker Scout baseline environment
         id: scout-env
         if: ${{ github.event_name == 'pull_request' }}
@@ -224,7 +215,7 @@ jobs:
       - name: Docker Scout Compare
         id: docker-scout-compare
         if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@v1.12.0
         with:
           command: compare
           image: ${{ steps.meta.outputs.tags }}
@@ -236,10 +227,19 @@ jobs:
       - name: Docker Scout Record
         id: docker-scout-record
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@v1.12.0
         with:
           command: environment
           environment: ${{ steps.meta.outputs.version }}
+          image: ${{ steps.meta.outputs.tags }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          organization: usdotfhwaops
+
+      - name: Docker Scout Policy Evaluation
+        id: docker-scout-policy
+        uses: docker/scout-action@v1.24.0
+        with:
+          command: policy
           image: ${{ steps.meta.outputs.tags }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           organization: usdotfhwaops

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           platforms: linux/amd64
           push: true
           sbom: true
-          provenance: true
+          provenance: mode=max
           tags: ${{ env.DOCKERHUB_NAMESPACE }}/v2xhub:${{ steps.meta.outputs.version }}-amd64
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -168,7 +168,7 @@ jobs:
           platforms: linux/arm64
           push: true
           sbom: true
-          provenance: true
+          provenance: mode=max
           tags: ${{ env.DOCKERHUB_NAMESPACE }}/v2xhub:${{ steps.meta.outputs.version }}-arm64
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,16 @@ jobs:
             --tag "${{ env.DOCKERHUB_NAMESPACE }}/v2xhub:${FINAL_TAG}" \
             "${{ env.DOCKERHUB_NAMESPACE }}/v2xhub:${FINAL_TAG}-amd64" \
             "${{ env.DOCKERHUB_NAMESPACE }}/v2xhub:${FINAL_TAG}-arm64"
+
+      - name: Docker Scout Policy Evaluation
+        id: docker-scout-policy
+        uses: docker/scout-action@v1.24.0
+        with:
+          command: policy
+          image: ${{ steps.meta.outputs.tags }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          organization: usdotfhwaops
+
       - name: Set Docker Scout baseline environment
         id: scout-env
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,7 @@ jobs:
           to-env: ${{ steps.scout-env.outputs.environment }}
           ignore-unchanged: true
           only-severities: critical,high
+          exit-on: policy
           github-token: ${{ secrets.GITHUB_TOKEN }}
           organization: usdotfhwaops
       - name: Docker Scout Record
@@ -231,15 +232,6 @@ jobs:
         with:
           command: environment
           environment: ${{ steps.meta.outputs.version }}
-          image: ${{ steps.meta.outputs.tags }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          organization: usdotfhwaops
-
-      - name: Docker Scout Policy Evaluation
-        id: docker-scout-policy
-        uses: docker/scout-action@v1.24.0
-        with:
-          command: policy
           image: ${{ steps.meta.outputs.tags }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           organization: usdotfhwaops

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Docker Scout Compare
         id: docker-scout-compare
         if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/scout-action@v1.12.0
+        uses: docker/scout-action@v1.24.0
         with:
           command: compare
           image: ${{ steps.meta.outputs.tags }}
@@ -228,7 +228,7 @@ jobs:
       - name: Docker Scout Record
         id: docker-scout-record
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/scout-action@v1.12.0
+        uses: docker/scout-action@v1.24.0
         with:
           command: environment
           environment: ${{ steps.meta.outputs.version }}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR updates the existing Docker Scout image comparison to include policy evaluation in the V2X-Hub CI workflow as the Docker Scout Policies Dashboard is being deprecated.

Changes made: 
- Updated Docker Scout and record Action to v1.24.0.
- Added `exit-on: policy` to the existing Scout comparison so PR builds fail when policy compliance worsens compared with the target environment.
- Updated V2X-Hub image provenance to `mode=max` to provide complete build metadata for Scout policy evaluation.

## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<img width="1169" height="945" alt="image" src="https://github.com/user-attachments/assets/945d2e68-4a04-414c-886c-7dcc07213834" />

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
