### PR TITLE
fix: null pointer dereference in SNMPClient::log_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ The V2X Hub system reduces time needed to create and deploy a roadside based V2X
 * CARMA Cloud Plugin – An interface between V2X Hub and CARMA Cloud
 * CDASim Adapter Plugin – An interface between V2X Hub and CDASim for simulation testing 
 * RSU Health Monitoring Plugin – A plugin used to monitor RSU health via RSU 4.1 specification or NTCIP 1218
+* Command Plugin – Listens for websocket connections from the TMX admin portal and processes commands from the Administration Portal
+* ERV Cloud Forwarding Plugin – Forwards BSMs broadcast by Emergency Response Vehicles (ERVs) to CARMA Cloud over a websocket connection
+* Intersection Validation Plugin – Validates MAP and SPaT messages received from RSUs against the CTI 4501 standard
+* MUST Sensor Driver Plugin – Consumes detections from an AI Waysion MUST camera sensor and translates them into Sensor Detected Object messages for cooperative perception
+* Port Drayage Plugin – Facilitates communication between infrastructure, vehicles, and container handling equipment (CHE) for automated port drayage operations
+* Priority Plugin – Handles J2735 Signal Request Messages (SRMs) and places priority requests against a Traffic Signal Controller (TSC) per NTCIP 1211
 
 V2X Hub is a communication, computation, and processing platform for V2I applications, and providing the functions listed below.
 

--- a/src/tmx/TmxUtils/src/SNMPClient.cpp
+++ b/src/tmx/TmxUtils/src/SNMPClient.cpp
@@ -391,7 +391,14 @@ namespace tmx::utils
 
         if (status == STAT_SUCCESS)
         {
-            PLOG(logERROR) << "Variable type: " << response->variables->type << ". Error in packet " << static_cast<std::string>(snmp_errstring(static_cast<int>(response->errstat)));
+            if (response && response->variables)
+            {
+                PLOG(logERROR) << "Variable type: " << response->variables->type << ". Error in packet " << static_cast<std::string>(snmp_errstring(static_cast<int>(response->errstat)));
+            }
+            else
+            {
+                PLOG(logERROR) << "Error in packet with no variables in response";
+            }
         }
         else if (status == STAT_TIMEOUT)
         {

--- a/src/tmx/TmxUtils/test/test_SNMPClient.cpp
+++ b/src/tmx/TmxUtils/test/test_SNMPClient.cpp
@@ -62,7 +62,7 @@ namespace unit_test
 
     TEST_F(test_SNMPClient, log_error)
     {
-        snmp_pdu response;
+        snmp_pdu response{};
         ASSERT_NO_THROW(scPtr->log_error(STAT_ERROR, request_type::GET, &response));
         ASSERT_NO_THROW(scPtr->log_error(STAT_ERROR, request_type::SET, &response));
         ASSERT_NO_THROW(scPtr->log_error(STAT_SUCCESS, request_type::OTHER, &response));


### PR DESCRIPTION
## Summary
- `SNMPClient::log_error()` dereferenced `response->variables->type` whenever `status == STAT_SUCCESS`, without checking that `response` or `response->variables` were non-null — even though the same function already guards `response` correctly a few lines later before its second use. A real SNMP response can legitimately carry an empty variable-bindings list (`response->variables == nullptr`), so this was reachable in production, not just in a test.
- Also fixes the triggering test (`test_SNMPClient.cpp`): it declared a stack `snmp_pdu response;` without zero-initializing it, so `variables` held indeterminate garbage rather than a deterministic null — changed to `snmp_pdu response{};` so the test doesn't rely on undefined behavior.
- Adds 6 plugins to the README's plugin list that exist in `src/v2i-hub/` but were never documented there: `CommandPlugin`, `ERVCloudForwardingPlugin`, `IntersectionValidationPlugin`, `MUSTSensorDriverPlugin`, `PortDrayagePlugin`, `PriorityPlugin`.

## Test plan
- [x] Caught by AddressSanitizer (SEGV) while running a coverage build (`./build.sh coverage --j2735-version 2024` + `./test.sh coverage`) — crash reproduced on `develop` prior to this fix.
- [x] After the fix, `test.sh coverage` runs clean: 467 tests across 19 test binaries, 0 failures.
- [x] Verified `src/v2i-hub/` plugin directory list against the README bullet list to confirm the 6 additions are accurate and complete.