### PR TITLE
fix: use-after-free issue when consuming kafka payloads from sensor_data_sharing_service

### DIFF
--- a/src/tmx/TmxUtils/src/kafka/kafka_consumer_worker.cpp
+++ b/src/tmx/TmxUtils/src/kafka/kafka_consumer_worker.cpp
@@ -122,11 +122,10 @@ namespace tmx::utils
         }
     }
 
-    const char *kafka_consumer_worker::consume(int timeout_ms)
+    std::string kafka_consumer_worker::consume(int timeout_ms)
     {
         std::shared_ptr<RdKafka::Message> msg(_consumer->consume(timeout_ms));
-        const char *msg_str = msg_consume(msg);
-        return msg_str;
+        return msg_consume(msg);
     }
 
     bool kafka_consumer_worker::is_running() const
@@ -140,9 +139,9 @@ namespace tmx::utils
             << (_group_id_str.empty() ? "UNKNOWN" : _group_id_str) << std::endl;
     }
 
-    const char *kafka_consumer_worker::msg_consume(const std::shared_ptr<RdKafka::Message> message)
+    std::string kafka_consumer_worker::msg_consume(const std::shared_ptr<RdKafka::Message> message)
     {
-        const char *return_msg_str = "";
+        std::string return_msg_str;
         switch (message->err())
         {
         case RdKafka::ERR__TIMED_OUT:
@@ -150,9 +149,11 @@ namespace tmx::utils
             break;
         case RdKafka::ERR_NO_ERROR:
             FILE_LOG(logDEBUG1) << _consumer->name() << " read message at offset " <<  message->offset() << std::endl;
-            FILE_LOG(logDEBUG1) << _consumer->name() << " message Consumed: " << static_cast<int>(message->len())  << " bytes : " << static_cast<const char *>(message->payload()) << std::endl;
+            // The librdkafka payload is not null terminated and is owned by the message, so it
+            // has to be sized with message->len() and copied out before the message is released.
+            return_msg_str.assign(static_cast<const char *>(message->payload()), message->len());
+            FILE_LOG(logDEBUG1) << _consumer->name() << " message Consumed: " << static_cast<int>(message->len())  << " bytes : " << return_msg_str << std::endl;
             _cur_offset = message->offset();
-            return_msg_str = static_cast<const char *>(message->payload());
             break;
         case RdKafka::ERR__PARTITION_EOF:
             FILE_LOG(logWARNING) << _consumer->name() << " reached the end of the queue, offset : " <<  _cur_offset << std::endl;

--- a/src/tmx/TmxUtils/src/kafka/kafka_consumer_worker.h
+++ b/src/tmx/TmxUtils/src/kafka/kafka_consumer_worker.h
@@ -2,6 +2,7 @@
 #define KAFKA_CONSUMER_WORKER_H
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <cstdlib>
 #include <cstdio>
@@ -55,7 +56,7 @@ namespace tmx::utils {
             bool _run = false;
             consumer_event_cb _consumer_event_cb;
             consumer_rebalance_cb _consumer_rebalance_cb;
-            const char* msg_consume(const std::shared_ptr<RdKafka::Message> message);
+            std::string msg_consume(const std::shared_ptr<RdKafka::Message> message);
 
         public:
             /**
@@ -92,9 +93,9 @@ namespace tmx::utils {
              * @brief Consume from topic.
              * 
              * @param timeout_ms timeout in milliseconds to wait before failing.;
-             * @return const char* of payload consumed.
+             * @return std::string payload consumed. Empty if nothing was consumed.
              */
-            virtual const char* consume(int timeout_ms);
+            virtual std::string consume(int timeout_ms);
             /**
              * @brief Subscribe consumer to topic
              */

--- a/src/tmx/TmxUtils/src/kafka/mock_kafka_consumer_worker.h
+++ b/src/tmx/TmxUtils/src/kafka/mock_kafka_consumer_worker.h
@@ -29,7 +29,7 @@ namespace tmx::utils {
             ~mock_kafka_consumer_worker() = default;
 
             MOCK_METHOD(bool, init,(),(override));
-            MOCK_METHOD(const char*, consume, (int timeout_ms), (override));
+            MOCK_METHOD(std::string, consume, (int timeout_ms), (override));
             MOCK_METHOD(void, subscribe, (), (override));
             MOCK_METHOD(void, printCurrConf, (), (override));
             MOCK_METHOD(bool, is_running, (), (const override));


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

This PR fixes the following issue:

`CARMAStreetsPlugin` fails to parse SDSM JSON consumed from the `v2xhub_sdsm_sub` topic. Every failure truncates the payload at 688 bytes, with the JSON parser reporting `Missing ',' or '}'` at column 687 and a trailing garbage byte (`P\x03`) where JSON should continue.

An example console log is as follows:
```bash
[2026-09-04 18:43:47.381] /kafka_consumer_worker.cpp (153) - DEBUG1 : rdkafka#consumer-5 message Consumed: 691 bytes : {"msg_cnt":122,"source_id":"rsu_1234","equipment_type":1,"sdsm_time_stamp":{"second":47374,"minute":43,"hour":18,"day":4,"month":9,"year":2026,"offset":0},"ref_pos":{"long":-771483512,"lat":389519791,"elevation":0},"ref_pos_xy_conf":{"semi_major":0,"semi_minor":0,"orientation":0},"objects":[{"detected_object_data":{"detected_object_common_data":{"obj_type":2,"object_id":13684,"obj_type_cfd":100,"measurement_time":87,"time_confidence":0,"pos":{"offset_x":3254,"offset_y":-99,"offset_z":0},"pos_confidence":{"pos":15,"elevation":15},"speed":0,"speed_confidence":7,"speed_z":0,"speed_confidence_z":4,"heading":0,"heading_conf":4},"detected_object_optional_data":{"detected_vru_data":{}}}}]}

[2026-09-04 18:43:47.381] src/CARMAStreetsPlugin.cpp (673) - DEBUG  : consumed message payload: {"msg_cnt":122,"source_id":"rsu_1234","equipment_type":1,"sdsm_time_stamp":{"second":47374,"minute":43,"hour":18,"day":4,"month":9,"year":2026,"offset":0},"ref_pos":{"long":-771483512,"lat":389519791,"elevation":0},"ref_pos_xy_conf":{"semi_major":0,"semi_minor":0,"orientation":0},"objects":[{"detected_object_data":{"detected_object_common_data":{"obj_type":2,"object_id":13684,"obj_type_cfd":100,"measurement_time":87,"time_confidence":0,"pos":{"offset_x":3254,"offset_y":-99,"offset_z":0},"pos_confidence":{"pos":15,"elevation":15},"speed":0,"speed_confidence":7,"speed_z":0,"speed_confidence_z":4,"heading":0,"heading_conf":4},"detected_object_optional_data":{"detected_vru_data":{}P

[2026-09-04 18:43:47.381] sonToJ3224SDSMConverter.cpp (17) - ERROR  : Parse error: * Line 1, Column 687
  Missing ',' or '}' in object declaration
```


The root cause of the problem:
- since `return_msg_str` is originally constructed as a c-str and the downstream consumer will walk it until it hits a null character (which it won't since kafka payload is not null terminated), it will not read the correct length of the payload.
- The `shared_ptr<RdKafka::Message>` owning that buffer was destroyed when `consume()` returned, so the returned raw pointer dangled into freed memory, and it happens to hit a terminating character that truncates the actual payload. This is a use-after-free error.

## Changes

- `msg_consume()` now returns `std::string`, built with `.assign(payload, message->len())` while the message is still alive — length-delimited, no scanning for a terminator, no read past the buffer.
- `consume()` returns `std::string` by value, so the bytes are copied out before the `RdKafka::Message` is released, fixing the use-after-free.
- Updated the `FILE_LOG(logDEBUG1)` consumed-message line, which was printing the same unterminated pointer.
- Updated the `consume` signature and Doxygen comment in `kafka_consumer_worker.h`; added `<memory>`.
- Updated `MOCK_METHOD(const char*, consume, ...)` → `std::string` in `mock_kafka_consumer_worker.h`.

<!--- Describe your changes in detail -->

## Related GitHub Issue
Supporting PR: https://github.com/usdot-fhwa-stol/carma-streets/pull/458
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The new changes (including ones necessary for carma-streets repo) were tested by deploying the newly built images and verifying that the same error no longer appears when the SDSM messages are consumed, with live pedestrian being detected by the FLIR camera.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
