### PR TITLE
feat: Set message subtype for SPDU and add debug log showing UUID

### DIFF
--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -247,8 +247,7 @@ namespace ImmediateForward
 			tmxType = rawSpdu.get_messageType();
 			payload = toUpperHex(rawSpdu.get_fullByteData());
 
-			PLOG(logDEBUG) << "Forwarding SPDU message with uuid: " << tmx::byte_stream_encode(rawSpdu.get_uuid())
-						   << " and timestamp: " << rawSpdu.get_timestampMs();
+			PLOG(logDEBUG) << "Forwarding SPDU message with uuid: " << tmx::byte_stream_encode(rawSpdu.get_uuid());
 		}
 		else
 		{

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -248,7 +248,7 @@ namespace ImmediateForward
 			payload = toUpperHex(rawSpdu.get_fullByteData());
 
 			PLOG(logDEBUG) << "Forwarding SPDU message with uuid: " << tmx::byte_stream_encode(rawSpdu.get_uuid())
-						   << " and timestamp: " << msg->get_timestamp();
+						   << " and timestamp: " << msg->timestamp;
 		}
 		else
 		{

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -246,6 +246,9 @@ namespace ImmediateForward
 			}
 			tmxType = rawSpdu.get_messageType();
 			payload = toUpperHex(rawSpdu.get_fullByteData());
+
+			PLOG(logDEBUG) << "Forwarding SPDU message with uuid: " << tmx::byte_stream_encode(rawSpdu.get_uuid())
+						   << " and timestamp: " << msg->get_timestamp();
 		}
 		else
 		{

--- a/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
+++ b/src/v2i-hub/ImmediateForwardPlugin/src/ImmediateForwardPlugin.cpp
@@ -248,7 +248,7 @@ namespace ImmediateForward
 			payload = toUpperHex(rawSpdu.get_fullByteData());
 
 			PLOG(logDEBUG) << "Forwarding SPDU message with uuid: " << tmx::byte_stream_encode(rawSpdu.get_uuid())
-						   << " and timestamp: " << msg->timestamp;
+						   << " and timestamp: " << rawSpdu.get_timestampMs();
 		}
 		else
 		{

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -220,7 +220,7 @@ int MessageReceiverPlugin::Main()
 						rMsg.refresh_timestamp();
 						rMsg.set_subtype(spduMsg.get_messageType());
 						PLOG(logDEBUG) << "Putting RawSpdu message on TMX Core with uuid: " << tmx::byte_stream_encode(spduMsg.get_uuid())
-									   << " and timestamp: " << rMsg.timestamp;
+									   << " and timestamp: " << rMsg.get_timestamp();
   						this->OutgoingMessage(rMsg);
 					}
 				}

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -217,7 +217,6 @@ int MessageReceiverPlugin::Main()
 						SetStatus<uint>(Key_ProcessedSPDU, _processedSPDU);
 						tmx::routeable_message rMsg;
 						rMsg.initialize<tmx::messages::RawSpdu>(spduMsg);
-						rMsg.refresh_timestamp();
 						rMsg.set_subtype(spduMsg.get_messageType());
 						PLOG(logDEBUG) << "Putting RawSpdu message on TMX Core with uuid: " << tmx::byte_stream_encode(spduMsg.get_uuid());
   						this->OutgoingMessage(rMsg);

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -219,8 +219,7 @@ int MessageReceiverPlugin::Main()
 						rMsg.initialize<tmx::messages::RawSpdu>(spduMsg);
 						rMsg.refresh_timestamp();
 						rMsg.set_subtype(spduMsg.get_messageType());
-						PLOG(logDEBUG) << "Putting RawSpdu message on TMX Core with uuid: " << tmx::byte_stream_encode(spduMsg.get_uuid())
-									   << " and timestamp: " << rMsg.get_timestamp();
+						PLOG(logDEBUG) << "Putting RawSpdu message on TMX Core with uuid: " << tmx::byte_stream_encode(spduMsg.get_uuid());
   						this->OutgoingMessage(rMsg);
 					}
 				}

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -217,7 +217,10 @@ int MessageReceiverPlugin::Main()
 						SetStatus<uint>(Key_ProcessedSPDU, _processedSPDU);
 						tmx::routeable_message rMsg;
 						rMsg.initialize<tmx::messages::RawSpdu>(spduMsg);
-						this->OutgoingMessage(rMsg);
+						rMsg.refresh_timestamp();
+						PLOG(logDEBUG) << "Putting RawSpdu message on TMX Core with uuid: " << tmx::byte_stream_encode(spduMsg.get_uuid())
+									   << " and timestamp: " << rMsg.get_timestamp();
+  						this->OutgoingMessage(rMsg);
 					}
 				}
 			}

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -220,7 +220,7 @@ int MessageReceiverPlugin::Main()
 						rMsg.refresh_timestamp();
 						rMsg.set_subtype(spduMsg.get_messageType());
 						PLOG(logDEBUG) << "Putting RawSpdu message on TMX Core with uuid: " << tmx::byte_stream_encode(spduMsg.get_uuid())
-									   << " and timestamp: " << rMsg.get_timestamp();
+									   << " and timestamp: " << rMsg.timestamp;
   						this->OutgoingMessage(rMsg);
 					}
 				}

--- a/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
+++ b/src/v2i-hub/MessageReceiverPlugin/src/MessageReceiverPlugin.cpp
@@ -218,6 +218,7 @@ int MessageReceiverPlugin::Main()
 						tmx::routeable_message rMsg;
 						rMsg.initialize<tmx::messages::RawSpdu>(spduMsg);
 						rMsg.refresh_timestamp();
+						rMsg.set_subtype(spduMsg.get_messageType());
 						PLOG(logDEBUG) << "Putting RawSpdu message on TMX Core with uuid: " << tmx::byte_stream_encode(spduMsg.get_uuid())
 									   << " and timestamp: " << rMsg.get_timestamp();
   						this->OutgoingMessage(rMsg);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR adds 2 small changes:
- When `MessageReceiverPlugin` routes SPDU, the `routable_message` now sets the subtype based on the actual message type of the SPDU (e.g., `BSM`) instead of the current behavior that defaults to `Basic`. In this way, the actual message type will be displayed correctly in the V2XHub UI as well.
- Add 2 debug logs at `MessageReceiverPlugin` and `ImmediateForwardPlugin` that print the UUID of the SPDU for verifying the one-to-one transmission of message.

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

[DT4IT-147](https://usdot-carma.atlassian.net/browse/DT4IT-147?atlOrigin=eyJpIjoiM2QxMGZiNWEwMDE3NGZiODhkODg2MzI3MzZkNzI3MGUiLCJwIjoiaiJ9)

<!-- e.g. CAR-123 -->


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This feature is added to correctly identify the concrete type of the SPDU message if possible.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested by sending secured BSM/SPAT messages through a Python script to the `MessageReceiver` plugin and verifying that the correct corresponding message type shows up in the V2XHub UI:
<img width="1822" height="603" alt="Screenshot from 2026-09-04 11-41-48" src="https://github.com/user-attachments/assets/f1120960-7541-47d6-bdfa-4f2fe6ca5c0f" />

The UUID logs are verified in the terminal output.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[DT4IT-147]: https://usdot-carma.atlassian.net/browse/DT4IT-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ